### PR TITLE
Endgames generalized to handle nonzero target time.

### DIFF
--- a/core/include/bertini2/tracking/base_endgame.hpp
+++ b/core/include/bertini2/tracking/base_endgame.hpp
@@ -224,6 +224,7 @@ namespace bertini{
 					We track then to the next_time and construct the next_sample.
 
 				\param start_time The time value at which we start the endgame. 
+				\param target_time The time value that we are trying to find a solution to. 
 				\param x_endgame The current space point at start_time.
 				\param times A deque that will hold all the time values of the samples we are going to use to start the endgame. 
 				\param samples a deque that will hold all the samples corresponding to the time values in times. 
@@ -231,7 +232,7 @@ namespace bertini{
 				\tparam CT The complex number type.
 				*/	
 				template<typename CT>
-				SuccessCode ComputeInitialSamples(const CT & start_time,const Vec<CT> & x_endgame, TimeCont<CT> & times, SampCont<CT> & samples) // passed by reference to allow times to be filled as well.
+				SuccessCode ComputeInitialSamples(const CT & start_time,const CT & target_time, const Vec<CT> & x_endgame, TimeCont<CT> & times, SampCont<CT> & samples) // passed by reference to allow times to be filled as well.
 				{	
 					using RT = typename Eigen::NumTraits<CT>::Real;
 					assert(endgame_settings_.num_sample_points>0 && "number of sample points must be positive");
@@ -252,8 +253,8 @@ namespace bertini{
 					//start at 1, because the input point is the 0th element.
 					for(int ii=1; ii < endgame_settings_.num_sample_points; ++ii)
 					{ 
-						times.emplace_back(times[ii-1] * RT(endgame_settings_.sample_factor));
-						samples.emplace_back(Vec<CT>(num_vars));
+						times.emplace_back((times[ii-1] + target_time) * RT(endgame_settings_.sample_factor)); // next time is a point between the previous time and target time.
+						samples.emplace_back(Vec<CT>(num_vars));											   // sample_factor gives us some point between the two, usually the midpoint.		
 
 						auto tracking_success = tracker_.TrackPath(samples[ii],times[ii-1],times[ii],samples[ii-1]);
 						AsDerived().EnsureAtPrecision(times[ii],Precision(samples[ii]));

--- a/core/include/bertini2/tracking/cauchy_endgame.hpp
+++ b/core/include/bertini2/tracking/cauchy_endgame.hpp
@@ -301,6 +301,7 @@ public:
 
 		## Input: 
 				starting_time: time value that we start from to track around the origin
+				target_time: the time value that we are centering out loops around, default is t = 0
 				starting_sample: an approximate solution of the homotopy at t = starting_time
 
 		## Output:
@@ -313,7 +314,7 @@ public:
 				as paths converging to the solution we are approximating. 
 	*/
 	template<typename CT> 
-	SuccessCode CircleTrack(CT const& starting_time, Vec<CT> const& starting_sample)
+	SuccessCode CircleTrack(CT const& starting_time, CT const& target_time, Vec<CT> const& starting_sample)
 	{	
 		using bertini::Precision;
 		assert(Precision(starting_time)==Precision(starting_sample) && "starting time and sample for circle track must be of same precision");
@@ -346,7 +347,8 @@ public:
 			using std::polar;
 			using bertini::polar;
 
-			RT radius = abs(starting_time), angle = arg(starting_time);
+			//Generalized since we could have a nonzero target time. 
+			RT radius = abs(starting_time - target_time), angle = arg(starting_time - target_time); // generalized for nonzero target_time.
 
 			auto next_sample = Vec<CT>(num_vars);
 			auto next_time = (ii==this->EndgameSettings().num_sample_points-1) 
@@ -354,7 +356,13 @@ public:
 							  starting_time
 								:
 							  polar(radius, (ii+1)*2*acos(static_cast<RT>(-1)) / (this->EndgameSettings().num_sample_points) + angle)
-							  ;
+							  ; 
+			// If we are tracking to a nonzero target time we need to shift our values to track to. This is a step that may not be needed if target_time = 0
+			if(target_time != BCT(0,0) && next_time != starting_time)
+			{
+				next_time = next_time + target_time; 
+			}
+
 
 			auto tracking_success = this->GetTracker().TrackPath(next_sample, current_time, next_time, current_sample);	
 			if (tracking_success != SuccessCode::Success)
@@ -613,13 +621,13 @@ public:
 					min = norm;
 				}
 			}
-
+			//compute the ratio if they are large enough.
 			if(min > this->Tolerances().final_tolerance && max > this->Tolerances().final_tolerance)
 			{
 				norm = min / max;
 				if(norm < cauchy_settings_.maximum_cauchy_ratio && (max - min) > this->Tolerances().final_tolerance)
 				{
-					return false;
+					return false; // bad ratio and too far apart. 
 				}
 			}
 		}
@@ -643,7 +651,7 @@ public:
 	encountered. 
 
 		## Input: 
-			None: all data needed are class data members
+			target_time: the time value that we are creating loops around, default set to t= 0
 
 		## Output:
 			initial_cauchy_loop_success: This variable returns any error code we have encountered or success if we have sucessfully 
@@ -653,7 +661,7 @@ public:
 				\tparam CT The complex number type.
 	*/		 
 	template<typename CT>
-	SuccessCode InitialCauchyLoops()
+	SuccessCode InitialCauchyLoops(CT const& target_time)
 	{	
 		using RT = typename Eigen::NumTraits<CT>::Real;
 		auto& cau_times = std::get<TimeCont<CT> >(cauchy_times_);
@@ -679,8 +687,8 @@ public:
 			auto next_time = ps_times.back();
 			auto next_sample = ps_samples.back();
 
-			// track around a circle once.  we'll use it to measure whether we believe we are in the eg operating zone, based on the ratio of ratios of norms of sample points around the circle
-			auto tracking_success = CircleTrack(cau_times.front(),cau_samples.front());
+			// track around a circle once.  we'll use it to measure whether we believe we are in the eg operating zone, based on the ratio of norms of sample points around the circle
+			auto tracking_success = CircleTrack(cau_times.front(),target_time,cau_samples.front());
 
 			this->IncrementCycleNumber(1);
 
@@ -706,7 +714,7 @@ public:
 					}
 
 					//compute next loop, the last sample in times and samples is the sample our loop ended on. Either where we started or on another sheet at the same time value. 
-					tracking_success = CircleTrack(cau_times.back(),cau_samples.back());
+					tracking_success = CircleTrack(cau_times.back(),target_time,cau_samples.back());
 
 					this->IncrementCycleNumber(1);
 
@@ -716,17 +724,17 @@ public:
 
 				if(initial_cauchy_loop_success == SuccessCode::CycleNumTooHigh)
 				{//see if we should continue to the next sample point
-					if(abs(cau_times.back()) < this->EndgameSettings().min_track_time)
+					if(abs(cau_times.back() - target_time) < this->EndgameSettings().min_track_time)
 						continue_loop = false;
 					else
 						continue_loop = true;
 				}
 			}//end if (RatioEGOperatingZoneTest())
-			else 
+			else
 			{
 				//compute the time for the next sample point
 				AsDerived().EnsureAtPrecision(next_time,Precision(ps_samples.back()));
-				next_time = ps_times.back() * static_cast<RT>(this->EndgameSettings().sample_factor);
+				next_time = (ps_times.back() + target_time) * static_cast<RT>(this->EndgameSettings().sample_factor);
 
 				SuccessCode tracking_success = this->GetTracker().TrackPath(next_sample,ps_times.back(),next_time,ps_samples.back());
 				AsDerived().EnsureAtPrecision(next_time,Precision(next_sample));
@@ -782,7 +790,7 @@ public:
 		auto& ps_samples = std::get<SampCont<CT> >(pseg_samples_);
 
 		//Compute initial samples for pseg
-		auto initial_sample_success = this->ComputeInitialSamples(start_time, start_point, ps_times, ps_samples);
+		auto initial_sample_success = this->ComputeInitialSamples(start_time, approximation_time, start_point, ps_times, ps_samples);
 		if (initial_sample_success!=SuccessCode::Success)
 			return initial_sample_success;
 
@@ -795,7 +803,8 @@ public:
 		//track until for more c_over_k estimates or until we reach a cutoff time. 
 		while ( (ii < cauchy_settings_.num_needed_for_stabilization) )
 		{	
-			next_time = ps_times.back() * static_cast<RT>(this->EndgameSettings().sample_factor);
+			next_time = (ps_times.back() + approximation_time) * static_cast<RT>(this->EndgameSettings().sample_factor); // using general midpoint formula with sample_factor to give us a time
+																												  // between ps_times.back() and the approximation_time.
 
 			auto tracking_success = this->GetTracker().TrackPath(next_sample,ps_times.back(),next_time,ps_samples.back());
 			if (tracking_success!=SuccessCode::Success)
@@ -816,7 +825,8 @@ public:
 		//have we stabilized yet? 
 		while(!CheckForCOverKStabilization(c_over_k) && abs(ps_times.back()) > cauchy_settings_.cycle_cutoff_time)
 		{
-			next_time = ps_times.back() * static_cast<RT>(this->EndgameSettings().sample_factor);
+			next_time = (ps_times.back() + approximation_time) * static_cast<RT>(this->EndgameSettings().sample_factor); // using general midpoint formula with sample_factor to give us a time
+																												  // between ps_times.back() and the approximation_time.
 
 			auto tracking_success = this->GetTracker().TrackPath(next_sample,ps_times.back(),next_time,ps_samples.back());
 
@@ -835,7 +845,7 @@ public:
 
 		}//end while
 
-		auto cauchy_loop_success = InitialCauchyLoops<CT>();
+		auto cauchy_loop_success = InitialCauchyLoops<CT>(approximation_time);
 		if (cauchy_loop_success != SuccessCode::Success)
 			return cauchy_loop_success;
 
@@ -969,7 +979,8 @@ public:
 
 		## Input: 
 			starting_time: the time value at which we start finding cauchy samples 
-			starting_sample: yhe current space point at starting_time, this will also be the first cauchy sample
+			target_time: the time value we are computing cauchy samples around
+			starting_sample: the current space point at starting_time, this will also be the first cauchy sample
 
 
 		## Output: 
@@ -982,7 +993,7 @@ public:
 
 	*/
 	template<typename CT>
-	SuccessCode ComputeCauchySamples(CT const& starting_time, Vec<CT> const& starting_sample)
+	SuccessCode ComputeCauchySamples(CT const& starting_time,CT const& target_time, Vec<CT> const& starting_sample)
 	{
 		using bertini::Precision;
 		assert(Precision(starting_time)==Precision(starting_sample));
@@ -1000,7 +1011,7 @@ public:
 		while( this->CycleNumber() < cauchy_settings_.fail_safe_maximum_cycle_number )
 		{
 			//track around the origin once.
-			auto tracking_success = CircleTrack(cau_times.back(),cau_samples.back());
+			auto tracking_success = CircleTrack(cau_times.back(),target_time,cau_samples.back());
 			this->IncrementCycleNumber(1);
 
 			if(tracking_success != SuccessCode::Success)
@@ -1027,6 +1038,7 @@ public:
 		## Input: 
 			start_time: the time value at which we start the endgame
 			start_point: an approximate solution to our homotopy H at start_time
+			target_time: the time value that we are using the endgame to interpolate to, default set to t = 0.
 
 		## Output: 
 			SuccessCode: reporting if we were successful in the endgame or if we encountered an error
@@ -1040,7 +1052,7 @@ public:
 					Integral Formula. 
 	*/
 	template<typename CT>
-	SuccessCode Run(CT const& start_time, Vec<CT> const& start_point)
+	SuccessCode Run(CT const& start_time, Vec<CT> const& start_point, CT const& target_time = static_cast<CT>(0))
 	{	
 		if (start_point.size()!=this->GetSystem().NumVariables())
 		{
@@ -1062,24 +1074,22 @@ public:
 		ClearTimesAndSamples<CT>(); //clear times and samples before we begin.
 		this->CycleNumber(0);
 
-		CT origin(0,0); // this should really be input, not set hardcoded.
-
 		Vec<CT> prev_approx, latest_approx;
 		RT approximate_error;
 		Vec<CT>& final_approx = std::get<Vec<CT> >(this->final_approximation_at_origin_);
 	
 
 		//Compute the first approximation using the power series approximation technique. 
-		auto initial_ps_success = InitialPowerSeriesApproximation(start_time, start_point, origin, prev_approx);  // last argument is output here
+		auto initial_ps_success = InitialPowerSeriesApproximation(start_time, start_point, target_time, prev_approx);  // last argument is output here
 		if(initial_ps_success != SuccessCode::Success)
 			return initial_ps_success;
 
-		CT next_time = ps_times.back();
+		//Generalized next_time in case if we are not trying to converge to the t = 0.
+		CT next_time = (ps_times.back() + target_time) * static_cast<RT>(this->EndgameSettings().sample_factor);
 		RT norm_of_dehom_of_prev_approx, norm_of_dehom_of_latest_approx;
 
 		if(this->SecuritySettings().level <= 0)
 			norm_of_dehom_of_prev_approx = this->GetSystem().DehomogenizePoint(prev_approx).norm();
-
 		do
 		{
 			//Compute a cauchy approximation.  Uses the previously computed samples, 
@@ -1101,7 +1111,7 @@ public:
 				final_approx = latest_approx;
 				return SuccessCode::Success;
 			}
-			else if (abs(cau_times.front()) < this->EndgameSettings().min_track_time)
+			else if (abs(cau_times.front() - target_time) < this->EndgameSettings().min_track_time) // generalized for target_time not equal to 0. 
 			{//we are too close to t = 0 but we do not have the correct tolerance - so we exit
 				final_approx = latest_approx;
 				return SuccessCode::FailedToConverge;
@@ -1118,7 +1128,11 @@ public:
 			prev_approx = latest_approx;
 			norm_of_dehom_of_prev_approx = norm_of_dehom_of_latest_approx;
 
-			next_time *= RT(this->EndgameSettings().sample_factor);
+			//Generalized next_time in case if we are not trying to converge to the t = 0.
+			next_time = (next_time + target_time) * static_cast<RT>(this->EndgameSettings().sample_factor);
+
+			
+
 			Vec<CT> next_sample;
 			auto tracking_success = this->GetTracker().TrackPath(next_sample,cau_times.back(),next_time,cau_samples.front());
 			if (tracking_success != SuccessCode::Success)
@@ -1129,14 +1143,14 @@ public:
 			ps_times.push_back(next_time);  ps_times.pop_front();
 			ps_samples.push_back(next_sample); ps_samples.pop_front();
 
-			auto cauchy_samples_success = ComputeCauchySamples(next_time,next_sample);
+			auto cauchy_samples_success = ComputeCauchySamples(next_time,target_time,next_sample);
 
 			//Added because of Griewank osborne test case where tracker returns GoingToInfinity.  
 			//The cauchy endgame should stop instead of attempting to continue. 
 			//This is because the tracker will not track to any meaningful space values. 
 			if (cauchy_samples_success == SuccessCode::GoingToInfinity)
 				return SuccessCode::GoingToInfinity;
-			else if (cauchy_samples_success != SuccessCode::Success && abs(cau_times.front()) < this->EndgameSettings().min_track_time)
+			else if (cauchy_samples_success != SuccessCode::Success && abs(cau_times.front()-target_time) < this->EndgameSettings().min_track_time)
 			{// we are too close to t = 0 but we do have the correct tolerance -so we exit.
 				final_approx = latest_approx;
 				return SuccessCode::MinTrackTimeReached;
@@ -1146,7 +1160,6 @@ public:
 				final_approx = latest_approx;
 				return cauchy_samples_success;
 			}
-
 		} while (approximate_error > this->Tolerances().final_tolerance);
 
 		final_approx = latest_approx;

--- a/core/include/bertini2/tracking/cauchy_endgame.hpp
+++ b/core/include/bertini2/tracking/cauchy_endgame.hpp
@@ -355,13 +355,9 @@ public:
 								?
 							  starting_time
 								:
-							  polar(radius, (ii+1)*2*acos(static_cast<RT>(-1)) / (this->EndgameSettings().num_sample_points) + angle)
-							  ; 
+							  polar(radius, (ii+1)*2*acos(static_cast<RT>(-1)) / (this->EndgameSettings().num_sample_points) + angle) + target_time;
 			// If we are tracking to a nonzero target time we need to shift our values to track to. This is a step that may not be needed if target_time = 0
-			if(target_time != BCT(0,0) && next_time != starting_time)
-			{
-				next_time = next_time + target_time; 
-			}
+							  ; 
 
 
 			auto tracking_success = this->GetTracker().TrackPath(next_sample, current_time, next_time, current_sample);	

--- a/core/test/endgames/generic_pseg_test.hpp
+++ b/core/test/endgames/generic_pseg_test.hpp
@@ -625,7 +625,7 @@ BOOST_AUTO_TEST_CASE(compute_initial_samples)
 
 	TestedEGType my_endgame(tracker,endgame_settings,power_series_settings);
 
-	auto tracking_success = my_endgame.ComputeInitialSamples(current_time, current_space, times, samples);
+	auto tracking_success = my_endgame.ComputeInitialSamples(current_time, origin, current_space, times, samples);
 
 	BOOST_REQUIRE(tracking_success==SuccessCode::Success);
 	
@@ -637,6 +637,89 @@ BOOST_AUTO_TEST_CASE(compute_initial_samples)
 	}
 
 }//end compute initial samples
+
+
+/**
+This test will check to see if we can compute initial samples where the time we start and target_time are not 0.1 and 0 respectively.
+target_time is .1 + .1I and we are going to start at the time value .2
+
+*/
+BOOST_AUTO_TEST_CASE(compute_initial_samples_non_zero_target_time)
+{
+	DefaultPrecision(ambient_precision);
+
+	bertini::System sys;
+	Var x = std::make_shared<Variable>("x"), t = std::make_shared<Variable>("t");
+	VariableGroup vars{x};
+	sys.AddVariableGroup(vars); sys.AddPathVariable(t);
+	// Define homotopy system
+	sys.AddFunction( pow(x-1,3)*(1-t) + (pow(x,3) + 1)*t);
+
+
+	auto precision_config = PrecisionConfig(sys);
+
+	TrackerType tracker(sys);
+	
+	config::Stepping<BRT> stepping_settings;
+	config::Newton newton_settings;
+
+	tracker.Setup(TestedPredictor,
+                RealFromString("1e-5"),
+                RealFromString("1e5"),
+                stepping_settings,
+                newton_settings);
+	
+	tracker.PrecisionSetup(precision_config);
+
+	BCT target_time = ComplexFromString(".1",".1");
+	Vec<BCT> x_origin(1);
+	x_origin << BCT(1);
+	TimeCont<BCT> correct_times; 
+	SampCont<BCT> correct_samples;
+
+	TimeCont<BCT> times; 
+	std::deque<Vec<BCT> > samples;
+	BCT time(1);
+	Vec<BCT> sample(1);
+
+
+	time = ComplexFromString(".2"); // x = .2
+	correct_times.push_back(time);
+	sample << ComplexFromString("3.603621541081173e-01", "2.859583229930518e-18"); // f(.2) = 3.603621541081173e-01 2.859583229930518e-18 from bertini classic
+	correct_samples.push_back(sample);
+
+	time = ComplexFromString(".15",".05"); // x = ((.2) + (.1 + .1I)) / 2 = .15 + .05I
+	correct_times.push_back(time);
+	sample << ComplexFromString("4.205197361710131e-01","-6.739509600163453e-02"); //f(.15 + .05I) = 4.205197361710131e-01 -6.739509600163453e-02  from bertini classic.
+	correct_samples.push_back(sample);
+
+	time = ComplexFromString(".125",".075"); // x = ((.15 + .05I) + (.1 + .1I))/2 = .125 + .075I
+	correct_times.push_back(time);
+	sample << ComplexFromString("4.469031847163714e-01", "-1.059855741137409e-01"); // f(.125 + .075I) =  4.469031847163714e-01 -1.059855741137409e-01 from bertini classic
+	correct_samples.push_back(sample);
+
+	BCT current_time(1);
+	Vec<BCT> current_space(1);
+	current_time = ComplexFromString(".2");
+	current_space << ComplexFromString("3.603621541081173e-01", "2.859583229930518e-18");
+
+	config::Endgame<BRT> endgame_settings;
+	config::PowerSeries power_series_settings;
+
+	TestedEGType my_endgame(tracker,endgame_settings,power_series_settings);
+
+	auto tracking_success = my_endgame.ComputeInitialSamples(current_time, target_time, current_space, times, samples);
+
+	BOOST_REQUIRE(tracking_success==SuccessCode::Success);
+	
+
+	for(unsigned ii = 0; ii < samples.size(); ++ii)
+	{
+		BOOST_CHECK_EQUAL(samples[ii].size(),1);
+		BOOST_CHECK((samples[ii] - correct_samples[ii]).norm() < my_endgame.Tolerances().newton_during_endgame);
+	}
+
+}//end compute initial samples nonzero target time
 
 
 
@@ -701,7 +784,64 @@ BOOST_AUTO_TEST_CASE(pseg_full_run)
 }//end pseg mp for power series class 
 
 
+/**
+The function that runs the power series endgame is called Run. Run takes an endgame_time value and and endgame_space value that is
+one of the solutions at t = endgame_time, it can also set a target_time other than t = 0. 
 
+This test will start at t = 0.2 and use the endgame to find the solution at t = .1 + .1*I. This is checking to make sure the powerseries
+endgame is general enough to move from t = a to t = b for a,b being generic complex numbers. 
+*/
+BOOST_AUTO_TEST_CASE(pseg_full_run_non_zero_target_time)
+{
+	DefaultPrecision(ambient_precision);
+
+	bertini::System sys;
+	Var x = std::make_shared<Variable>("x"), t = std::make_shared<Variable>("t");
+
+	sys.AddFunction( pow(x-1,3)*(1-t) + (pow(x,3)+1)*t);
+
+	VariableGroup vars{x};
+	sys.AddVariableGroup(vars); 
+	sys.AddPathVariable(t);
+
+	auto precision_config = PrecisionConfig(sys);
+
+	TrackerType tracker(sys);
+	
+	config::Stepping<BRT> stepping_settings;
+	config::Newton newton_settings;
+
+	tracker.Setup(TestedPredictor,
+                RealFromString("1e-6"),
+                RealFromString("1e5"),
+                stepping_settings,
+                newton_settings);
+	
+	tracker.PrecisionSetup(precision_config);
+
+
+	BCT current_time(1);
+	BCT target_time(1);
+	Vec<BCT> current_space(1);
+	current_time = ComplexFromString(".2");
+	target_time = ComplexFromString(".1", ".1");
+
+	current_space << ComplexFromString("3.603621541081173e-01", "2.859583229930518e-18");
+
+	Vec<BCT> correct(1);
+	correct << ComplexFromString("4.680740395503238e-01", "-1.470429372721208e-01");
+
+	config::Endgame<BRT> endgame_settings;
+	config::Security<BRT> security_settings;
+	config::Tolerances<BRT> tolerances;
+
+	TestedEGType my_endgame(tracker,endgame_settings,security_settings,tolerances);
+	my_endgame.Run(current_time,current_space,target_time);
+
+
+	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - correct).norm() < 1e-11);
+
+}//end pseg mp for power series class non zero target time
 
 
 
@@ -1141,7 +1281,65 @@ BOOST_AUTO_TEST_CASE(parabola)
 
 	auto endgame_solution = my_endgame.FinalApproximation<BCT>();
 
-	BOOST_CHECK_SMALL( abs(endgame_solution(0)-correct_eg_soln(0)), BRT(1e-11) );
+	BOOST_CHECK_SMALL( abs(endgame_solution(0)-correct_eg_soln(0)), BRT(1e-10) );
 }
+
+/**
+	Full blown test to see if we can actually track using an endgame to a nonzero target time. 
+*/
+BOOST_AUTO_TEST_CASE(pseg_full_run_nonzero_target_time)
+{
+
+	DefaultPrecision(ambient_precision);
+
+	System sys;
+	Var x = std::make_shared<Variable>("x");
+	Var t = std::make_shared<Variable>("t"); 
+
+	sys.AddFunction(pow(x-1,3)*(1-t) + (pow(x,3)+1)*t);
+
+	VariableGroup vars{x};
+	sys.AddVariableGroup(vars); 
+	sys.AddPathVariable(t);
+
+
+	auto precision_config = PrecisionConfig(sys);
+
+	TrackerType tracker(sys);
+		
+	config::Stepping<BRT> stepping_preferences;
+	config::Newton newton_preferences;
+
+	tracker.Setup(TestedPredictor,
+	    RealFromString("1e-5"),
+	    RealFromString("1e5"),
+	    stepping_preferences,
+	    newton_preferences);
+		
+	tracker.PrecisionSetup(precision_config);
+
+	TimeCont<BCT> pseg_times;
+		SampCont<BCT> pseg_samples;
+
+	auto start_time = ComplexFromString("0.2");
+	Vec<BCT> start_sample(1);
+	auto target_time = ComplexFromString(".15","-.01");
+	Vec<BCT> first_approx(1);
+	Vec<BCT> x_to_check_against(1);
+
+	start_sample << ComplexFromString("3.603621541081173e-01", "2.859583229930518e-18"); 
+	x_to_check_against << ComplexFromString("4.248924277564006e-01", "1.369835558109531e-02");
+
+	config::Endgame<BRT> endgame_settings;
+	config::Security<BRT> security_settings;
+	config::PowerSeries power_series_settings;
+	TestedEGType my_endgame(tracker,endgame_settings,power_series_settings, security_settings);
+
+	auto endgame_success = my_endgame.Run(start_time,start_sample,target_time);
+	BOOST_CHECK(endgame_success == SuccessCode::Success);
+
+	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - x_to_check_against).norm() < 1e-10);
+
+}// end cauchy_full_run_nonzero_target_time
 
 


### PR DESCRIPTION
* Cauchy endgame can now be used to approximate solutions for t not equal to 0
* Power series endgame can now be used to approximate solutions for t not equal to 0
     * Functions that implicitly use target_time = 0 now have test cases to check if they are able 
        to handle when the target time is nonzero.