### PR TITLE
Auto Retrack of crossed paths

### DIFF
--- a/core/include/bertini2/nag_algorithms/config.hpp
+++ b/core/include/bertini2/nag_algorithms/config.hpp
@@ -46,6 +46,14 @@ struct Tolerances
 	T path_truncation_threshold = T(100000); //E.4.13
 	// T final_tolerance_times_final_tolerance_multiplier = final_tolerance * final_tolerance_multiplier;
 };
+			
+
+			template<typename T>
+			struct AutoRetrack
+			{
+				T midpath_decrease_tolerance_factor = T(1)/T(2);
+				T boundary_near_tol = T(1)/T(100000);
+			};
 
 
 template<typename T>

--- a/core/include/bertini2/nag_algorithms/config.hpp
+++ b/core/include/bertini2/nag_algorithms/config.hpp
@@ -86,7 +86,7 @@ struct PostProcessing{
 
 struct ZeroDim
 {
-	unsigned max_num_crossed_path_resolve_attempts = 1; ///< The maximum number of times to attempt to re-solve crossed paths at the endgame boundary.
+	unsigned max_num_crossed_path_resolve_attempts = 2; ///< The maximum number of times to attempt to re-solve crossed paths at the endgame boundary.
 };
 
 

--- a/core/include/bertini2/nag_algorithms/midpath_check.hpp
+++ b/core/include/bertini2/nag_algorithms/midpath_check.hpp
@@ -59,7 +59,10 @@ namespace bertini{
 			}
 			
 			
-			
+			/**
+			 \struct Stores data for each path that crosses, including the index of the path, all paths that it crosses with, and whether it has the same
+				starting point as a path it crosses with.
+			 */
 			struct CrossedPath{
 				
 				CrossedPath(PathIndT index, PathIndT crossed_with, bool same_start)

--- a/core/include/bertini2/nag_algorithms/midpath_check.hpp
+++ b/core/include/bertini2/nag_algorithms/midpath_check.hpp
@@ -36,6 +36,9 @@ namespace bertini{
 
 struct Midpath
 {
+	
+	using BoundaryData = typename SolnCont< std::tuple<Vec<BaseComplexType>, tracking::SuccessCode, BaseRealType>>;
+	
 	struct Data{
 		bool Passed()
 		{
@@ -55,6 +58,15 @@ struct Midpath
 	{
 		return Data();
 	}
+	
+	
+	
+	
+	template<>
+	static Data Check<BoundaryData>(BoundaryData const& boundary_solutions)
+	{
+		
+	};
 };
 
 	}

--- a/core/include/bertini2/nag_algorithms/midpath_check.hpp
+++ b/core/include/bertini2/nag_algorithms/midpath_check.hpp
@@ -60,12 +60,12 @@ namespace bertini{
 					return pass_;
 				}
 				
-				void Crossed(int path_index, bool same_start)
+				void Crossed(unsigned long long path_index, bool same_start)
 				{
 					bool already_stored = false;
 					for(auto v : crossed_paths)
 					{
-						int index = std::get<int>(v);
+						auto index = std::get<unsigned long long>(v);
 						if(path_index == index)
 						{
 							already_stored = true;
@@ -79,21 +79,23 @@ namespace bertini{
 					
 					pass_ = false;
 				}
+				
+				auto GetCrossedPaths() const
+				{
+					return crossed_paths;
+				}
 
 
 			private:
 				bool pass_ = true;
-				std::vector< std::tuple< int, bool > > crossed_paths;
+				std::vector< std::tuple< unsigned long long, bool > > crossed_paths;
 
 
 			}; //re: struct Data
 
-//			template<typename T>
-//			static
-//			Data Check(T const&)
-//			{
-//				return Data();
-//			}
+
+			
+			
 			
 			
 			
@@ -108,11 +110,11 @@ namespace bertini{
 			Data Check(BoundaryData const& boundary_data)
 			{
 				Data check_data;
-				for (int ii = 0; ii < boundary_data.size(); ++ii)
+				for (unsigned long long ii = 0; ii < boundary_data.size(); ++ii)
 				{
 					const Vec<ComplexType>& solution_ii = std::get<Vec<ComplexType>>(boundary_data[ii]);
-					
-					for(int jj = ii+1; jj < boundary_data.size(); ++jj)
+										
+					for(unsigned long long jj = ii+1; jj < boundary_data.size(); ++jj)
 					{
 						if(std::get<tracking::SuccessCode>(boundary_data[ii]) == tracking::SuccessCode::Success)
 						{

--- a/core/include/bertini2/nag_algorithms/midpath_check.hpp
+++ b/core/include/bertini2/nag_algorithms/midpath_check.hpp
@@ -63,7 +63,7 @@ namespace bertini{
 				void Crossed(unsigned long long path_index, bool same_start)
 				{
 					bool already_stored = false;
-					for(auto v : crossed_paths)
+					for(auto const& v : crossed_paths)
 					{
 						auto index = std::get<unsigned long long>(v);
 						if(path_index == index)
@@ -121,7 +121,7 @@ namespace bertini{
 							const Vec<ComplexType>& solution_jj = std::get<Vec<ComplexType>>(boundary_data[jj]);
 							const Vec<ComplexType> diff_sol = solution_ii - solution_jj;
 							
-							if(diff_sol.norm() < boundary_near_tolerance_)
+							if((diff_sol.template lpNorm<Eigen::Infinity>()/solution_ii.template lpNorm<Eigen::Infinity>()) < boundary_near_tolerance_)
 							{
 								// Check if start points are the same
 								const auto& start_ii = start_system_.template StartPoint<ComplexType>(ii);

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -334,7 +334,7 @@ namespace bertini {
 				midpath_reduced_tolerance_ = midpath_reduced_tolerance_*midpath_decrease_tolerance_factor_;
 				tracker_.SetTrackingTolerance(midpath_reduced_tolerance_);
 				
-				for(auto v : midcheck.GetCrossedPaths())
+				for(auto const& v : midcheck.GetCrossedPaths())
 				{
 					if(!std::get<bool>(v))
 					{

--- a/core/include/bertini2/systems/precon.hpp
+++ b/core/include/bertini2/systems/precon.hpp
@@ -59,6 +59,29 @@ System GriewankOsborn()
 
 	return griewank_osborn_sys;
 }
+			
+			
+			/**
+			 Creates system with crossed paths at t = 1/3 and t = 2/3.
+			 
+			 From the returned system, you can unpack the variables, etc.
+			 */
+			static
+			System CrossedPaths()
+			{
+				using Var = std::shared_ptr<node::Variable>;
+				
+				bertini::System crossed_paths_sys;
+				Var x = std::make_shared<node::Variable>("x"), t = std::make_shared<node::Variable>("t"), y = std::make_shared<node::Variable>("y");
+				VariableGroup vars{x,y};
+				crossed_paths_sys.AddVariableGroup(vars);
+				
+				crossed_paths_sys.AddFunction(pow(x,3)+2);
+				crossed_paths_sys.AddFunction(pow(y,2) + 0.5);
+				
+				return crossed_paths_sys;
+			}
+
 
 };
 		

--- a/core/include/bertini2/systems/precon.hpp
+++ b/core/include/bertini2/systems/precon.hpp
@@ -73,11 +73,13 @@ System GriewankOsborn()
 				
 				bertini::System crossed_paths_sys;
 				Var x = std::make_shared<node::Variable>("x"), t = std::make_shared<node::Variable>("t"), y = std::make_shared<node::Variable>("y");
+				auto two = std::make_shared<node::Float>("2");
+				auto half = std::make_shared<node::Float>("0.5");
 				VariableGroup vars{x,y};
 				crossed_paths_sys.AddVariableGroup(vars);
 				
-				crossed_paths_sys.AddFunction(pow(x,3)+2);
-				crossed_paths_sys.AddFunction(pow(y,2) + 0.5);
+				crossed_paths_sys.AddFunction(pow(x,3)+ two);
+				crossed_paths_sys.AddFunction(pow(y,2) + half);
 				
 				return crossed_paths_sys;
 			}

--- a/core/include/bertini2/tracking/explicit_predictors.hpp
+++ b/core/include/bertini2/tracking/explicit_predictors.hpp
@@ -79,6 +79,8 @@ namespace bertini{
 			{
 				switch (predictor_choice)
 				{
+					case (Predictor::Constant):
+						return 0;
 					case (Predictor::Euler):
 						return 1;
 					case (Predictor::HeunEuler):
@@ -110,6 +112,8 @@ namespace bertini{
 			{
 				switch (predictor_choice)
 				{
+					case (Predictor::Constant):
+						return false;
 					case (Predictor::Euler):
 						return false;
 					case (Predictor::HeunEuler):
@@ -223,6 +227,25 @@ namespace bertini{
 					p_ = predict::Order(method);
 					switch(method)
 					{
+						case Predictor::Constant:
+						{
+							s_ = 1;
+							Mat<double>& arefd = std::get< Mat<double> >(a_);
+							Vec<double>& brefd = std::get< Vec<double> >(b_);
+							Vec<double>& crefd = std::get< Vec<double> >(c_);
+							crefd.resize(s_); crefd(0) = 0;
+							arefd.resize(s_,s_); arefd(0,0) = 0;
+							brefd.resize(s_); brefd(0) = 0;
+							Mat<mpfr_float>& arefmp = std::get< Mat<mpfr_float> >(a_);
+							Vec<mpfr_float>& brefmp = std::get< Vec<mpfr_float> >(b_);
+							Vec<mpfr_float>& crefmp = std::get< Vec<mpfr_float> >(c_);
+							crefmp.resize(s_); crefmp(0) = 0;
+							arefmp.resize(s_,s_); arefmp(0,0) = 0;
+							brefmp.resize(s_); brefmp(0) = 0;
+							uses_embedded_ = false;
+							
+							break;
+						}
 						case Predictor::Euler:
 						{
 							s_ = 1;
@@ -673,6 +696,14 @@ namespace bertini{
 									 ComplexType const& delta_t)
 				{
 					static_assert(std::is_same<typename Derived::Scalar, ComplexType>::value, "scalar types must match");
+					
+					// If using constant predictor
+					if(s_ == 0)
+					{
+						next_space = current_space;
+						
+						return SuccessCode::Success;
+					}
 					
 					Mat<ComplexType>& Kref = std::get< Mat<ComplexType> >(K_);
 					Mat<RealType>& aref = std::get< Mat<RealType> >(a_);


### PR DESCRIPTION
Check is done for crossed paths by determining if two paths are the same at the endgame boundary.  Those paths are then rerun with a reduced tracking tolerance.