### PR TITLE
bug fixes and compile improvements

### DIFF
--- a/core/configure.ac
+++ b/core/configure.ac
@@ -60,20 +60,16 @@ AC_ARG_ENABLE([thread_local],
 
 AS_IF([test "x$enable_thread_local" != "xno"],[
 	AC_DEFINE([USE_THREAD_LOCAL], [1],[Define if thread_local keyword should be used.  ])
-]
-
-)
+])
 
 
+AC_ARG_ENABLE([expression_templates],
+    AS_HELP_STRING([--disable-expression_templates], [Disable the use of expression templates for Boost.Multiprecision.  Versions of Boost.Multiprecision prior to 1.61 are missing min/max for expressions of real numbers, and some operations in Eigen prior to 3.3 (3.2.92) fail to compile.  If you are using Boost prior to 1.61, either patch according to https://github.com/boostorg/multiprecision/commit/f57bd6b31a64787425ec891bd2ceb536c9036f72 or turn expression templates off using this argument.]))
 
-#this calls a file in the m4/ directory, which sets up the MPI wrapper stuffs
-LX_FIND_MPI
+AS_IF([test "x$enable_expression_templates" != "xno"],[
+	AC_DEFINE([BMP_EXPRESSION_TEMPLATES], [1],[Use expression templates from Boost.Multiprecision.])
+])
 
-# print a notice about the presence of MPI on the machine.
-AS_IF([test "$have_CXX_mpi" = "yes"],
-	AC_MSG_NOTICE([mpi c++ appears to work correctly]),
-	AC_MSG_NOTICE([it appears you do not have mpi installed])
-	)
 
 
 

--- a/core/include/bertini2/function_tree/node.hpp
+++ b/core/include/bertini2/function_tree/node.hpp
@@ -41,7 +41,7 @@
 #define BERTINI_NODE_BASE_HPP
 
 
-
+#include "bertini2/config.h"
 
 #include <iostream>
 #include <string>

--- a/core/include/bertini2/mpfr_complex.hpp
+++ b/core/include/bertini2/mpfr_complex.hpp
@@ -66,7 +66,7 @@ namespace bertini {
 		mpfr_float real_, imag_;
 		
 		#ifdef USE_THREAD_LOCAL
-			static thread_local mpfr_float temp_[8];
+			static thread_local mpfr_float temp_[8]; //OSX clang does NOT implement this. Use ./configure --disable-thread_local.  Also, send Apple a letter telling them to implement this keyword.
 		#else
 			static mpfr_float temp_[8];
 		#endif

--- a/core/include/bertini2/mpfr_extensions.hpp
+++ b/core/include/bertini2/mpfr_extensions.hpp
@@ -33,6 +33,7 @@ Particularly includes Boost.Serialize code for the mpfr_float, gmp_rational, and
 #ifndef BERTINI_MPFR_EXTENSIONS_HPP
 #define BERTINI_MPFR_EXTENSIONS_HPP
 
+#include "bertini2/config.h"
 
 #include <boost/multiprecision/mpfr.hpp>
 #include <boost/multiprecision/random.hpp>
@@ -49,14 +50,15 @@ Particularly includes Boost.Serialize code for the mpfr_float, gmp_rational, and
 
 namespace bertini{
 
-	using mpfr_float = boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_on>;
-
+#ifdef BMP_EXPRESSION_TEMPLATES
+	using mpfr_float = boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_on>; 
 	using mpz_int = boost::multiprecision::number<boost::multiprecision::backends::gmp_int, boost::multiprecision::et_on>;
-
 	using mpq_rational = boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on>;
-
-	// using mpz_int = boost::multiprecision::mpz_int;
-	// using mpq_rational = boost::multiprecision::mpq_rational;
+#else
+	using mpfr_float = boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off>; 
+	using mpz_int = boost::multiprecision::number<boost::multiprecision::backends::gmp_int, boost::multiprecision::et_off>;
+	using mpq_rational = boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_off>;
+#endif
 }
 
 // the following code block extends serialization to the mpfr_float class from boost::multiprecision
@@ -144,9 +146,17 @@ BOOST_SERIALIZATION_SPLIT_FREE(::boost::multiprecision::backends::gmp_int)
 // if you wish to use et_on with Boost.Multiprecision with Eigen 3.2.x or earlier, you must apply a patch to Boost.MP related to bug 11149, and use the following non-standard lines.
 // https://svn.boost.org/trac/boost/ticket/11149
 
-// namespace std{ using boost::multiprecision::min; using
-//  boost::multiprecision::max;
-// }
+#define EIGEN_DEVICE_FUNC // to make Eigen 3.3 happy... ugh, this is likely to break CUDA usage with Bertini2, if that ever happens.
+#include <Eigen/src/Core/util/Macros.h>
+
+#ifdef BMP_EXPRESSION_TEMPLATES
+	#if (!EIGEN_VERSION_AT_LEAST(3,2,92)) // version of 3.3-beta1 is 3,2,92.
+		namespace std{ 
+using boost::multiprecision::min; //error receiver: please see https://svn.boost.org/trac/boost/ticket/11149 for information about these using statements in std namespace.  
+using boost::multiprecision::max; //3 options: ./configure --disable-expression_templates, use Boost 1.61, or patch earlier Boost versions to resolve this.
+		}
+	#endif
+#endif
 
 namespace bertini
 {

--- a/core/include/bertini2/tracking/powerseries_endgame.hpp
+++ b/core/include/bertini2/tracking/powerseries_endgame.hpp
@@ -373,7 +373,7 @@ public:
 				s_derivatives[ii] = derivatives[ii+offset] * (candidate * pow(times[ii+offset], static_cast<RT>(candidate-1)/candidate));
 			}
 
-			auto curr_diff = (HermiteInterpolateAndSolve(
+			RT curr_diff = (HermiteInterpolateAndSolve(
 			                      pow(most_recent_time,static_cast<RT>(1)/candidate), // the target time
 			                      num_used_points,s_times,samples,s_derivatives) // the input data
 			                 - 
@@ -497,11 +497,11 @@ public:
 	SuccessCode AdvanceTime()
 	{
 		auto& samples = std::get<SampCont<CT> >(samples_);
-			auto& times   = std::get<TimeCont<CT> >(times_);
-			auto& derivatives  = std::get<SampCont<CT> >(derivatives_);
+		auto& times   = std::get<TimeCont<CT> >(times_);
+		auto& derivatives  = std::get<SampCont<CT> >(derivatives_);
 
-			Vec<CT> next_sample;
-		auto next_time = times.back() * this->EndgameSettings().sample_factor; //setting up next time value.
+		Vec<CT> next_sample;
+		CT next_time = times.back() * this->EndgameSettings().sample_factor; //setting up next time value.
 
   		if (abs(next_time) < this->EndgameSettings().min_track_time)
   		{

--- a/python/configure.ac
+++ b/python/configure.ac
@@ -1,9 +1,4 @@
-
-
-
-
-
-#we're building pybertini, version 1.0.alpha2, and the corresponding email is dan brake's
+#we're building pybertini, version 1.0.alpha2, and the corresponding email is daniel brake's
 AC_INIT([pybertini], [1.0.alpha2], [danielthebrake@gmail.com],[pybertini], [http://github.com/bertiniteam/b2])
 
 
@@ -13,6 +8,9 @@ AC_PREREQ([2.68])
 
 #
 AC_CONFIG_AUX_DIR([config])
+
+#ensure that minieigen got cloned...  i wish git recursed by default, but it doesn't.
+AC_CHECK_FILE([./minieigen/src/common.hpp],[],[AC_MSG_ERROR([it appears you didn't recurse when cloning b2, so you don't have minieigen in this directory.  to get it, simply run `git submodule update --init'.])])
 
 # turn on the keeping of produced objects in their folders.  this is for non-recursive make
 # and autotools
@@ -78,7 +76,7 @@ AC_SEARCH_LIBS([mpfr_get_version],[mpfr], [],[
 AX_EIGEN
 
 
-AX_BOOST_BASE([1.55],, [AC_MSG_ERROR([bertini2 needs Boost at least 1.55, but it was not found in your system])])
+AX_BOOST_BASE([1.56],, [AC_MSG_ERROR([bertini2 needs Boost at least 1.56, but it was not found in your system])])
 AX_BOOST_SYSTEM
 AX_BOOST_FILESYSTEM
 AX_BOOST_CHRONO

--- a/python/include/node_export.hpp
+++ b/python/include/node_export.hpp
@@ -43,7 +43,6 @@ namespace bertini{
 
 		using namespace bertini::node;
 
-		using Node = Node;
 		using Nodeptr = std::shared_ptr<Node>;
 
 		void ExportNode();

--- a/python/src/node_export.cpp
+++ b/python/src/node_export.cpp
@@ -25,6 +25,8 @@
 //  West Texas A&M University
 //  Spring 2016
 //
+//  Daniel Brake
+//  University of Notre Dame
 //
 //  python/node_export.cpp:  Source file for exposing Node class to python.
 
@@ -32,8 +34,6 @@
 
 
 #include "node_export.hpp"
-
-//#include <bertini2/function_tree/node.hpp>
 
 
 namespace bertini{
@@ -168,8 +168,6 @@ namespace bertini{
 			class_<NodeWrap, boost::noncopyable, Nodeptr >("AbstractNode", no_init)
 			.def(NodeVisitor<Node>())
 			;
-
-			register_ptr_to_python<std::shared_ptr<Node> >();
 		};
 		
 		


### PR DESCRIPTION
- detect absent minieigen when compiling python
- for Boost versions which have min/max (1.61, and patched earlier versions), inject into std namespace for Eigen 3.2.x.  This should be relaxed for Eigen 3.3 when it comes out officially.
- allow user to disable expression templates, to allow unpatched Boost to be used with Eigen (affects JacobiSVD, e.g.)
- added some hopefully helpful error messages related to thread_local (missing for OSX clang) and expression template min/max (missing in Boost 1.60 and earlier).