### PR TITLE
made the default constructors private where relevant, for the Node types

### DIFF
--- a/core/include/bertini2/function_tree/operators/operator.hpp
+++ b/core/include/bertini2/function_tree/operators/operator.hpp
@@ -64,8 +64,6 @@ namespace node{
 	{
 	public:
 		
-		UnaryOperator(){}
-		
 		UnaryOperator(const std::shared_ptr<Node> & N) : child_(N)
 		{}
 		
@@ -185,9 +183,8 @@ namespace node{
 	protected:
 		//Stores the single child of the unary operator
 		std::shared_ptr<Node> child_;
-
+		UnaryOperator(){}
 	private:
-
 		friend class boost::serialization::access;
 		
 		template <typename Archive>
@@ -216,10 +213,9 @@ namespace node{
 	protected:
 		
 		virtual void print(std::ostream & target) const = 0;
-		
+		BinaryOperator(){}
 
 	private:
-
 		friend class boost::serialization::access;
 		
 		template <typename Archive>
@@ -296,9 +292,8 @@ namespace node{
 		//Stores all children for this operator node.
 		//This is an NaryOperator and can have any number of children.
 		std::vector< std::shared_ptr<Node> > children_;
-		
+		NaryOperator(){}
 	private:
-
 		friend class boost::serialization::access;
 		
 		template <typename Archive>

--- a/core/include/bertini2/function_tree/operators/trig.hpp
+++ b/core/include/bertini2/function_tree/operators/trig.hpp
@@ -38,7 +38,7 @@ namespace node{
 	{
 	public:
 
-		TrigOperator(){}
+		
 		TrigOperator(const std::shared_ptr<Node> & N) : UnaryOperator(N)
 		{};
 
@@ -50,7 +50,8 @@ namespace node{
 		 For transcendental functions, the degree is 0 if the argument is constant, otherwise it's undefined, and we return -1.
 		 */
 		int Degree(std::shared_ptr<Variable> const& v = nullptr) const override;
-
+	protected:
+		TrigOperator(){}
 	private:
 		friend class boost::serialization::access;
 
@@ -75,8 +76,6 @@ namespace node{
 	class SinOperator : public  virtual TrigOperator
 	{
 	public:
-		
-		SinOperator(){}
 		
 		SinOperator(const std::shared_ptr<Node> & N) : TrigOperator(N), UnaryOperator(N)
 		{};
@@ -110,7 +109,7 @@ namespace node{
 		}
 		
 	private:
-
+		SinOperator() = default;
 		friend class boost::serialization::access;
 
 		template <typename Archive>
@@ -130,7 +129,7 @@ namespace node{
 	{
 	public:
 		
-		ArcSinOperator(){}
+		
 		
 		ArcSinOperator(const std::shared_ptr<Node> & N) : TrigOperator(N), UnaryOperator(N)
 		{};
@@ -162,7 +161,7 @@ namespace node{
 		}
 		
 	private:
-
+		ArcSinOperator() = default;
 		friend class boost::serialization::access;
 		
 
@@ -189,7 +188,7 @@ namespace node{
 	{
 	public:
 		
-		CosOperator(){}
+		
 		
 		CosOperator(const std::shared_ptr<Node> & N) : TrigOperator(N), UnaryOperator(N)
 		{};
@@ -225,7 +224,7 @@ namespace node{
 		}
 		
 	private:
-
+		CosOperator() = default;
 		friend class boost::serialization::access;
 		
 		template <typename Archive>
@@ -245,7 +244,7 @@ namespace node{
 	{
 	public:
 		
-		ArcCosOperator(){}
+		
 		
 		ArcCosOperator(const std::shared_ptr<Node> & N) : TrigOperator(N), UnaryOperator(N)
 		{};
@@ -281,7 +280,7 @@ namespace node{
 		}
 		
 	private:
-
+		ArcCosOperator() = default;
 		friend class boost::serialization::access;
 		
 		template <typename Archive>
@@ -309,7 +308,7 @@ namespace node{
 	{
 	public:
 		
-		TanOperator(){}
+		
 		
 		TanOperator(const std::shared_ptr<Node> & N) : TrigOperator(N), UnaryOperator(N)
 		{};
@@ -344,7 +343,7 @@ namespace node{
 		}
 		
 	private:
-
+		TanOperator() = default;
 		friend class boost::serialization::access;
 		
 
@@ -365,7 +364,7 @@ namespace node{
 	{
 	public:
 		
-		ArcTanOperator(){}
+		
 		
 		ArcTanOperator(const std::shared_ptr<Node> & N) : TrigOperator(N), UnaryOperator(N)
 		{};
@@ -400,7 +399,7 @@ namespace node{
 		}
 		
 	private:
-
+		ArcTanOperator() = default;
 		friend class boost::serialization::access;
 		
 		template <typename Archive>

--- a/core/include/bertini2/function_tree/roots/function.hpp
+++ b/core/include/bertini2/function_tree/roots/function.hpp
@@ -40,10 +40,6 @@ namespace node{
 	public:
 		
 		
-		/**
-		 The default constructor
-		 */
-		Function() {};
 		
 		
 
@@ -55,7 +51,7 @@ namespace node{
 		/**
 		 Constructor defines entry node at construct time.
 		 */
-		Function(const std::shared_ptr<Node> & entry) : entry_node_(entry)
+		Function(const std::shared_ptr<Node> & entry) : NamedSymbol("unnamed_function"), entry_node_(entry)
 		{
 		}
 		
@@ -214,9 +210,13 @@ namespace node{
 		
 		
 		std::shared_ptr<Node> entry_node_; ///< The top node for the function.
-
+		
+		Function() = default;
 	private:
-
+		/**
+		 The default constructor
+		 */
+		
 		friend class boost::serialization::access;
 		
 		template <typename Archive>

--- a/core/include/bertini2/function_tree/roots/jacobian.hpp
+++ b/core/include/bertini2/function_tree/roots/jacobian.hpp
@@ -41,11 +41,7 @@ namespace node{
 		public:
 				
 				
-				/**
-				 The default constructor
-				 */
-				Jacobian()
-				{};
+				
 				
 				
 				/**
@@ -160,8 +156,12 @@ namespace node{
 		// }
 
 				std::tuple< std::pair<dbl,std::shared_ptr<Variable>>, std::pair<mpfr,std::shared_ptr<Variable>> > current_diff_variable_;
-				
+				Jacobian() = default;
 		private:
+				/**
+				 The default constructor
+				 */
+				
 				friend class boost::serialization::access;
 		
 				template <typename Archive>

--- a/core/include/bertini2/function_tree/symbols/differential.hpp
+++ b/core/include/bertini2/function_tree/symbols/differential.hpp
@@ -43,13 +43,13 @@ namespace node{
 	class Differential : public virtual NamedSymbol
 	{
 	public:
-		Differential(){};
+		
 
 
 		/**
 		 Input shared_ptr to a Variable.
 		 */
-		Differential(std::shared_ptr<Variable> diff_variable, std::string var_name)
+		Differential(std::shared_ptr<Variable> diff_variable, std::string var_name) : NamedSymbol(var_name)
 		{
 			differential_variable_ = diff_variable;
 			name("d" + var_name);
@@ -164,6 +164,7 @@ namespace node{
 
 
 	private:
+		Differential() = default;
 		std::shared_ptr<Variable> differential_variable_;
 
 		friend class boost::serialization::access;

--- a/core/include/bertini2/function_tree/symbols/number.hpp
+++ b/core/include/bertini2/function_tree/symbols/number.hpp
@@ -115,7 +115,6 @@ namespace node{
 	protected:
 
 	private:
-
 		friend class boost::serialization::access;
 
 		template <typename Archive>
@@ -135,8 +134,7 @@ namespace node{
 	class Float : public virtual Number
 	{
 	public:
-		Float()
-		{}
+		
 
 		Float(double val)
 		{
@@ -232,6 +230,8 @@ namespace node{
 
 		friend class boost::serialization::access;
 
+		Float() = default;
+
 		template <typename Archive>
 		void serialize(Archive& ar, const unsigned version) {
 			ar & boost::serialization::base_object<Number>(*this);
@@ -250,8 +250,7 @@ namespace node{
 	public:
 		using mpz_int = boost::multiprecision::mpz_int;
 
-		Integer()
-		{}
+		
 
 		Integer(int val) : true_value_(val)
 		{}
@@ -300,7 +299,7 @@ namespace node{
 		mpz_int true_value_;
 
 		friend class boost::serialization::access;
-
+		Integer() = default;
 		template <typename Archive>
 		void serialize(Archive& ar, const unsigned version) {
 			ar & boost::serialization::base_object<Number>(*this);
@@ -321,8 +320,7 @@ namespace node{
 
 		using mpq_rational = boost::multiprecision::mpq_rational;
 
-		Rational()
-		{}
+		
 
 		Rational(int val) : true_value_real_(val), true_value_imag_(0)
 		{}
@@ -376,7 +374,7 @@ namespace node{
 
 
 	private:
-
+		
 		// Return value of constant
 		dbl FreshEval(dbl, std::shared_ptr<Variable> diff_variable) override
 		{
@@ -389,7 +387,7 @@ namespace node{
 		}
 
 		mpq_rational true_value_real_, true_value_imag_;
-
+		Rational() = default;
 		friend class boost::serialization::access;
 
 		template <typename Archive>

--- a/core/include/bertini2/function_tree/symbols/symbol.hpp
+++ b/core/include/bertini2/function_tree/symbols/symbol.hpp
@@ -79,11 +79,7 @@ namespace node {
 		*/
 		void name(const std::string & new_name){name_ = new_name;};
 		
-		/**
-		Default constructor
-		*/
-		NamedSymbol(){};
-
+		
 		/**
 		Parameterized constructor, sets the name of the symbol
 		*/
@@ -97,7 +93,8 @@ namespace node {
 		
 		virtual ~NamedSymbol() = default;
 		
-		
+	protected:
+		NamedSymbol() = default;
 	private:
 
 		friend class boost::serialization::access;

--- a/core/include/bertini2/function_tree/symbols/variable.hpp
+++ b/core/include/bertini2/function_tree/symbols/variable.hpp
@@ -41,7 +41,7 @@ namespace node{
 	class Variable : public virtual NamedSymbol, public std::enable_shared_from_this<Variable>
 	{
 	public:
-		Variable(){};
+		
 		
 		Variable(std::string new_name) : NamedSymbol(new_name)
 		{ }
@@ -162,9 +162,9 @@ namespace node{
 		{
 			return std::get< std::pair<mpfr,bool> >(current_value_).first;
 		}
-
+		Variable() = default;
 	private:
-
+		
 		friend class boost::serialization::access;
 
 		template <typename Archive>

--- a/core/src/function_tree/operators/arithmetic.cpp
+++ b/core/src/function_tree/operators/arithmetic.cpp
@@ -63,7 +63,7 @@ namespace bertini{
 	std::shared_ptr<Node> SumOperator::Differentiate()
 	{
 		unsigned int counter = 0;
-		std::shared_ptr<SumOperator> ret_sum = std::make_shared<SumOperator>();
+		std::shared_ptr<Node> ret_sum = Zero();
 		for (int ii = 0; ii < children_.size(); ++ii)
 		{
 			auto converted = std::dynamic_pointer_cast<Number>(children_[ii]);
@@ -76,14 +76,15 @@ namespace bertini{
 				if (converted->Eval<dbl>()==dbl(0.0))
 					continue;
 			
-			ret_sum->AddChild(temp_node,children_sign_[ii]);
 			counter++;
+			if (counter==1)
+				ret_sum = std::make_shared<SumOperator>(temp_node,children_sign_[ii]);
+			else
+				std::dynamic_pointer_cast<SumOperator>(ret_sum)->AddChild(temp_node,children_sign_[ii]);
+			
 		}
 		
-		if (counter>0)
-			return ret_sum;
-		else
-			return std::make_shared<Float>(0.0);
+		return ret_sum;
 	}
 	
 	
@@ -380,54 +381,46 @@ namespace bertini{
 	
 	std::shared_ptr<Node> MultOperator::Differentiate()
 	{
-		std::shared_ptr<SumOperator> ret_sum = std::make_shared<SumOperator>();
+		std::shared_ptr<Node> ret_sum = node::Zero();
 		
 		unsigned term_counter {0};
-		
+		// this loop implements the generic product rule, perhaps inefficiently.
 		for (int ii = 0; ii < children_.size(); ++ii)
 		{
-			
 			auto local_derivative = children_[ii]->Differentiate();
 			
+			// if the derivative of the current term is 0, then stop 
 			auto is_it_a_number = std::dynamic_pointer_cast<Float>(local_derivative);
 			if (is_it_a_number)
 				if (is_it_a_number->Eval<dbl>()==dbl(0.0))
 					continue;
 			
+			// no, the term's derivative is not 0.  
 			
-			
-			auto term_ii = std::make_shared<MultOperator>();
+			// create the product of the remaining terms
+			auto term_ii = std::make_shared<MultOperator>(local_derivative);
 			for (int jj = 0; jj < children_.size(); ++jj)
 			{
 				if(jj != ii)
 					term_ii->AddChild(children_[jj],children_mult_or_div_[jj]);
 			}
-			
-			
-			// if the derivative of the term under consideration is equal to 1, no need to go on.  already have the product we need.
+
+			// and then either 1. multiply it against the current derivative, or 2. invoke the quotient rule.
 			if (is_it_a_number)
 				if (is_it_a_number->Eval<dbl>()==dbl(1.0))
 					continue;
 			
+			// if the derivative of the term under consideration is equal to 1, no need to go on.  already have the product we need.
 			
-			// the first branch is for division, and the quotient rule.
+			// if is division, need this for the quotient rule
 			if ( !(children_mult_or_div_[ii]) )
-			{
-				// divide by the
-				term_ii->AddChild(children_[ii],false);
-				term_ii->AddChild(children_[ii],false);
-				term_ii->AddChild(local_derivative);
-				ret_sum->AddChild(term_ii,false);  // false for subtract here.
-			}
-			// the second branch is for multiplication, and the product rule
-			else
-			{
-				term_ii->AddChild(local_derivative,true);// true for multiply, not divide
-				ret_sum->AddChild(term_ii); //  no truth second argument, because is add.
-			}
+				term_ii->AddChild(pow(children_[ii],2),false); // draw a line and square below
 			
 			term_counter++;
-			
+			if (term_counter==1)
+				ret_sum = std::make_shared<SumOperator>(term_ii,children_mult_or_div_[ii]);
+			else
+				std::dynamic_pointer_cast<SumOperator>(ret_sum)->AddChild(term_ii,children_mult_or_div_[ii]);
 		} // re: for ii
 		
 		return ret_sum;
@@ -449,7 +442,6 @@ namespace bertini{
 			if (is_it_a_differential)
 				if (is_it_a_differential->GetVariable()!=v)
 				{
-					// std::cout << *this << " deg " << 0 << "\n";
 					return 0;
 				}
 			
@@ -464,7 +456,6 @@ namespace bertini{
 			else
 				deg+=factor_deg;
 		}
-		// std::cout << *this << " deg " << deg << "\n";
 		return deg;
 	}
 	
@@ -600,9 +591,9 @@ namespace bertini{
 	
 	std::shared_ptr<Node> PowerOperator::Differentiate()
 	{
-		auto ret_mult = std::make_shared<MultOperator>();
+		
 		auto exp_minus_one = std::make_shared<SumOperator>(exponent_, true, std::make_shared<Float>("1.0"),false);
-		ret_mult->AddChild(base_->Differentiate());
+		auto ret_mult = std::make_shared<MultOperator>(base_->Differentiate());
 		ret_mult->AddChild(exponent_);
 		ret_mult->AddChild(std::make_shared<PowerOperator>(base_, exp_minus_one));
 		return ret_mult;
@@ -650,7 +641,7 @@ namespace bertini{
 		}
 		else
 		{
-			// there may be an edge case here where the base is the numbers 0 or 1.  but that would be stupid, wouldn't it.
+			// there may be an edge case here where the base is the number 0 or 1.  but that would be stupid, wouldn't it.
 			return -1;
 		}
 	}
@@ -819,10 +810,9 @@ namespace bertini{
 	
 	std::shared_ptr<Node> SqrtOperator::Differentiate()
 	{
-		auto ret_mult = std::make_shared<MultOperator>();
-		ret_mult->AddChild(std::make_shared<PowerOperator>(child_, std::make_shared<Float>(-0.5)));
+		auto ret_mult = std::make_shared<MultOperator>(std::make_shared<PowerOperator>(child_, std::make_shared<Rational>(-1,2)));
 		ret_mult->AddChild(child_->Differentiate());
-		ret_mult->AddChild(std::make_shared<Float>(0.5));
+		ret_mult->AddChild(std::make_shared<Rational>(1,2));
 		return ret_mult;
 	}
 	
@@ -877,10 +867,7 @@ namespace bertini{
 	
 	std::shared_ptr<Node> ExpOperator::Differentiate()
 	{
-		auto ret_mult = std::make_shared<MultOperator>();
-		ret_mult->AddChild(std::make_shared<ExpOperator>(child_));
-		ret_mult->AddChild(child_->Differentiate());
-		return ret_mult;
+		return exp(child_)*child_->Differentiate();
 	}
 	
 	int ExpOperator::Degree(std::shared_ptr<Variable> const& v) const
@@ -929,10 +916,7 @@ namespace bertini{
 	
 	std::shared_ptr<Node> LogOperator::Differentiate()
 	{
-		auto ret_mult = std::make_shared<MultOperator>();
-		ret_mult->AddChild(child_,false);
-		ret_mult->AddChild(child_->Differentiate());
-		return ret_mult;
+		return std::make_shared<MultOperator>(child_,false,child_->Differentiate(),true);
 	}
 	
 	int LogOperator::Degree(std::shared_ptr<Variable> const& v) const

--- a/core/test/classes/function_tree_test.cpp
+++ b/core/test/classes/function_tree_test.cpp
@@ -42,7 +42,7 @@
 using Variable = bertini::node::Variable;
 using Node = bertini::node::Node;
 using Float = bertini::node::Float;
-
+using Function = bertini::node::Function;
 
 
 double relaxed_threshold_clearance_d = 1e-14;
@@ -1787,3 +1787,24 @@ BOOST_AUTO_TEST_CASE(function_tree_combine_product_of_two_integer_powers)
 
 
 BOOST_AUTO_TEST_SUITE_END()
+
+
+
+
+// BOOST_AUTO_TEST_SUITE(function_tree_default_constructors)
+
+// BOOST_AUTO_TEST_CASE(function)
+// {
+
+// 	std::shared_ptr<Variable> x = std::make_shared<Variable>("x");
+//     std::shared_ptr<Node> f = std::make_shared<Function>();
+//     f += x;
+//     BOOST_CHECK_EQUAL(f->Eval<dbl>(),dbl(0));
+
+// }
+// BOOST_AUTO_TEST_SUITE_END()
+
+
+
+
+


### PR DESCRIPTION
This resolves the problem with creating empty nodes in a tree, which should be not allowed.  Now it isn't!