### PR TITLE
added m4 autoconf macro for finding eigen.

### DIFF
--- a/core/configure.ac
+++ b/core/configure.ac
@@ -85,10 +85,7 @@ AC_SEARCH_LIBS([cos], [m], [], [
   ])
 
 # look for a header file in Eigen, and croak if fail to find.
-AC_LANG_PUSH([C++])
-AC_CHECK_HEADERS([eigen3/Eigen/Dense],[],AC_MSG_ERROR([unable to find Eigen 3  (eigen3/Eigen/Dense)]),[])
-AC_LANG_POP([C++])
-
+AX_EIGEN
 
 AX_BOOST_BASE([1.55],, [AC_MSG_ERROR([bertini2 needs Boost at least 1.55, but it was not found in your system])])
 AX_BOOST_SYSTEM

--- a/core/include/bertini2/bertini.hpp
+++ b/core/include/bertini2/bertini.hpp
@@ -28,8 +28,8 @@
 
 #include "config.h"
 
-#include <eigen3/Eigen/Dense>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Dense>
+#include <Eigen/LU>
 #include <boost/multiprecision/mpfr.hpp>
 #include <boost/multiprecision/random.hpp>
 

--- a/core/include/bertini2/mpfr_complex.hpp
+++ b/core/include/bertini2/mpfr_complex.hpp
@@ -38,7 +38,7 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/serialization/split_member.hpp>
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <string>
 #include <assert.h>

--- a/core/include/bertini2/mpfr_extensions.hpp
+++ b/core/include/bertini2/mpfr_extensions.hpp
@@ -35,7 +35,7 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/serialization/split_member.hpp>
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <string>
 #include <assert.h>

--- a/core/include/bertini2/system.hpp
+++ b/core/include/bertini2/system.hpp
@@ -34,7 +34,7 @@
 
 #include <assert.h>
 
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>

--- a/core/m4/ax_eigen.m4
+++ b/core/m4/ax_eigen.m4
@@ -1,0 +1,93 @@
+#
+# SYNOPSIS
+#
+#   AX_EIGEN()
+#
+# DESCRIPTION
+#
+#   Check for the Eigen linear algebra library.
+#
+#
+# LICENSE
+#
+#   Copyright Daniel Brake 2016
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+AC_DEFUN([AX_EIGEN],
+    [
+AC_ARG_WITH([eigen],
+    [AS_HELP_STRING([--with-eigen@<:@=ARG@:>@], 
+        [Use the Eigen linear algebra library from a standard location (ARG=yes),
+         from the given location (ARG=<path>),
+         or disable it (ARG=no)
+         @<:@ARG=yes@:>@ ])],
+        [
+        if test "$withval" = "no"; then
+            want_eigen="no"
+        elif test "$withval" = "yes"; then
+            want_eigen="yes"
+            ac_eigen_path=""
+        else
+            want_eigen="yes"
+            ac_eigen_path="$withval"
+        fi
+        ],
+        [want_eigen="yes"])
+
+
+if test "x$want_eigen" = "xyes"; then
+    
+    CPPFLAGS_SAVED="$CPPFLAGS"
+
+    AC_REQUIRE([AC_PROG_CXX])
+    AC_LANG_PUSH(C++)
+
+    found_eigen_dir=no
+    if test "$ac_eigen_path" != ""; then
+        
+        if test -d "$ac_eigen_path/Eigen"; then
+            EIGEN_CPPFLAGS="-I$ac_eigen_path"
+            found_eigen_dir=yes;
+        else
+            if test -d "$ac_eigen_path/eigen3/Eigen"; then
+                EIGEN_CPPFLAGS="-I$ac_eigen_path/eigen3"
+                found_eigen_dir=yes;
+            fi
+        fi
+
+    else 
+        for ac_eigen_path_tmp in /usr /usr/local /opt /opt/local ; do
+            if test -d "$ac_eigen_path_tmp/include/eigen3/Eigen"; then
+                EIGEN_CPPFLAGS="-I$ac_eigen_path_tmp/include/eigen3"
+                found_eigen_dir=yes;
+                break;
+            fi
+        done
+    fi
+
+    if test "x$found_eigen_dir" = "xyes"; then
+        CPPFLAGS="$CPPFLAGS $EIGEN_CPPFLAGS"
+    else
+        AC_MSG_ERROR([unable to find Eigen directory])
+    fi
+
+    AC_CHECK_HEADERS([Eigen/Dense],
+        [
+        succeeded=yes;
+        export CPPFLAGS;
+        ],
+        [
+        CPPFLAGS="$CPPFLAGS_SAVED";
+        export CPPFLAGS;
+        AC_MSG_ERROR([unable to include Eigen])
+        ])
+    AC_LANG_POP([C++])
+fi
+
+])
+
+       

--- a/core/test/classes/eigen_test.cpp
+++ b/core/test/classes/eigen_test.cpp
@@ -27,8 +27,8 @@
 #include <boost/test/unit_test.hpp>
 
 
-#include <eigen3/Eigen/Dense>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Dense>
+#include <Eigen/LU>
 
 #include "mpfr_complex.hpp"
 


### PR DESCRIPTION
removed eigen3/ from #include paths throughout bertini2.

we were previously looking for eigen in the wrong place, and need to strip a level off the include paths in Bertini2's core.  the submitted m4 macro, called from configure.ac, does just that.  the user can specify the location of their Eigen installation, or let configure attempt to find it itself.
