### PR TITLE
parsing of configs, mods to zerodim algorithm, typelists, testing order

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -33,6 +33,7 @@ pool_test
 nag_algorithms_test
 generating_test
 nag_datatypes_test
+blackbox_test
 
 cachegrind.out.*
 

--- a/core/Makefile.am
+++ b/core/Makefile.am
@@ -99,4 +99,4 @@ include test/pools/Makemodule.am
 include test/generating/Makemodule.am
 include test/nag_algorithms/Makemodule.am
 include test/nag_datatypes/Makemodule.am
-
+include test/blackbox/Makemodule.am

--- a/core/core.sublime-project
+++ b/core/core.sublime-project
@@ -27,12 +27,10 @@
 										"endgames_test",
 										"pool_test",
 										"generating_test",
-										"bertini_*.log",
 										"config.log",
 										"config.status",
 										"configure",
 										"*.trs",
-										"*.log",
 										"ltmain.sh"],
 			"folder_exclude_patterns": [
 				".deps",

--- a/core/include/bertini2/blackbox/global_configs.hpp
+++ b/core/include/bertini2/blackbox/global_configs.hpp
@@ -1,0 +1,83 @@
+//This file is part of Bertini 2.
+//
+//bertini2/blackbox/global_configs.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/blackbox/global_configs.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/blackbox/global_configs.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license, 
+// as well as COPYING.  Bertini2 is provided with permitted 
+// additional terms in the b2/licenses/ directory.
+
+
+/**
+\file bertini2/blackbox/global_configs.hpp 
+
+\brief Provides types and utilities for dealing with global defaults for the blackbox routines
+*/
+
+
+#pragma once
+#include "bertini2/detail/typelist.hpp"
+#include "bertini2/detail/configured.hpp"
+
+#include "bertini2/trackers/config.hpp"
+#include "bertini2/endgames/config.hpp"
+#include "bertini2/nag_algorithms/common/config.hpp"
+
+namespace bertini{
+
+namespace blackbox{
+
+namespace config {
+
+
+namespace {
+	using namespace tracking::config;
+	using namespace algorithm::config;
+}
+
+struct Configs
+{
+	
+
+	template<typename T>
+	using Tracking = detail::TypeList<Stepping<T>, Newton, FixedPrecisionConfig<T>, AdaptiveMultiplePrecisionConfig>;
+
+	template<typename T>
+	using Endgame = detail::TypeList<Security<T>, Endgame<T>, PowerSeries, Cauchy<T>, TrackBack>;
+
+	template<typename T>
+	using Algorithm = detail::TypeList<Tolerances<T>, MidPath<T>, AutoRetrack<T>, Sharpening<T>, Regeneration<T>, PostProcessing<T>, ZeroDim<T>, Meta>;
+
+	template<typename T>
+	using All = detail::ListCat<Tracking<T>, Endgame<T>, Algorithm<T>>;
+};
+
+
+struct Defaults : 
+detail::Configured<Configs::All<double>, Configs::All<mpfr_float>>
+{
+
+
+};
+
+}
+} // namespace blackbox
+} // namespace bertini
+
+
+
+
+
+

--- a/core/include/bertini2/blackbox/switches_zerodim.hpp
+++ b/core/include/bertini2/blackbox/switches_zerodim.hpp
@@ -1,0 +1,119 @@
+//This file is part of Bertini 2.
+//
+//bertini2/blackbox/switches_zerodim.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/blackbox/switches_zerodim.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/blackbox/switches_zerodim.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license, 
+// as well as COPYING.  Bertini2 is provided with permitted 
+// additional terms in the b2/licenses/ directory.
+
+
+/**
+\file bertini2/blackbox/switches_zerodim.hpp 
+
+\brief A sequence of switches for getting a particular instantiation of a ZeroDim algorithm, based on runtime options.
+*/
+
+
+
+#pragma once
+
+
+#include "bertini2/system.hpp"
+#include "bertini2/nag_algorithms/zero_dim_solve.hpp"
+#include "bertini2/endgames.hpp"
+
+namespace bertini{
+namespace blackbox{
+
+namespace type{
+enum class Start{ TotalDegree, MHom, User};
+enum class Tracker{ FixedDouble, FixedMultiple, Adaptive};
+enum class Endgame{ PowerSeries, Cauchy};
+}
+
+struct ZeroDimRT
+{
+	type::Start start = type::Start::TotalDegree;
+	type::Tracker tracker = type::Tracker::Adaptive;
+	type::Endgame endgame = type::Endgame::Cauchy;
+};
+
+
+template <typename StartType, typename TrackerType, typename EndgameType, typename ... ConstTs>
+std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecify(ConstTs const& ...ts)
+{
+	return std::make_unique<
+			algorithm::ZeroDim<
+				TrackerType, 
+				EndgameType, 
+				System, 
+				StartType>
+			>(ts...);
+
+}
+
+template <typename StartType, typename TrackerType, typename ... ConstTs>
+std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecifyEndgame(ZeroDimRT const& rt, ConstTs const& ...ts)
+{
+	switch (rt.endgame)
+	{
+		case type::Endgame::PowerSeries:
+			return ZeroDimSpecify<StartType, TrackerType, 
+					typename tracking::EndgameSelector<TrackerType>::PSEG>(ts...);
+
+		case type::Endgame::Cauchy:
+			return ZeroDimSpecify<StartType, TrackerType, 
+					typename tracking::EndgameSelector<TrackerType>::Cauchy>(ts...);
+	}
+}
+
+template <typename StartType, typename ... ConstTs>
+std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecifyTracker(ZeroDimRT const& rt, ConstTs const& ...ts)
+{
+	switch (rt.tracker)
+	{
+		case type::Tracker::FixedDouble:
+			return ZeroDimSpecifyEndgame<StartType, tracking::DoublePrecisionTracker>(rt, ts...);
+		case type::Tracker::FixedMultiple:
+			return ZeroDimSpecifyEndgame<StartType, tracking::MultiplePrecisionTracker>(rt, ts...);
+		case type::Tracker::Adaptive:
+			return ZeroDimSpecifyEndgame<StartType, tracking::AMPTracker>(rt, ts...);
+	}
+}
+
+template <typename ... ConstTs>
+std::unique_ptr<algorithm::AnyZeroDim> ZeroDimSpecifyStart(ZeroDimRT const& rt, ConstTs const& ...ts)
+{
+	switch (rt.start)
+	{
+		case type::Start::TotalDegree:
+			return ZeroDimSpecifyTracker<start_system::TotalDegree>(rt, ts...);
+		case type::Start::MHom:
+			return ZeroDimSpecifyTracker<start_system::MHomogeneous>(rt, ts...);
+		case type::Start::User:
+			return ZeroDimSpecifyTracker<start_system::User>(rt, ts...);
+	}
+}
+
+template <typename ... ConstTs>
+std::unique_ptr<algorithm::AnyZeroDim> MakeZeroDim(ZeroDimRT const& rt, ConstTs const& ...ts)
+{
+	return ZeroDimSpecifyStart(rt, ts...);
+}
+
+
+} //ns blackbox
+} //ns bertini

--- a/core/include/bertini2/detail/configured.hpp
+++ b/core/include/bertini2/detail/configured.hpp
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with configured.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2016 by Bertini2 Development Team
+// Copyright(C) 2016 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license, 
 // as well as COPYING.  Bertini2 is provided with permitted 
@@ -23,14 +23,8 @@
 // Daniel Brake
 // University of Notre Dame
 //
-
 //  detail/configured.hpp
-//
-//  copyright 2016
-//  Daniel Brake
-//  University of Notre Dame
-//  ACMS
-//  Spring 2016
+
 
 /**
 \file detail/configured.hpp
@@ -51,6 +45,45 @@ namespace bertini {
 		This templated struct allows one to provide a variable typelist of config structs (or anything else for that matter), and provides a way to get and set these configs by looking up the structs by type.
 
 		I will add lookup by index if it is needed.  If you need to look up by index, try type first.  If your types are non-unique, consider making a struct to hold the things you are storing.
+	
+
+		## On nested configs.  If two or more things in your inheritance tree require Configured, 
+		consider the following code, which can help determine whether to Get or Set from here, or to pass 
+		down the tree to a base class.
+	
+	\code
+		template <typename T>
+		const 
+		typename std::enable_if<detail::IsTemplateParameter<T, config::Cauchy<typename TrackerTraits<TrackerType>::BaseRealType>>::value, T>::type
+		& Get() const
+		{
+			return Config::template Get<T>();
+		}
+
+		template <typename T>
+		const 
+		typename std::enable_if<not detail::IsTemplateParameter<T, config::Cauchy<typename TrackerTraits<TrackerType>::BaseRealType>>::value, T>::type
+		& Get() const
+		{
+			return EndgameBase<TrackerType, FinalEGT, UsedNumTs...>::template Get<T>();
+		}
+
+
+		template <typename T>
+		typename std::enable_if<detail::IsTemplateParameter<T, config::Cauchy<typename TrackerTraits<TrackerType>::BaseRealType>>::value, void>::type
+		Set(T const& t)
+		{
+			Config::template Set(t);
+		}
+
+		template <typename T>
+		typename std::enable_if<not detail::IsTemplateParameter<T, config::Cauchy<typename TrackerTraits<TrackerType>::BaseRealType>>::value, void>::type
+		Set(T const& t)
+		{
+			EndgameBase<TrackerType, FinalEGT, UsedNumTs...>::template Set(t);
+		}
+	\endcode
+
 		*/
 		template<typename ...Ts>
 		struct Configured
@@ -74,8 +107,20 @@ namespace bertini {
 				std::get<T>(configuration_) = t;
 			}
 
+			using UsedConfigs = TypeList<Ts...>;
 
 		}; // Configured
+
+		template<typename ...Ts>
+		struct Configured<TypeList<Ts...>> : public Configured<Ts...>
+		{
+			template<typename ... T>
+			Configured(T const& ...t) : Configured<Ts...>(t...)
+			{}
+
+			Configured() : Configured<Ts...>() {}
+
+		};
 
 		#define FORWARD_GET_CONFIGURED \
 		template <typename T> \

--- a/core/include/bertini2/detail/is_template_parameter.hpp
+++ b/core/include/bertini2/detail/is_template_parameter.hpp
@@ -39,7 +39,7 @@
 */
 
 #pragma once
-
+#include "bertini2/detail/typelist.hpp"
 
 namespace bertini {
 
@@ -62,6 +62,15 @@ namespace bertini {
 	        std::is_same<F, S>::value || IsTemplateParameter<F, T...>::value;
 	        // either it is the same as the first one in the pack, or we need to expand to the right in the pack.
 	};
+
+
+	template < typename T, typename ...Ts>
+	struct IsTemplateParameter<T, TypeList<Ts...>>
+	{
+		static constexpr bool value = IsTemplateParameter<T, Ts...>::value;
+	};
+
+
 
 	} // namespace detail
 

--- a/core/include/bertini2/detail/typelist.hpp
+++ b/core/include/bertini2/detail/typelist.hpp
@@ -32,8 +32,10 @@
 #pragma once
 
 #include "bertini2/detail/enable_permuted_arguments.hpp"
+#include "bertini2/eigen_extensions.hpp"
 
 namespace bertini {
+
 namespace detail {
 
 /**
@@ -59,6 +61,26 @@ struct TypeList {
 	}
 };
 
+
+/**
+\brief Concatenate two typelists, get via ::type
+*/
+template <typename ...Ts>
+struct ListCat {};
+
+
+
+template <typename ...Ts, typename ... Rs>
+struct ListCat <TypeList<Ts...>, TypeList<Rs...>>
+{
+	using type = TypeList<Ts..., Rs...>;
+};
+
+template <typename ...Ps, typename ... Qs, typename ... Rs>
+struct ListCat <TypeList<Ps...>, TypeList<Qs...>, TypeList<Rs...>>
+{
+	using type = TypeList<Ps..., Qs..., Rs...>;
+};
 
 }} // close namespaces
 

--- a/core/include/bertini2/detail/typelist.hpp
+++ b/core/include/bertini2/detail/typelist.hpp
@@ -1,0 +1,68 @@
+//This file is part of Bertini 2.
+//
+//typelist.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//typelist.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with typelist.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license, 
+// as well as COPYING.  Bertini2 is provided with permitted 
+// additional terms in the b2/licenses/ directory.
+
+// individual authors of this file include:
+// Dani Brake
+// University of Notre Dame
+
+
+/**
+\file detail/typelist.hpp
+
+\brief Contains the detail/typelist helper type, for templated getting/setting/storage of config structs
+*/
+#pragma once
+
+#include "bertini2/detail/enable_permuted_arguments.hpp"
+
+namespace bertini {
+namespace detail {
+
+/**
+\brief A basic typelist, in the style of Modern C++ Design, but using variadic templates
+
+To construct one, feed the types you want into the template arguments of the TypeList
+*/
+template <typename... Ts>
+struct TypeList {
+	using ToTuple = std::tuple<Ts...>;
+	using ToTupleOfVec = std::tuple<Vec<Ts>...>;
+	using ToTupleOfReal = std::tuple<typename Eigen::NumTraits<Ts>::Real...>;
+
+	template <template<typename> class ContT>
+	using ToTupleOfCont = std::tuple<ContT<Ts>...>;
+
+
+	template<typename ...Rs>
+	static 
+	std::tuple<Ts...> Unpermute(const Rs& ...rs)
+	{
+		return bertini::Unpermute<Ts...>(rs...);
+	}
+};
+
+
+}} // close namespaces
+
+
+
+
+

--- a/core/include/bertini2/endgames.hpp
+++ b/core/include/bertini2/endgames.hpp
@@ -1,41 +1,40 @@
 //This file is part of Bertini 2.
 //
-//system.hpp is free software: you can redistribute it and/or modify
+//bertini2/endgames.hpp is free software: you can redistribute it and/or modify
 //it under the terms of the GNU General Public License as published by
 //the Free Software Foundation, either version 3 of the License, or
 //(at your option) any later version.
 //
-//system.hpp is distributed in the hope that it will be useful,
+//bertini2/endgames.hpp is distributed in the hope that it will be useful,
 //but WITHOUT ANY WARRANTY; without even the implied warranty of
 //MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //GNU General Public License for more details.
 //
 //You should have received a copy of the GNU General Public License
-//along with system.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//along with bertini2/endgames.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license, 
 // as well as COPYING.  Bertini2 is provided with permitted 
 // additional terms in the b2/licenses/ directory.
 
 // individual authors of this file include:
-// Tim Hodges, Colorado State University
+// dani brake, university of notre dame
 
 /**
-\file system.hpp 
+\file bertini2/endgames.hpp 
 
-\brief Collects the various header files which define the Bertini2 systems.
+\brief Collects the various header files which define the Bertini2 endgames.
 */
 
 
 #pragma once
 
-#include "bertini2/system/precon.hpp"
-#include "bertini2/system/start_systems.hpp"
-#include "bertini2/system/system.hpp"
-
-
+#include "bertini2/endgames/fixed_prec_cauchy.hpp"
+#include "bertini2/endgames/fixed_prec_powerseries.hpp"
+#include "bertini2/endgames/amp_cauchy.hpp"
+#include "bertini2/endgames/amp_powerseries.hpp"
 
 
 

--- a/core/include/bertini2/endgames/amp_cauchy.hpp
+++ b/core/include/bertini2/endgames/amp_cauchy.hpp
@@ -44,7 +44,7 @@ namespace bertini {  namespace tracking  { namespace endgame  {
 /**
 \brief The Adaptive Precision Cauchy Endgame, in a class.
 */
-class AMPCauchyEndgame : public CauchyEndgame<AMPTracker,AMPCauchyEndgame, dbl,mpfr>, 
+class AMPCauchyEndgame : public CauchyEndgame<AMPTracker,AMPCauchyEndgame>, 
 							  public AMPEndgamePolicyBase
 {
 	
@@ -184,7 +184,7 @@ protected:
 
 public:
 	using TrackerType = AMPTracker;
-	using EGType = CauchyEndgame<TrackerType, AMPCauchyEndgame, dbl, mpfr>;
+	using EGType = CauchyEndgame<TrackerType, AMPCauchyEndgame>;
 	
 	SuccessCode RefineSample(Vec<mpfr> & result, Vec<mpfr> const& current_sample, mpfr const& current_time) const
 	{
@@ -281,18 +281,15 @@ public:
 		return refinement_success;
 	}
 
-
+	using Configs = typename AlgoTraits<EGType>::NeededConfigs;
 
 	explicit AMPCauchyEndgame(TrackerType const& tr, 
-	                               const std::tuple< const config::Cauchy<BRT> &,
-	                               					 const config::Endgame<BRT>&, 
-	                               				     const config::Security<BRT>&
-	                               				    > & settings )
+	                          typename Configs::ToTuple const& settings )
       : EGType(tr, settings)
    	{}
 
     template< typename... Ts >
-	AMPCauchyEndgame(TrackerType const& tr, const Ts&... ts ) : AMPCauchyEndgame(tr, Unpermute<config::Cauchy<BRT>, config::Endgame<BRT>, config::Security<BRT> >( ts... ) ) 
+	AMPCauchyEndgame(TrackerType const& tr, const Ts&... ts ) : AMPCauchyEndgame(tr, Configs::Unpermute( ts... ) ) 
 	{}
 };// AMPCauchyEndgame
 

--- a/core/include/bertini2/endgames/amp_powerseries.hpp
+++ b/core/include/bertini2/endgames/amp_powerseries.hpp
@@ -43,7 +43,7 @@ namespace bertini{ namespace tracking { namespace endgame {
 /**
 \brief The Adaptive Precision Power Series Endgame, in a class.
 */
-class AMPPowerSeriesEndgame : public PowerSeriesEndgame<AMPTracker,AMPPowerSeriesEndgame, dbl,mpfr>, 
+class AMPPowerSeriesEndgame : public PowerSeriesEndgame<AMPTracker,AMPPowerSeriesEndgame>, 
 							  public AMPEndgamePolicyBase
 {
 	
@@ -55,8 +55,8 @@ protected:
 	void MultipleToMultipleImpl(unsigned new_precision) const override
 	{
 		// first, change precision on the final approximation
-		const auto& source_point = std::get<Vec<mpfr> >(this->final_approximation_at_origin_);
-		auto& target_point = std::get<Vec<mpfr> >(this->final_approximation_at_origin_);
+		const auto& source_point = std::get<Vec<mpfr> >(this->final_approximation_);
+		auto& target_point = std::get<Vec<mpfr> >(this->final_approximation_);
 		target_point.resize(source_point.size());
 
 		for (unsigned ii=0; ii<source_point.size(); ii++)
@@ -78,8 +78,8 @@ protected:
 
 	void DoubleToMultipleImpl(unsigned new_precision) const override
 	{
-		const auto& source_point = std::get<Vec<dbl> >(this->final_approximation_at_origin_);
-		auto& target_point = std::get<Vec<mpfr> >(this->final_approximation_at_origin_);
+		const auto& source_point = std::get<Vec<dbl> >(this->final_approximation_);
+		auto& target_point = std::get<Vec<mpfr> >(this->final_approximation_);
 
 		target_point.resize(source_point.size());
 		for (unsigned ii=0; ii<source_point.size(); ii++)
@@ -116,8 +116,8 @@ protected:
 
 	void MultipleToDoubleImpl() const override
 	{
-		const auto& source_point = std::get<Vec<mpfr> >(this->final_approximation_at_origin_);
-		auto& target_point = std::get<Vec<dbl> >(this->final_approximation_at_origin_);
+		const auto& source_point = std::get<Vec<mpfr> >(this->final_approximation_);
+		auto& target_point = std::get<Vec<dbl> >(this->final_approximation_);
 		target_point.resize(source_point.size());
 
 		for (unsigned ii=0; ii<source_point.size(); ii++)
@@ -148,7 +148,7 @@ protected:
 	}
 public:
 	using TrackerType = AMPTracker;
-	using EGType = PowerSeriesEndgame<TrackerType, AMPPowerSeriesEndgame, dbl, mpfr>;
+	using EGType = PowerSeriesEndgame<TrackerType, AMPPowerSeriesEndgame>;
 	
 	SuccessCode RefineSample(Vec<mpfr> & result, Vec<mpfr> const& current_sample, mpfr const& current_time) const
 	{
@@ -245,17 +245,16 @@ public:
 		return refinement_success;
 	}
 	
+	using Configs = typename AlgoTraits<EGType>::NeededConfigs;
+
 	explicit AMPPowerSeriesEndgame(TrackerType const& tr, 
-	                               const std::tuple< const config::PowerSeries &,
-	                               					 const config::Endgame<BRT>&, 
-	                               				     const config::Security<BRT>&
-	                               				    > & settings )
+	                          typename Configs::ToTuple const& settings )
       : EGType(tr, settings)
    	{}
 
     template< typename... Ts >
-		AMPPowerSeriesEndgame(TrackerType const& tr, const Ts&... ts ) : AMPPowerSeriesEndgame(tr, Unpermute<config::PowerSeries, config::Endgame<BRT>, config::Security<BRT> >( ts... ) ) 
-		{}
+	AMPPowerSeriesEndgame(TrackerType const& tr, const Ts&... ts ) : AMPPowerSeriesEndgame(tr, Configs::Unpermute( ts... ) ) 
+	{}
 
 
 }; // re: AMPPowerSeriesEndgame

--- a/core/include/bertini2/endgames/cauchy.hpp
+++ b/core/include/bertini2/endgames/cauchy.hpp
@@ -616,7 +616,7 @@ public:
 
 
 		## Input: 
-			None: all data needed are class data members
+			target_time: Used to stay correct if we are using the endgame for a non-zero target time. 
 		 
 		## Output:
 			true: If we are within the ratio cutoff time, or have a ratio within the thresholds.
@@ -629,14 +629,14 @@ public:
 				heuristcially will tell us if we are. 
 	*/
 	template<typename CT>
-	bool RatioEGOperatingZoneTest()
+	bool RatioEGOperatingZoneTest(CT const& target_time)
 	{	
 		using RT = typename Eigen::NumTraits<CT>::Real;
 		RT min(1e300);
 		RT max(0);
 		auto& times = std::get<TimeCont<CT> >(cauchy_times_);
 		auto& samples = std::get<SampCont<CT> >(cauchy_samples_);
-		if(norm(times.front()) < GetCauchySettings().ratio_cutoff_time)
+		if(norm(times.front() - target_time) < GetCauchySettings().ratio_cutoff_time)
 		{
 			return true;
 		}
@@ -730,7 +730,7 @@ public:
 				return tracking_success;
 
 			// find the ratio of the maximum and minimum coordinate wise for the loop. 
-			if (RatioEGOperatingZoneTest<CT>())
+			if (RatioEGOperatingZoneTest<CT>(target_time))
 			{ // then we believe we are in the EG operating zone, since the path is relatively flat.  i still disbelieve this is a good test (dab 20160310)
 				while (true)
 				{

--- a/core/include/bertini2/endgames/cauchy.hpp
+++ b/core/include/bertini2/endgames/cauchy.hpp
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with cauchy_endgame.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license, 
 // as well as COPYING.  Bertini2 is provided with permitted 
@@ -158,10 +158,9 @@ File: test/endgames/amp_cauchy_test.cpp
 File: test/endgames/fixed_double_cauchy_test.cpp
 FIle: test/endgames/fixed_multiple_cauchy_test.cpp
 */	
-template<typename TrackerType, typename FinalEGT, typename... UsedNumTs> 
+template<typename TrackerType, typename FinalEGT> 
 class CauchyEndgame : 
-	public EndgameBase<TrackerType, FinalEGT>,
-	public detail::Configured<config::Cauchy<typename TrackerTraits<TrackerType>::BaseRealType>>
+	public EndgameBase<TrackerType, FinalEGT>
 {
 private:
 	// convert the base endgame into the derived type.
@@ -172,31 +171,36 @@ private:
 
 
 protected:
+	using BaseEG = EndgameBase<TrackerType, FinalEGT>;
 
-	using BaseComplexType = typename TrackerTraits<TrackerType>::BaseComplexType;
-	using BaseRealType = typename TrackerTraits<TrackerType>::BaseRealType;
+	using BaseComplexType = typename BaseEG::BaseComplexType;
+	using BaseRealType = typename BaseEG::BaseRealType;
+
+	using TupleOfTimes = typename BaseEG::TupleOfTimes;
+	using TupleOfSamps = typename BaseEG::TupleOfSamps;
 
 	using BCT = BaseComplexType;
 	using BRT = BaseRealType;
 
-	using Config = detail::Configured<config::Cauchy<typename TrackerTraits<TrackerType>::BaseRealType>>;
-
+	using Configs = typename AlgoTraits<FinalEGT>::NeededConfigs;
+	using ConfigsAsTuple = typename Configs::ToTuple;
+	
 	/**
 	\brief A deque of times that are specifically used to compute the power series approximation for the Cauchy endgame. 
 	*/
-	mutable std::tuple<TimeCont<UsedNumTs>...> pseg_times_;
+	mutable TupleOfTimes pseg_times_;
 	/**
 	\brief A deque of samples that are in correspondence with the pseg_times_. These samples are also used to compute the first power series approximation for the Cauchy endgame.
 	*/
-	mutable std::tuple<SampCont<UsedNumTs>...> pseg_samples_; //samples used for the first approximation. 
+	mutable TupleOfSamps pseg_samples_; //samples used for the first approximation. 
 	/**
 	\brief A deque of times that are collected by CircleTrack. These samples are used to compute all approximations of the origin after the first. 
 	*/
-	mutable std::tuple<TimeCont<UsedNumTs>...> cauchy_times_;
+	mutable TupleOfTimes cauchy_times_;
 	/**
 	\brief A deque of samples collected by CircleTrack. Computed a mean of the values of this deque, after a loop has been closed, will give an approximation of the origin.
 	*/
-	mutable std::tuple<SampCont<UsedNumTs>...> cauchy_samples_;
+	mutable TupleOfSamps cauchy_samples_;
 
 
 
@@ -205,12 +209,8 @@ protected:
 	
 public:
 
+	
 
-	using Config::Get;
-	using EndgameBase<TrackerType, FinalEGT>::Get;
-
-	using Config::Set;
-	using EndgameBase<TrackerType, FinalEGT>::Set;
 
 	/**
 	\brief Function that clears all samples and times from data members for the Cauchy endgame
@@ -223,32 +223,37 @@ public:
 		std::get<SampCont<CT> >(pseg_samples_).clear(); 
 		std::get<SampCont<CT> >(cauchy_samples_).clear();}
 	/**
-	\brief Setter for the deque holding time values for the power series approximation of the Cauchy endgame. 
+	\brief Setter for the time values for the power series approximation of the Cauchy endgame. 
 	*/
 	template<typename CT>
 	void SetPSEGTimes(TimeCont<CT> pseg_times_to_set) 
 	{ std::get<TimeCont<CT> >(pseg_times_) = pseg_times_to_set;}
 
 	/**
-	\brief Getter for the deque holding time values for the power series approximation of the Cauchy endgame.
+	\brief Getter for the time values for the power series approximation of the Cauchy endgame.
 	*/
 	template<typename CT>
 	TimeCont<CT>& GetPSEGTimes() {return std::get<TimeCont<CT> >(pseg_times_);}
+	template<typename CT>
+	const TimeCont<CT>& GetPSEGTimes() const {return std::get<TimeCont<CT> >(pseg_times_);}
 
 	/**
-	\brief Setter for the deque holding space values for the power series approximation of the Cauchy endgame. 
+	\brief Setter for the space values for the power series approximation of the Cauchy endgame. 
 	*/
 	template<typename CT>
 	void SetPSEGSamples(SampCont<CT> pseg_samples_to_set) { std::get<SampCont<CT> >(pseg_samples_) = pseg_samples_to_set;}
 
 	/**
-	\brief Getter for the deque holding space values for the power series approximation of the Cauchy endgame. 
+	\brief Getter for the space values for the power series approximation of the Cauchy endgame. 
+
+	Available in const and non-const flavors
 	*/
 	template<typename CT>
 	SampCont<CT>& GetPSEGSamples() {return std::get<SampCont<CT> >(pseg_samples_);}
-
+	template<typename CT>
+	const SampCont<CT>& GetPSEGSamples() const {return std::get<SampCont<CT> >(pseg_samples_);}
 	/**
-	\brief Setter for the deque holding space values for the Cauchy endgame. 
+	\brief Setter for the space values for the Cauchy endgame. 
 	*/
 	template<typename CT>
 	void SetCauchySamples(SampCont<CT> cauchy_samples_to_set) 
@@ -257,16 +262,21 @@ public:
 	}
 
 	/**
-	\brief Getter for the deque holding space values for the Cauchy endgame. 
+	\brief Getter for the space values for the Cauchy endgame. 
+
+	Available in const and non-const flavors
 	*/
 	template<typename CT>
 	SampCont<CT>& GetCauchySamples() 
 	{
 		return std::get<SampCont<CT> >(cauchy_samples_);
 	}
+	template<typename CT>
+	const SampCont<CT>& GetCauchySamples() const { return std::get<SampCont<CT> >(cauchy_samples_); }
+
 
 	/**
-	\brief Setter for the deque holding time values for the Cauchy endgame. 
+	\brief Setter for the time values for the Cauchy endgame. 
 	*/
 	template<typename CT>
 	void SetCauchyTimes(TimeCont<CT> cauchy_times_to_set) 
@@ -275,12 +285,23 @@ public:
 	}
 
 	/**
-	\brief Getter for the deque holding time values for the Cauchy endgame. 
+	\brief Getter for the time values for the Cauchy endgame. 
 	*/
 	template<typename CT>
 	TimeCont<CT>& GetCauchyTimes() 
 	{
 		return std::get<TimeCont<CT> >(cauchy_times_);
+	}
+	template<typename CT>
+	const TimeCont<CT>& GetCauchyTimes() const
+	{
+		return std::get<TimeCont<CT> >(cauchy_times_);
+	}
+
+
+	const BCT& LatestTimeImpl() const
+	{
+		return GetPSEGTimes<BCT>().back();
 	}
 
 
@@ -302,16 +323,12 @@ public:
 	
 
 	explicit CauchyEndgame(TrackerType const& tr, 
-	                            const std::tuple< config::Cauchy<BRT> const&, 
-	                            					const config::Endgame<BRT>&, 
-	                            					const config::Security<BRT>&
-	                            				>& settings )
-      : EndgameBase<TrackerType, FinalEGT>(tr, std::get<1>(settings), std::get<2>(settings)), 
-          Config( std::get<0>(settings) )
+                            const ConfigsAsTuple& settings )
+      : EndgameBase<TrackerType, FinalEGT>(tr, settings)
    	{ }
 
     template< typename... Ts >
-		CauchyEndgame(TrackerType const& tr, const Ts&... ts ) : CauchyEndgame(tr, Unpermute<config::Cauchy<BRT>, config::Endgame<BRT>, config::Security<BRT>>( ts... ) ) 
+		CauchyEndgame(TrackerType const& tr, const Ts&... ts ) : CauchyEndgame(tr, Configs::Unpermute( ts... ) ) 
 		{}
 
 
@@ -386,7 +403,6 @@ public:
 			auto tracking_success = this->GetTracker().TrackPath(next_sample, current_time, next_time, current_sample);	
 			if (tracking_success != SuccessCode::Success)
 			{
-				std::cout << "tracker fail in circle track, radius " << radius << ", type " << int(tracking_success) << std::endl;
 				return tracking_success;
 			}
 
@@ -395,7 +411,7 @@ public:
 			auto refinement_success = AsDerived().RefineSample(next_sample, next_sample, next_time);
 			if (refinement_success != SuccessCode::Success)
 			{
-				std::cout << "refinement fail in circle track, type " << int(refinement_success) << std::endl;
+				return refinement_success;
 				return refinement_success;
 			}
 
@@ -448,7 +464,7 @@ public:
 
 		// //DO NOT USE Eigen .dot() it will do conjugate transpose which is not what we want.
 		// //Also, the .transpose*rand_vector returns an expression template that we do .norm of since abs is not available for that expression type. 
-		RT estimate = abs(log(abs((((sample2 - sample1).transpose()*rand_vector).norm())/(((sample1 - sample0).transpose()*rand_vector).norm()))));
+		RT estimate = abs(log(abs((((sample2 - sample1).transpose()*rand_vector).template lpNorm<Eigen::Infinity>())/(((sample1 - sample0).transpose()*rand_vector).template lpNorm<Eigen::Infinity>()))));
 		estimate = abs(log(RT(this->EndgameSettings().sample_factor)))/estimate;
 		if (estimate < 1)
 		  	return RT(1);
@@ -530,7 +546,6 @@ public:
 		auto norm_of_sample = x_sample.norm();
 		L = pow(norm_of_sample,degree_max - 2);
 		auto tol = K * L * M;
-		// std::cout << "TOL IS " << tol << '\n';
 		if (tol == 0) // fail-safe
 					tol = minimum_singular_value;
 			else
@@ -570,7 +585,7 @@ public:
 		auto& times = std::get<TimeCont<CT> >(cauchy_times_);
 		auto& samples = std::get<SampCont<CT> >(cauchy_samples_);
 
-		if((samples.front() - samples.back()).norm() < this->GetTracker().TrackingTolerance())
+		if((samples.front() - samples.back()).template lpNorm<Eigen::Infinity>() < this->GetTracker().TrackingTolerance())
 		{
 			return true;
 		}
@@ -584,7 +599,7 @@ public:
 		this->GetTracker().Refine(samples.front(),samples.front(),times.front(),RT(this->FinalTolerance()),this->EndgameSettings().max_num_newton_iterations);
 		this->GetTracker().Refine(samples.back(),samples.back(),times.back(),RT(this->FinalTolerance()),this->EndgameSettings().max_num_newton_iterations);
 
-		if((samples.front() - samples.back()).norm() < this->GetTracker().TrackingTolerance())
+		if((samples.front() - samples.back()).template lpNorm<Eigen::Infinity>() < this->GetTracker().TrackingTolerance())
 		{
 			return true;
 		}
@@ -630,7 +645,7 @@ public:
 			RT norm;
 			for(unsigned int ii=0; ii < this->EndgameSettings().num_sample_points; ++ii)
 			{
-				norm = samples[ii].norm();
+				norm = samples[ii].template lpNorm<Eigen::Infinity>();
 				if(norm > max)
 				{
 					max = norm;
@@ -798,7 +813,7 @@ public:
 	*/
 	template<typename CT>
 	SuccessCode InitialPowerSeriesApproximation(CT const& start_time, Vec<CT> const& start_point, 
-	                                            CT const& approximation_time, Vec<CT> & approximation)
+	                                            CT const& target_time, Vec<CT> & approximation)
 	{	
 		using RT = typename Eigen::NumTraits<CT>::Real;
 
@@ -809,7 +824,7 @@ public:
 		auto& ps_samples = std::get<SampCont<CT> >(pseg_samples_);
 
 		//Compute initial samples for pseg
-		auto initial_sample_success = this->ComputeInitialSamples(start_time, approximation_time, start_point, ps_times, ps_samples);
+		auto initial_sample_success = this->ComputeInitialSamples(start_time, target_time, start_point, ps_times, ps_samples);
 		if (initial_sample_success!=SuccessCode::Success)
 			return initial_sample_success;
 
@@ -818,13 +833,12 @@ public:
 		Vec<CT> next_sample;
 		CT next_time;
 
-		unsigned ii = 0;
+		
 		//track until for more c_over_k estimates or until we reach a cutoff time. 
-		while ( (ii < GetCauchySettings().num_needed_for_stabilization) )
+		for (unsigned ii = 0; ii < GetCauchySettings().num_needed_for_stabilization; ++ii) 
 		{	
-			next_time = (ps_times.back() + approximation_time) * static_cast<RT>(this->EndgameSettings().sample_factor); // using general midpoint formula with sample_factor to give us a time
-
-																							
+			next_time = (ps_times.back() + target_time) * static_cast<RT>(this->EndgameSettings().sample_factor); // using general midpoint formula with sample_factor to give us a time
+																
 			auto tracking_success = this->GetTracker().TrackPath(next_sample,ps_times.back(),next_time,ps_samples.back());
 			if (tracking_success!=SuccessCode::Success)
 				return tracking_success;
@@ -836,15 +850,13 @@ public:
 			ps_samples.push_back(next_sample);
 			ps_times.push_back(next_time);
 			c_over_k.push_back(ComputeCOverK<CT>());
-
-			++ii;
 		}//end while
 
 
 		//have we stabilized yet? 
 		while(!CheckForCOverKStabilization(c_over_k) && abs(ps_times.back()) > GetCauchySettings().cycle_cutoff_time)
 		{
-			next_time = (ps_times.back() + approximation_time) * static_cast<RT>(this->EndgameSettings().sample_factor); // using general midpoint formula with sample_factor to give us a time
+			next_time = (ps_times.back() + target_time) * static_cast<RT>(this->EndgameSettings().sample_factor); // using general midpoint formula with sample_factor to give us a time
 																									 
 			auto tracking_success = this->GetTracker().TrackPath(next_sample,ps_times.back(),next_time,ps_samples.back());
 
@@ -863,20 +875,22 @@ public:
 
 		}//end while
 
-		auto cauchy_loop_success = InitialCauchyLoops<CT>(approximation_time);
+		// you have to leave this here.  yeah, i know, you want to extract it, but this sets up the cycle number
+		// used in the subsequent call to ComputePSEGApproximationAtT0.  Ah, side-effects.  Sorry.
+		auto cauchy_loop_success = InitialCauchyLoops<CT>(target_time);
 		if (cauchy_loop_success != SuccessCode::Success)
 			return cauchy_loop_success;
 
-		return ComputePSEGApproximationAtT0(approximation, approximation_time);
+		return ComputePSEGApproximationAtT0(approximation, target_time);
 
 	}//end InitialPowerSeriesApproximation
 
 	/**
-		\brief 	This function takes the pseg_samples_ and pseg_times that have been collected and uses them to compute a Hermite interpolation to the time value time_t0. 
+		\brief 	This function takes the pseg_samples_ and pseg_times that have been collected and uses them to compute a Hermite interpolation to the time value target_time. 
 
 		## Input: 
 				result: This vector holds the approxmation that we end up calculating
-				time_t0: The time value at which we are trying to approximate, usually t = 0
+				target_time: The time value at which we are trying to approximate, usually t = 0
 
 		## Output:
 				SuccessCode deeming if we were successful or if we encountered an error. 
@@ -889,18 +903,16 @@ public:
 		We use the converted times and derivatives along with the samples to do a Hermite interpolation which is found in base_endgame.hpp.
 	*/
 	template<typename CT>
-	SuccessCode ComputePSEGApproximationAtT0(Vec<CT>& result, const CT & time_t0)
+	SuccessCode ComputePSEGApproximationAtT0(Vec<CT>& result, const CT & target_time)
 	{
 		using RT = typename Eigen::NumTraits<CT>::Real;
 
 		auto& ps_times = std::get<TimeCont<CT> >(pseg_times_);
 		auto& ps_samples = std::get<SampCont<CT> >(pseg_samples_);
 
+		//Ensure all samples are of the same precision.
 		if (TrackerTraits<TrackerType>::IsAdaptivePrec)
-		{
-			//Ensure all samples are of the same precision.
-			auto new_precision = AsDerived().EnsureAtUniformPrecision(ps_times, ps_samples);
-		}
+			AsDerived().EnsureAtUniformPrecision(ps_times, ps_samples);
 
 
 		for (unsigned ii=0; ii<ps_samples.size(); ++ii)
@@ -910,11 +922,9 @@ public:
 				return refine_code;
 		}
 		
+		//Ensure all samples are of the same precision.
 		if (TrackerTraits<TrackerType>::IsAdaptivePrec)
-		{
-			//Ensure all samples are of the same precision.
-			auto new_precision = AsDerived().EnsureAtUniformPrecision(ps_times, ps_samples);
-		}
+			AsDerived().EnsureAtUniformPrecision(ps_times, ps_samples);
 		
 
 		auto num_sample_points = this->EndgameSettings().num_sample_points;
@@ -923,7 +933,7 @@ public:
 		for(unsigned ii = 0; ii < num_sample_points; ++ii)
 		{	
 			// the inverse() call uses LU look at Eigen documentation on inverse in Eigen/LU.
-			pseg_derivatives.push_back(
+			pseg_derivatives.emplace_back(
 			                           -(this->GetSystem().Jacobian(ps_samples[ii],ps_times[ii]).inverse())*this->GetSystem().TimeDerivative(ps_samples[ii],ps_times[ii])
 			                           );
 		}
@@ -932,14 +942,15 @@ public:
 		TimeCont<CT> s_times(num_sample_points);
 		SampCont<CT> s_derivatives(num_sample_points);
 		auto c = static_cast<RT>(this->CycleNumber());
+		auto one_over_c = 1/c;
 		for(unsigned ii = 0; ii < num_sample_points; ++ii)
 		{
 			s_derivatives[ii] = pseg_derivatives[ii]*
-			                        (c*pow(ps_times[ii],(c-1)/c));
-			s_times[ii] =  pow(ps_times[ii], 1/c);
+			                        (c*pow(ps_times[ii],1-one_over_c));
+			s_times[ii] =  pow(ps_times[ii], one_over_c);
 		}
 
-		result = HermiteInterpolateAndSolve(time_t0, num_sample_points, 
+		result = HermiteInterpolateAndSolve(target_time, num_sample_points, 
                                             s_times, ps_samples, s_derivatives);
 		return SuccessCode::Success;
 	}//end ComputePSEGApproximationOfXAtT0
@@ -968,26 +979,29 @@ public:
 		if (cau_samples.size() != this->CycleNumber() * this->EndgameSettings().num_sample_points+1)
 		{
 			std::stringstream err_msg;
-			err_msg << "to compute cauchy approximation, cauchy_samples must be of size " << this->CycleNumber() * this->EndgameSettings().num_sample_points+1 << " but is of size " << cau_samples.size() << '\n';
+			err_msg << "to compute cauchy approximation, cau_samples must be of size " << this->CycleNumber() * this->EndgameSettings().num_sample_points+1 << " but is of size " << cau_samples.size() << '\n';
 			throw std::runtime_error(err_msg.str());
 		}
 
-		result = Vec<CT>::Zero(this->GetSystem().NumVariables());//= (cau_samples[0]+cau_samples.back())/2; 
 
+		//Ensure all samples are of the same precision.
 		if (TrackerTraits<TrackerType>::IsAdaptivePrec)
-		{
-			//Ensure all samples are of the same precision.
 			auto new_precision = AsDerived().EnsureAtUniformPrecision(cau_times, cau_samples);
-		}
 
-		for(unsigned int ii = 0; ii < this->CycleNumber() * this->EndgameSettings().num_sample_points; ++ii)
+
+		auto total_num_pts = this->CycleNumber() * this->EndgameSettings().num_sample_points;
+		for(unsigned int ii = 0; ii < total_num_pts; ++ii)
 		{
 			auto refine_code = AsDerived().RefineSample(cau_samples[ii],cau_samples[ii],cau_times[ii]);
 			if (refine_code!=SuccessCode::Success)
 				return refine_code;
-			result += cau_samples[ii];
 		}
+
+		result = Vec<CT>::Zero(this->GetSystem().NumVariables());
+		for(unsigned int ii = 0; ii < total_num_pts; ++ii)
+			result += cau_samples[ii];
 		result /= static_cast<RT>(this->CycleNumber() * this->EndgameSettings().num_sample_points);
+
 		return SuccessCode::Success;
 
 	}
@@ -1034,7 +1048,6 @@ public:
 
 			if(tracking_success != SuccessCode::Success)
 			{
-				std::cout << "Cauchy loop fail tracking "<< int(tracking_success) <<"\n\n";
 				return tracking_success;
 			}
 			else if(CheckClosedLoop<CT>())
@@ -1089,7 +1102,12 @@ public:
 			throw std::runtime_error(err_msg.str());
 		}
 
-		assert(Precision(start_time)==Precision(start_time) && ("CauchyEG Run time and point must be of matching precision"));
+		if (Precision(start_time)!=Precision(start_point))
+		{
+			std::stringstream ss;
+			ss << "CauchyEG Run time and point must be of matching precision. (" << Precision(start_time) << "!=" << Precision(start_point) << ")";
+			throw std::runtime_error(ss.str());
+		}
 
 		using RT = typename Eigen::NumTraits<CT>::Real;
 
@@ -1102,22 +1120,21 @@ public:
 		ClearTimesAndSamples<CT>(); //clear times and samples before we begin.
 		this->CycleNumber(0);
 
-		Vec<CT> prev_approx, latest_approx;
-		RT approximate_error;
-		Vec<CT>& final_approx = std::get<Vec<CT> >(this->final_approximation_at_origin_);
-	
+		Vec<CT>& latest_approx = std::get<Vec<CT> >(this->final_approximation_);
+		Vec<CT>& prev_approx = std::get<Vec<CT> >(this->previous_approximation_);
+		RT& approx_error = std::get<RT>(this->approximate_error_);
 
 		//Compute the first approximation using the power series approximation technique. 
 		auto initial_ps_success = InitialPowerSeriesApproximation(start_time, start_point, target_time, prev_approx);  // last argument is output here
-		if(initial_ps_success != SuccessCode::Success)
+		if (initial_ps_success != SuccessCode::Success)
 			return initial_ps_success;
 
-		//Generalized next_time in case if we are not trying to converge to the t = 0.
+
 		CT next_time = (ps_times.back() + target_time) * static_cast<RT>(this->EndgameSettings().sample_factor);
-		RT norm_of_dehom_of_prev_approx, norm_of_dehom_of_latest_approx;
+		RT norm_of_dehom_prev, norm_of_dehom_latest;
 
 		if(this->SecuritySettings().level <= 0)
-			norm_of_dehom_of_prev_approx = this->GetSystem().DehomogenizePoint(prev_approx).norm();
+			norm_of_dehom_prev = this->GetSystem().DehomogenizePoint(prev_approx).template lpNorm<Eigen::Infinity>();
 		do
 		{
 			//Compute a cauchy approximation.  Uses the previously computed samples, 
@@ -1127,70 +1144,46 @@ public:
 				return extrapolation_success;
 
 			if (this->SecuritySettings().level <= 0)
-				norm_of_dehom_of_latest_approx = this->GetSystem().DehomogenizePoint(latest_approx).norm();
+				norm_of_dehom_latest = this->GetSystem().DehomogenizePoint(latest_approx).template lpNorm<Eigen::Infinity>();
 
-			approximate_error = (latest_approx - prev_approx).norm(); //Calculate the error between approximations. 
+			approx_error = (latest_approx - prev_approx).template lpNorm<Eigen::Infinity>();
 
-			// dehom of prev approx and last approx not used because they are not updated with the most current information. However, prev approx and last approx are 
-			// the most current. 
-
-			if (approximate_error < this->FinalTolerance())
-			{
-				final_approx = latest_approx;
+			if (approx_error < this->FinalTolerance())
 				return SuccessCode::Success;
-			}
-			else if (abs(cau_times.front() - target_time) < this->EndgameSettings().min_track_time) // generalized for target_time not equal to 0. 
-			{//we are too close to t = 0 but we do not have the correct tolerance - so we exit
-				final_approx = latest_approx;
-				return SuccessCode::FailedToConverge;
-			}
 			else if (this->SecuritySettings().level <= 0 && 
-			   norm_of_dehom_of_prev_approx   > this->SecuritySettings().max_norm &&  
-			   norm_of_dehom_of_latest_approx > this->SecuritySettings().max_norm  )
+			   norm_of_dehom_prev   > this->SecuritySettings().max_norm &&  
+			   norm_of_dehom_latest > this->SecuritySettings().max_norm  )
 			{//we are too large, break out of loop to return error.
-				final_approx = latest_approx;
 				return SuccessCode::SecurityMaxNormReached;
 			}
 
 
 			prev_approx = latest_approx;
-			norm_of_dehom_of_prev_approx = norm_of_dehom_of_latest_approx;
+			norm_of_dehom_prev = norm_of_dehom_latest;
 
 			//Generalized next_time in case if we are not trying to converge to the t = 0.
 			next_time = (next_time + target_time) * static_cast<RT>(this->EndgameSettings().sample_factor);
-
+			if (abs(next_time - target_time) < this->EndgameSettings().min_track_time)//we are too close to t = 0 but we do not have the correct tolerance - so we exit
+				return SuccessCode::MinTrackTimeReached;
 			
-
+			// advance in time
 			Vec<CT> next_sample;
-			auto tracking_success = this->GetTracker().TrackPath(next_sample,cau_times.back(),next_time,cau_samples.front());
-			if (tracking_success != SuccessCode::Success)
-				return tracking_success;
+			auto time_advance_success = this->GetTracker().TrackPath(next_sample,cau_times.back(),next_time,cau_samples.front()); // the front is used because the loops go round and round
+			if (time_advance_success != SuccessCode::Success)
+				return time_advance_success;
 
 			AsDerived().EnsureAtPrecision(next_time,Precision(next_sample));
 
 			ps_times.push_back(next_time);  ps_times.pop_front();
 			ps_samples.push_back(next_sample); ps_samples.pop_front();
 
+			// then compute the next set of cauchy samples used for extrapolating the point at target time
 			auto cauchy_samples_success = ComputeCauchySamples(next_time,target_time,next_sample);
-
-			//Added because of Griewank osborne test case where tracker returns GoingToInfinity.  
-			//The cauchy endgame should stop instead of attempting to continue. 
-			//This is because the tracker will not track to any meaningful space values. 
-			if (cauchy_samples_success == SuccessCode::GoingToInfinity)
-				return SuccessCode::GoingToInfinity;
-			else if (cauchy_samples_success != SuccessCode::Success && abs(cau_times.front()-target_time) < this->EndgameSettings().min_track_time)
-			{// we are too close to t = 0 but we do have the correct tolerance -so we exit.
-				final_approx = latest_approx;
-				return SuccessCode::MinTrackTimeReached;
-			}
-			else if(cauchy_samples_success != SuccessCode::Success)
-			{
-				final_approx = latest_approx;
+			if (cauchy_samples_success != SuccessCode::Success)
 				return cauchy_samples_success;
-			}
-		} while (approximate_error > this->FinalTolerance());
 
-		final_approx = latest_approx;
+		} while (true);
+
 		return SuccessCode::Success;
 	} //end main CauchyEG function
 };

--- a/core/include/bertini2/endgames/config.hpp
+++ b/core/include/bertini2/endgames/config.hpp
@@ -37,6 +37,27 @@ namespace bertini{
 
 	namespace tracking{
 
+		namespace endgame{
+
+
+		// some forward declarations
+		template<typename Tracker, typename Enable = void>
+		class FixedPrecPowerSeriesEndgame;
+
+		template<typename Tracker, typename Enable = void>
+		class FixedPrecCauchyEndgame;
+
+		class AMPPowerSeriesEndgame;
+		class AMPCauchyEndgame;
+
+		template<typename TrackerType, typename FinalEGT> 
+		class PowerSeriesEndgame;
+
+		template<typename TrackerType, typename FinalEGT> 
+		class CauchyEndgame;
+		}
+
+		
 		/**
 		\brief Facilitates lookup of required endgame type based on tracker type
 		
@@ -129,5 +150,90 @@ namespace bertini{
 		};
 
 	}
+
+
+
+	template <typename T>
+	struct AlgoTraits;
+
+	/**
+	specialization for PowerSeries, which uses CRTP
+	*/
+	template<typename TrackerType, typename FinalEGT>
+	struct AlgoTraits< typename endgame::PowerSeriesEndgame<TrackerType, FinalEGT>>
+	{
+		using NeededConfigs = detail::TypeList<
+			config::PowerSeries,
+			config::Endgame<typename TrackerTraits<TrackerType>::BaseRealType>,
+			config::Security<typename TrackerTraits<TrackerType>::BaseRealType>
+			>;
+	};
+
+	
+	template<typename TrackerType>
+	struct AlgoTraits<typename endgame::FixedPrecPowerSeriesEndgame<TrackerType>> : 
+		public AlgoTraits<
+				endgame::PowerSeriesEndgame<TrackerType, typename endgame::FixedPrecPowerSeriesEndgame<TrackerType>>
+				>
+	{
+		using NeededConfigs = detail::TypeList<
+			config::PowerSeries,
+			config::Endgame<typename TrackerTraits<TrackerType>::BaseRealType>,
+			config::Security<typename TrackerTraits<TrackerType>::BaseRealType>
+			>;
+	};
+
+	template<>
+	struct AlgoTraits<endgame::AMPPowerSeriesEndgame> : 
+		public AlgoTraits<
+				endgame::PowerSeriesEndgame<AMPTracker, typename endgame::AMPPowerSeriesEndgame>
+				>
+	{
+		using NeededConfigs = detail::TypeList<
+			config::PowerSeries,
+			config::Endgame<typename TrackerTraits<AMPTracker>::BaseRealType>,
+			config::Security<typename TrackerTraits<AMPTracker>::BaseRealType>
+			>;
+	};
+
+	/**
+	specialization for Cauchy, which uses CRTP
+	*/
+	template<typename TrackerType, typename FinalEGT>
+	struct AlgoTraits< typename endgame::CauchyEndgame<TrackerType, FinalEGT>>
+	{
+		using NeededConfigs = detail::TypeList<
+			config::Cauchy<typename TrackerTraits<TrackerType>::BaseRealType>,
+			config::Endgame<typename TrackerTraits<TrackerType>::BaseRealType>,
+			config::Security<typename TrackerTraits<TrackerType>::BaseRealType>>;
+	};
+	
+	template<typename TrackerType>
+	struct AlgoTraits<typename endgame::FixedPrecCauchyEndgame<TrackerType>> : 
+		public AlgoTraits<
+				endgame::CauchyEndgame<TrackerType, typename endgame::FixedPrecCauchyEndgame<TrackerType>>
+				>
+	{
+		using NeededConfigs = detail::TypeList<
+			config::Cauchy<typename TrackerTraits<TrackerType>::BaseRealType>,
+			config::Endgame<typename TrackerTraits<TrackerType>::BaseRealType>,
+			config::Security<typename TrackerTraits<TrackerType>::BaseRealType>>;
+	};
+	
+	template<>
+	struct AlgoTraits<endgame::AMPCauchyEndgame> : 
+		public AlgoTraits<
+				endgame::CauchyEndgame<AMPTracker, typename endgame::AMPCauchyEndgame>
+				>
+	{
+		using NeededConfigs = detail::TypeList<
+			config::Cauchy<typename TrackerTraits<AMPTracker>::BaseRealType>,
+			config::Endgame<typename TrackerTraits<AMPTracker>::BaseRealType>,
+			config::Security<typename TrackerTraits<AMPTracker>::BaseRealType>
+			>;
+	};
+
+
+
 	}
 }

--- a/core/include/bertini2/endgames/config.hpp
+++ b/core/include/bertini2/endgames/config.hpp
@@ -144,9 +144,9 @@ namespace bertini{
 
 		struct TrackBack
 		{
-			unsigned minimum_cycle; //MinCycleTrackback, default = 4
-			bool junk_removal_test; //JunkRemovalTest, default = 1
-			unsigned max_depth_LDT; //MaxLDTDepth, default = 3
+			unsigned minimum_cycle = 4; //MinCycleTrackback, default = 4
+			bool junk_removal_test = 1; //JunkRemovalTest, default = 1
+			unsigned max_depth_LDT = 3; //MaxLDTDepth, default = 3
 		};
 
 	}

--- a/core/include/bertini2/endgames/endgame.hpp
+++ b/core/include/bertini2/endgames/endgame.hpp
@@ -31,7 +31,7 @@
 
 #pragma once
 
-#include "bertini2/endgames/fixed_prec_endgame.hpp"
+#include "bertini2/endgames/fixed_prec_powerseries.hpp"
 #include "bertini2/endgames/fixed_prec_cauchy.hpp"
 
 #include "bertini2/endgames/amp_powerseries.hpp"

--- a/core/include/bertini2/endgames/fixed_prec_cauchy.hpp
+++ b/core/include/bertini2/endgames/fixed_prec_cauchy.hpp
@@ -43,17 +43,16 @@ namespace bertini{ namespace tracking { namespace endgame {
 template<typename TrackerT, typename Enable>
 class FixedPrecCauchyEndgame : 
 		public CauchyEndgame<TrackerT,
-							  FixedPrecCauchyEndgame<TrackerT, typename std::enable_if<TrackerTraits<TrackerT>::IsFixedPrec>::type>, 
-							  typename TrackerTraits<TrackerT>::BaseComplexType>, 
+							  FixedPrecCauchyEndgame<TrackerT, typename std::enable_if<TrackerTraits<TrackerT>::IsFixedPrec>::type>>, 
 		public FixedPrecEndgamePolicyBase<TrackerT>
 {
 public:
 	using TrackerType = TrackerT;
-	using EGType = CauchyEndgame<TrackerType, FixedPrecCauchyEndgame, typename TrackerType::BaseComplexType>;
+	using EGType = CauchyEndgame<TrackerType, FixedPrecCauchyEndgame>;
 	using BRT = typename TrackerTraits<TrackerType>::BaseRealType;
+	using Configs = typename AlgoTraits<EGType>::NeededConfigs;
+	using ConfigsAsTuple = typename Configs::ToTuple;
 
-	using EGType::Set;
-	
 	template<typename CT>
 	SuccessCode RefineSample(Vec<CT> & result, Vec<CT> const& current_sample, CT const& current_time) const
 	{
@@ -70,15 +69,12 @@ public:
 
 public:
 	explicit FixedPrecCauchyEndgame(TrackerType const& tr, 
-	                               const std::tuple< const config::Cauchy<BRT> &,
-	                               					 const config::Endgame<BRT>&, 
-	                               				     const config::Security<BRT>&
-	                               				    > & settings )
+	                               ConfigsAsTuple const& settings )
       : EGType(tr, settings)
    	{}
 
     template< typename... Ts >
-		FixedPrecCauchyEndgame(TrackerType const& tr, const Ts&... ts ) : FixedPrecCauchyEndgame(tr, Unpermute<config::Cauchy<BRT>, config::Endgame<BRT>, config::Security<BRT> >( ts... ) ) 
+		FixedPrecCauchyEndgame(TrackerType const& tr, const Ts&... ts ) : FixedPrecCauchyEndgame(tr, Configs::Unpermute( ts... ) ) 
 		{}
 
 };

--- a/core/include/bertini2/endgames/fixed_prec_powerseries.hpp
+++ b/core/include/bertini2/endgames/fixed_prec_powerseries.hpp
@@ -43,16 +43,17 @@ namespace bertini{ namespace tracking { namespace endgame {
 template<typename TrackerT, typename Enable>
 class FixedPrecPowerSeriesEndgame : 
 		public PowerSeriesEndgame<TrackerT,
-								  FixedPrecPowerSeriesEndgame<TrackerT, typename std::enable_if<TrackerTraits<TrackerT>::IsFixedPrec>::type>, 
-								  typename TrackerTraits<TrackerT>::BaseComplexType>, 
+								  FixedPrecPowerSeriesEndgame<TrackerT, typename std::enable_if<TrackerTraits<TrackerT>::IsFixedPrec>::type>>, 
 		public FixedPrecEndgamePolicyBase<TrackerT>
 {
 public:
 	using TrackerType = TrackerT;
-	using EGType = PowerSeriesEndgame<TrackerType, FixedPrecPowerSeriesEndgame, typename TrackerType::BaseComplexType>;
+	using EGType = PowerSeriesEndgame<TrackerType, FixedPrecPowerSeriesEndgame>;
 	using BRT = typename TrackerTraits<TrackerType>::BaseRealType;
 
-	
+	using Configs = typename AlgoTraits<EGType>::NeededConfigs;
+
+
 	template<typename CT>
 	SuccessCode RefineSample(Vec<CT> & result, Vec<CT> const& current_sample, CT const& current_time) const
 	{
@@ -69,15 +70,13 @@ public:
 
 public:
 	explicit FixedPrecPowerSeriesEndgame(TrackerType const& tr, 
-	                               const std::tuple< const config::PowerSeries &,
-	                               					 const config::Endgame<BRT>&, 
-	                               				     const config::Security<BRT>&
-	                               				    > & settings )
+	                                	typename Configs::ToTuple const& settings )
       : EGType(tr, settings)
    	{}
 
     template< typename... Ts >
-		FixedPrecPowerSeriesEndgame(TrackerType const& tr, const Ts&... ts ) : FixedPrecPowerSeriesEndgame(tr, Unpermute<config::PowerSeries, config::Endgame<BRT>, config::Security<BRT> >( ts... ) ) 
+		FixedPrecPowerSeriesEndgame(TrackerType const& tr, const Ts&... ts ) : 
+			FixedPrecPowerSeriesEndgame(tr, Configs::Unpermute( ts... ) ) 
 		{}
 
 };

--- a/core/include/bertini2/function_tree.hpp
+++ b/core/include/bertini2/function_tree.hpp
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with function_tree.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license, 
 // as well as COPYING.  Bertini2 is provided with permitted 
@@ -41,10 +41,6 @@
 #include "bertini2/function_tree/operators/trig.hpp"
 
 
-
-
-
-
 #include "bertini2/function_tree/symbols/symbol.hpp"
 #include "bertini2/function_tree/symbols/variable.hpp"
 #include "bertini2/function_tree/symbols/number.hpp"
@@ -55,7 +51,6 @@
 
 #include "bertini2/function_tree/factory.hpp"
 
-#include "bertini2/io/parsing/function_parsers.hpp"
 
 
 #endif

--- a/core/include/bertini2/function_tree/roots/function.hpp
+++ b/core/include/bertini2/function_tree/roots/function.hpp
@@ -92,13 +92,8 @@ namespace node{
 		 */
 		void print(std::ostream & target) const override
 		{
-			if (entry_node_)
-			{
-				NamedSymbol::print(target);
-				entry_node_->print(target);
-			}
-			else
-				target << "impossibly emptyfunction";
+			EnsureNotEmpty();
+			entry_node_->print(target);
 		}
 		
 		
@@ -257,7 +252,7 @@ namespace node{
 
 		
 		
-		std::shared_ptr<Node> entry_node_; ///< The top node for the function.
+		std::shared_ptr<Node> entry_node_ = nullptr; ///< The top node for the function.
 		
 		Function() = default;
 	private:

--- a/core/include/bertini2/io/file_utilities.hpp
+++ b/core/include/bertini2/io/file_utilities.hpp
@@ -28,6 +28,7 @@
 
 #pragma once
 #include <iostream>
+#include <fstream>
 #include <boost/filesystem.hpp>
 
 namespace bertini{

--- a/core/include/bertini2/io/file_utilities.hpp
+++ b/core/include/bertini2/io/file_utilities.hpp
@@ -27,7 +27,7 @@
 */
 
 #pragma once
-
+#include <iostream>
 #include <boost/filesystem.hpp>
 
 namespace bertini{

--- a/core/include/bertini2/io/generators.hpp
+++ b/core/include/bertini2/io/generators.hpp
@@ -30,6 +30,7 @@
 
 
 #include "bertini2/mpfr_complex.hpp"
+#include "bertini2/eigen_extensions.hpp"
 
 #include <boost/math/special_functions/modf.hpp> 
 
@@ -179,6 +180,21 @@ namespace bertini{
 
 	                c.real().str(), c.imag().str()     //  Data to output
 	                );
+			}
+
+
+			template <typename OutputIterator, typename T>
+			static bool generate(OutputIterator sink, Vec<T> const& c)
+			{
+				auto s = c.size();
+				for (decltype(s) ii=0; ii<s; ++ii)
+				{
+					bool b = generate(sink, c(ii));
+					if (!b)
+						return b;
+					boost::spirit::karma::generate(sink, (boost::spirit::karma::char_), '\n');
+				}
+				return true;
 			}
 
 		};

--- a/core/include/bertini2/io/parsing.hpp
+++ b/core/include/bertini2/io/parsing.hpp
@@ -1,19 +1,19 @@
 //This file is part of Bertini 2.
 //
-//bertini2/io/parsers.hpp is free software: you can redistribute it and/or modify
+//bertini2/io/parsing.hpp is free software: you can redistribute it and/or modify
 //it under the terms of the GNU General Public License as published by
 //the Free Software Foundation, either version 3 of the License, or
 //(at your option) any later version.
 //
-//bertini2/io/parsing/settings_parsers.hpp is distributed in the hope that it will be useful,
+//bertini2/io/parsing.hpp is distributed in the hope that it will be useful,
 //but WITHOUT ANY WARRANTY; without even the implied warranty of
 //MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //GNU General Public License for more details.
 //
 //You should have received a copy of the GNU General Public License
-//along with bertini2/io/parsing/settings_parsers.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//along with bertini2/io/parsing.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015 - 2017 by Bertini2 Development Team
+// Copyright(C) 2015, 2016 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license,
 // as well as COPYING.  Bertini2 is provided with permitted
@@ -21,12 +21,16 @@
 
 
 /**
- \file bertini2/io/parsing/settings_parsers.hpp
+ \file bertini2/io/parsing.hpp
  
- \brief Useful Qi rules for parsing settings
+ \brief A collective include file for parsing utilities
  */
-
 
 #pragma once
 
+#include "bertini2/io/parsing/classic_utilities.hpp"
+#include "bertini2/io/parsing/function_parsers.hpp"
+#include "bertini2/io/parsing/number_parsers.hpp"
+#include "bertini2/io/parsing/settings_parsers.hpp"
+#include "bertini2/io/parsing/system_parsers.hpp"
 

--- a/core/include/bertini2/io/parsing/classic_utilities.hpp
+++ b/core/include/bertini2/io/parsing/classic_utilities.hpp
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with bertini2/io/parsing/classic_utilities.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license,
 // as well as COPYING.  Bertini2 is provided with permitted
@@ -55,9 +55,6 @@ namespace bertini {
 			 SplitFileInputConfig parser return an instance of this class.  The user can then parse the config and input portions separately using the appropriate parser.
 			 
 			 */
-			
-			
-			
 			class SplitInputFile
 			{
 			public:
@@ -399,11 +396,12 @@ namespace bertini {
 				return input_file;
 			}
 			
-			
+
+
 			/**
 			 \brief Function for splitting a Bertini Classic style input file into `config` and `input`.
 			 */
-			void SplitIntoConfigAndInput(std::string & config_section, std::string & input_section, Path const& input_file)
+			std::tuple<std::string, std::string> SplitIntoConfigAndInput(Path const& input_file)
 			{
 				auto file_as_string = FileToString(input_file);
 				
@@ -412,8 +410,17 @@ namespace bertini {
 				std::string::const_iterator iter = file_as_string.begin();
 				std::string::const_iterator end = file_as_string.end();
 				phrase_parse(iter, end, parser, boost::spirit::ascii::space, config_and_input);
-				config_section = config_and_input.Config();
-				input_section = config_and_input.Input();
+
+				return std::make_tuple(config_and_input.Config(), config_and_input.Input());
+			}
+
+
+			/**
+			 \brief Function for splitting a Bertini Classic style input file into `config` and `input`.
+			 */
+			void SplitIntoConfigAndInput(std::string & config_section, std::string & input_section, Path const& input_file)
+			{
+				std::tie(config_section, input_section) = SplitIntoConfigAndInput(input_file);
 			}
 
 

--- a/core/include/bertini2/io/parsing/function_parsers.hpp
+++ b/core/include/bertini2/io/parsing/function_parsers.hpp
@@ -42,7 +42,7 @@ namespace bertini {
 			
 			
 			template <typename Iterator>
-			static bool parse(Iterator first, Iterator last, std::shared_ptr<bertini::node::Node>& func)
+			bool parse(Iterator first, Iterator last, std::shared_ptr<bertini::node::Node>& func)
 			{
 				using boost::spirit::qi::double_;
 				using boost::spirit::qi::_1;

--- a/core/include/bertini2/io/parsing/number_parsers.hpp
+++ b/core/include/bertini2/io/parsing/number_parsers.hpp
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with bertini2/io/parsing/number_parsers.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license,
 // as well as COPYING.  Bertini2 is provided with permitted
@@ -23,12 +23,11 @@
 /**
  \file bertini2/io/parsing/number_parsers.hpp
  
- \brief Provides functions for parsing numbers in bertini.
+ \brief Provides parsers for numbers in bertini.
  */
 
 #pragma once
 
-#include "bertini2/io/parsing/qi_files.hpp"
 #include "bertini2/io/parsing/number_rules.hpp"
 
 
@@ -37,7 +36,94 @@ namespace bertini{
 	namespace parsing{
 
 		namespace classic{
-			
+			template<typename Iterator, typename Skipper = ascii::space_type>
+			struct MpfrFloatParser : qi::grammar<Iterator, mpfr_float(), boost::spirit::ascii::space_type>
+			{
+				MpfrFloatParser() : MpfrFloatParser::base_type(root_rule_,"MpfrFloatParser")
+				{
+					using std::max;
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+
+					root_rule_.name("mpfr_float");
+					root_rule_ = mpfr_rules_.number_string_
+									[ phx::bind( 
+											[]
+											(mpfr_float & B, std::string const& P)
+											{
+												using std::max;
+												auto prev_prec = DefaultPrecision();
+												auto asdf = max(prev_prec,LowestMultiplePrecision());
+												auto digits = max(P.size(),static_cast<decltype(P.size())>(asdf));
+												std::cout << "making mpfr_float with precition " << digits << " from " << P << std::endl;
+												DefaultPrecision(digits);
+												B = mpfr_float{P};
+												DefaultPrecision(prev_prec);
+												assert(B.precision() == digits);
+											},
+											_val,_1
+										)
+									];
+
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("mpfr_float parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+				}
+
+				qi::rule<Iterator, mpfr_float(), Skipper > root_rule_;
+				rules::LongNum<Iterator> mpfr_rules_;
+			};
+
+
+			template<typename Iterator, typename Skipper = ascii::space_type>
+			struct MpfrComplex : qi::grammar<Iterator, mpfr(), boost::spirit::ascii::space_type>
+			{
+				MpfrComplex() : MpfrComplex::base_type(root_rule_,"MpfrComplex")
+				{
+					using std::max;
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_val;
+					
+					root_rule_ =
+					(mpfr_float_ >> mpfr_float_)
+					[ phx::bind(
+								[]
+								(mpfr & B, mpfr_float const& P, mpfr_float const& Q)
+								{
+									auto prev_prec = DefaultPrecision();
+									auto digits = max(P.precision(),Q.precision());
+									
+									DefaultPrecision(digits);
+									B.real(P);
+									B.imag(Q);
+									B.precision(digits);
+									DefaultPrecision(prev_prec);
+									assert(B.precision() == digits);
+								},
+								_val,_1,_2
+								)
+					 ];
+				}
+				
+				qi::rule<Iterator, mpfr(), Skipper > root_rule_;
+				parsing::MpfrFloatParser<Iterator> mpfr_float_;
+			};
+
 			template <typename Iterator>
 			static bool parse(Iterator first, Iterator last, double& c)
 			{

--- a/core/include/bertini2/io/parsing/settings_parsers.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers.hpp
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with bertini2/io/parsing/settings_parsers.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license,
 // as well as COPYING.  Bertini2 is provided with permitted
@@ -30,8 +30,12 @@
 
 
 
+#include "bertini2/detail/typelist.hpp"
 
-#include "bertini2/io/parsing/settings_rules.hpp"
+#include "bertini2/io/parsing/settings_parsers/tracking.hpp"
+#include "bertini2/io/parsing/settings_parsers/endgames.hpp"
+#include "bertini2/io/parsing/settings_parsers/algorithm.hpp"
+
 
 
 
@@ -40,54 +44,105 @@ namespace bertini {
 		
 		namespace classic {
 			
-			
 			/**
 			 \brief Helper function to fill a single configuration struct by parsing a config input file.
 			 
 			 \param config_str The comment-stripped configuration string from a Bertini classic input file.
 			 
-			 \tparam Structure The config structure type
+			 \tparam ConfigT The config ConfigT type
 			 \tparam RT Real number type
 			 
 			 \returns The config struct filled with data from the input file.
 			 */
 			
-			template<typename Structure, typename RT>
-			Structure FillConfigStruct(std::string config_str)
+			template<typename RT, typename ConfigT>
+			ConfigT FillConfigStruct(std::string const& config_str)
 			{
 				std::string::const_iterator iter = config_str.begin();
 				std::string::const_iterator end = config_str.end();
-				Structure settings;
-				ConfigSettingParser<std::string::const_iterator, Structure, RT> parser;
-				// TODO: error handling if parsing goes wrong
-				bool parsed = phrase_parse(iter, end, parser,boost::spirit::ascii::space, settings);
-				
+				ConfigT settings;
+				ConfigSettingParser<std::string::const_iterator, ConfigT, RT> parser;
+				auto parse_success = phrase_parse(iter, end, parser,boost::spirit::ascii::space, settings);
+				if (!parse_success || iter!=end)
+					throw std::runtime_error("failed to parse into config struct from file");
+
 				return settings;
 			}
-			
-			
-			
-			
+
+
+
+
 			/**
-			 This idea for filling a tuple using variadic templates comes from:
-			 http://stackoverflow.com/questions/10014713/build-tuple-using-variadic-templates
-			 
-			 
-			 \brief Reads in a comment-stripped, config portion of a Bertini classic input file.  Parses the config settings and returns the structures passed into the template parameters with the relevant config settings.
-			 
-			 \param config_str The string containing the comment-stripped config portion of the Bertini classic input file.
-			 
-			 \tparam RT Real number type
-			 \tparam Structs A configuration structure to be filled by the parser
-			 
-			 \return A tuple containing all the required config structures.
-			 */
-			template<typename RT, typename... Structs>
-			std::tuple<Structs...> GetConfigSettings(std::string config_str)
+			\brief Base variadic parser for parsing many config structs at once.
+
+			A specialization for a typelist of configs appears below.
+
+			\tparam RT Real number type
+			\tparam Ts Configuration structures to be filled by the parser
+			*/
+			template<typename RT, typename ...Ts>
+			struct ConfigParser
 			{
-				return std::make_tuple<Structs...>(FillConfigStruct<Structs,RT>(config_str)...);
-			}
-			
+				/**
+				 The primary idea for filling a tuple using variadic templates comes from:
+				 http://stackoverflow.com/questions/10014713/build-tuple-using-variadic-templates
+				 
+				 
+				 \brief Reads in a comment-stripped, config portion of a Bertini classic input file.  Parses the config settings and returns the structures passed into the template parameters with the relevant config settings.
+				 
+				 \param config The string containing the comment-stripped config portion of the Bertini classic input file.
+				 
+				 \return A tuple containing all the required config structures.
+				 */
+				static
+				std::tuple<Ts...> Parse(std::string const& config)
+				{
+					return std::make_tuple<Ts...>(FillConfigStruct<RT, Ts>(config)...);
+				}
+
+			};
+
+
+			/**
+			\brief Specialization of ConfigParser for a single config struct
+
+			\tparam ConfigT The config ConfigT type
+			\tparam RT Real number type
+			*/
+			template<typename RT, typename ConfigT>
+			struct ConfigParser <RT, ConfigT>
+			{	
+
+				/**
+				 \brief Fill a single configuration struct by parsing a config input file.
+				 
+				 \param config The comment-stripped configuration string from a Bertini classic input file.
+				 
+				 \returns The config struct filled with data from the input file.
+				 */
+				static
+				ConfigT Parse(std::string const& config)
+				{
+					return FillConfigStruct<RT, ConfigT>(config);
+				}
+			};
+
+
+			/**
+			\brief Specialization of ConfigParser for a typelist, returning a thing passed down from the base variadic case.
+
+			\tparam ConfigT The config ConfigT type
+			\tparam RT Real number type
+			*/
+			template<typename RT, typename ...Ts>
+			struct ConfigParser<RT, detail::TypeList<Ts...>>
+			{	
+				static
+				auto Parse(std::string const& config)
+				{
+					return ConfigParser<RT, Ts...>::Parse(config);
+				}
+			};
 		} // re: namespace classic
 		
 	}// re: namespace parsing

--- a/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/algorithm.hpp
@@ -1,0 +1,926 @@
+//This file is part of Bertini 2.
+//
+//bertini2/io/parsing/settings_parsers/algorithm.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/io/parsing/settings_parsers/algorithm.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/io/parsing/settings_parsers/algorithm.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+
+/**
+ \file bertini2/io/parsing/settings_parsers/algorithm.hpp
+ 
+ \brief Provides the parsing rules for algorithm-related settings in bertini2.
+ */
+
+#pragma once
+
+
+#include "bertini2/io/parsing/settings_parsers/base.hpp"
+#include "bertini2/nag_algorithms/common/config.hpp"
+
+namespace bertini {
+	namespace parsing {
+		namespace classic {
+
+
+			
+			/**
+
+			 */
+			template<typename Iterator, typename T, typename Skipper> 
+			struct ConfigSettingParser<Iterator, algorithm::config::Tolerances<T>, T, Skipper> : qi::grammar<Iterator, algorithm::config::Tolerances<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::TolerancesType")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string newton_before_name = "tracktolbeforeeg";
+					std::string newton_during_name = "tracktolduringeg";
+					std::string final_tol_name = "finaltol";
+					std::string path_trunc_name = "pathtruncationthreshold";
+					
+					
+					root_rule_.name("config::Tolerances");
+					
+					root_rule_ = ((newton_before_endgame_[phx::bind( [this](algorithm::config::Tolerances<T> & S, T l)
+																	{
+																		S.newton_before_endgame = l;
+																	}, _val, _1 )]
+								   ^ newton_during_endgame_[phx::bind( [this](algorithm::config::Tolerances<T> & S, T num)
+																	  {
+																		  S.newton_during_endgame = num;
+																	  }, _val, _1 )]
+								   ^ final_tol_[phx::bind( [this](algorithm::config::Tolerances<T> & S, T num)
+														  {
+															  S.final_tolerance = num;
+														  }, _val, _1 )]
+								   ^ path_trunc_threshold_[phx::bind( [this](algorithm::config::Tolerances<T> & S, T num)
+																	 {
+																		 S.path_truncation_threshold = num;
+																	 }, _val, _1 )])
+								  
+								  >> -no_setting_)
+					| no_setting_;
+					
+					
+					all_names_ = (no_case[newton_before_name] >> ':') | (no_case[newton_during_name] >> ':')| (no_case[final_tol_name] >> ':')
+					| (no_case[path_trunc_name] >> ':');
+					
+					newton_before_endgame_.name("newton_before_endgame_");
+					newton_before_endgame_ = *(char_ - all_names_) >> (no_case[newton_before_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					newton_during_endgame_.name("newton_during_endgame_");
+					newton_during_endgame_ = *(char_ - all_names_) >> (no_case[newton_during_name] >>':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					final_tol_.name("final_tol_");
+					final_tol_ = *(char_ - all_names_) >> (no_case[final_tol_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					path_trunc_threshold_.name("path_trunc_threshold_");
+					path_trunc_threshold_ = *(char_ - all_names_) >> (no_case[path_trunc_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, algorithm::config::Tolerances<T>(), ascii::space_type > root_rule_;
+				qi::rule<Iterator, T(), ascii::space_type > newton_before_endgame_, newton_during_endgame_,
+				final_tol_, path_trunc_threshold_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+				
+				
+			}; //re: Tolerances
+			
+			
+			
+			
+			
+			
+			
+			
+
+			template<typename Iterator, typename T, typename Skipper> 
+			struct ConfigSettingParser<Iterator, algorithm::config::ZeroDim<T>, T, Skipper> : qi::grammar<Iterator, algorithm::config::ZeroDim<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "algorithm::config::ZeroDim")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string init_prec_name = "initialprec";
+					std::string max_cross_resolve_name = "maxcrossedpathresolves";
+					std::string start_time_name = "starttime";
+					std::string endgame_boundary_name = "endgamebdry";
+					std::string target_time_name = "targettime";
+					std::string path_variable_name_name = "pathvarname";
+
+
+					root_rule_.name("config::ZeroDim");
+					
+					root_rule_ = ((init_prec_[phx::bind( [this](algorithm::config::ZeroDim<T> & S, int num)
+														   {
+															   S.initial_ambient_precision = num;
+														   }, _val, _1 )]
+								   ^ path_variable_name_[phx::bind( [this](algorithm::config::ZeroDim<T> & S, std::string omnom)
+															 {
+																 S.path_variable_name = omnom;
+															 }, _val, _1 )]
+								   ^ max_cross_resolve_[phx::bind( [this](algorithm::config::ZeroDim<T> & S, int num)
+															 {
+																 S.max_num_crossed_path_resolve_attempts = num;
+															 }, _val, _1 )]
+								   ^ start_time_[phx::bind( [this](algorithm::config::ZeroDim<T> & S, T num)
+															 {
+																 S.start_time = num;
+															 }, _val, _1 )]
+								   ^ endgame_boundary_[phx::bind( [this](algorithm::config::ZeroDim<T> & S, T num)
+															 {
+																 S.endgame_boundary = num;
+															 }, _val, _1 )]
+								   ^ target_time_[phx::bind( [this](algorithm::config::ZeroDim<T> & S, T num)
+															 {
+																 S.target_time = num;
+															 }, _val, _1 )]
+								   )
+								  >> -no_setting_) | no_setting_;
+					
+					all_names_ = (no_case[init_prec_name] >> ':') | 
+								 (no_case[target_time_name] >> ':') |
+								 (no_case[path_variable_name_name] >> ':') |
+								 (no_case[max_cross_resolve_name] >> ':') |
+								 (no_case[start_time_name] >> ':') |
+								 (no_case[endgame_boundary_name] >> ':')
+								 ;
+					
+
+					auto str_to_T = [this](T & num, std::string str)
+									   {
+										   num = bertini::NumTraits<T>::FromString(str);
+									   };
+
+
+
+					valid_variable_name_.name("valid_variable_name_");
+					valid_variable_name_ = +qi::alpha >> *(qi::alnum | qi::char_("[]_") );
+
+
+					path_variable_name_.name("path_variable_name_");
+					path_variable_name_ = *(char_ - all_names_) >> (no_case[path_variable_name_name] >> ':') >> valid_variable_name_ >> ';';
+
+					init_prec_.name("init_prec_");
+					init_prec_ = *(char_ - all_names_) >> (no_case[init_prec_name] >> ':') >> qi::int_[_val=_1] >> ';';
+
+					max_cross_resolve_.name("max_cross_resolve_");
+					max_cross_resolve_ = *(char_ - all_names_) >> (no_case[max_cross_resolve_name] >> ':') >> qi::int_[_val=_1] >> ';';
+
+					start_time_.name("start_time_");
+					start_time_ = *(char_ - all_names_) >> (no_case[start_time_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+					endgame_boundary_.name("endgame_boundary_");
+					endgame_boundary_ = *(char_ - all_names_) >> (no_case[endgame_boundary_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+					target_time_.name("target_time_");
+					target_time_ = *(char_ - all_names_) >> (no_case[target_time_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+
+
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, algorithm::config::ZeroDim<T>(), ascii::space_type > root_rule_;
+
+				qi::rule<Iterator, T(), ascii::space_type > start_time_, target_time_, endgame_boundary_;
+				qi::rule<Iterator, int(), ascii::space_type > init_prec_, max_cross_resolve_;
+				qi::rule<Iterator, std::string(), ascii::space_type > valid_variable_name_, path_variable_name_;
+				
+
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+				
+				
+			}; //re: ZeroDim
+
+			template<typename Iterator, typename T, typename Skipper> 
+			struct ConfigSettingParser<Iterator, algorithm::config::MidPath<T>, T, Skipper> : qi::grammar<Iterator, algorithm::config::MidPath<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::MidPath")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string same_point_tol_name = "midpathtol";
+					
+					
+					root_rule_.name("config::MidPath");
+					
+					root_rule_ = ((same_point_tol_[phx::bind( [this](algorithm::config::MidPath<T> & S, T num)
+														   {
+															   S.same_point_tolerance = num;
+														   }, _val, _1 )]
+								  )
+								  >> -no_setting_) | no_setting_;
+					
+					all_names_ = (no_case[same_point_tol_name] >> ':');
+					
+					auto str_to_T = [this](T & num, std::string str)
+									   {
+										   num = bertini::NumTraits<T>::FromString(str);
+									   };
+
+
+					same_point_tol_.name("same_point_tol_");
+					same_point_tol_ = *(char_ - all_names_) >> (no_case[same_point_tol_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+					
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, algorithm::config::MidPath<T>(), ascii::space_type > root_rule_;
+				qi::rule<Iterator, T(), ascii::space_type > same_point_tol_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+			}; //re: MidPath
+
+
+			template<typename Iterator, typename T, typename Skipper> 
+			struct ConfigSettingParser<Iterator, algorithm::config::AutoRetrack<T>, T, Skipper> : qi::grammar<Iterator, algorithm::config::AutoRetrack<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::AutoRetrack")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string decrease_factor_name = "retracktolfactor";
+					
+					
+					root_rule_.name("config::AutoRetrack");
+					
+					root_rule_ = ((decrease_factor[phx::bind( [this](algorithm::config::AutoRetrack<T> & S, T num)
+														   {
+															   S.midpath_decrease_tolerance_factor = num;
+														   }, _val, _1 )]
+								  )
+								  >> -no_setting_) | no_setting_;
+					
+					all_names_ = (no_case[decrease_factor_name] >> ':');
+					
+					auto str_to_T = [this](T & num, std::string str)
+									   {
+										   num = bertini::NumTraits<T>::FromString(str);
+									   };
+
+
+					decrease_factor.name("decrease_factor");
+					decrease_factor = *(char_ - all_names_) >> (no_case[decrease_factor_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+					
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, algorithm::config::AutoRetrack<T>(), ascii::space_type > root_rule_;
+				qi::rule<Iterator, T(), ascii::space_type > decrease_factor;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+			}; //re: AutoRetrack
+
+
+			template<typename Iterator, typename T, typename Skipper> 
+			struct ConfigSettingParser<Iterator, algorithm::config::Sharpening<T>, T, Skipper> : qi::grammar<Iterator, algorithm::config::Sharpening<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "algorithm::config::Sharpening")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string sharpen_digits_name = "sharpendigits";
+					std::string func_res_tol_name = "functiontolerance";
+					std::string ratio_tol_name = "ratiotolerance";
+
+
+					root_rule_.name("config::Sharpening");
+					
+					root_rule_ = ((sharpen_digits_[phx::bind( [this](algorithm::config::Sharpening<T> & S, unsigned num)
+														   {
+															   S.sharpendigits = num;
+														   }, _val, _1 )]
+								   ^ func_res_tol_[phx::bind( [this](algorithm::config::Sharpening<T> & S, T num)
+															 {
+																 S.function_residual_tolerance = num;
+															 }, _val, _1 )]
+								   ^ ratio_tol_[phx::bind( [this](algorithm::config::Sharpening<T> & S, T num)
+															 {
+																 S.ratio_tolerance = num;
+															 }, _val, _1 )]
+								   )
+								  >> -no_setting_) | no_setting_;
+					
+					all_names_ = (no_case[sharpen_digits_name] >> ':') | 
+								 (no_case[func_res_tol_name] >> ':') |
+								 (no_case[ratio_tol_name] >> ':')
+								 ;
+					
+
+					auto str_to_T = [this](T & num, std::string str)
+									   {
+										   num = bertini::NumTraits<T>::FromString(str);
+									   };
+
+
+					func_res_tol_.name("func_res_tol_");
+					func_res_tol_ = *(char_ - all_names_) >> (no_case[func_res_tol_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+					
+					ratio_tol_.name("ratio_tol_");
+					ratio_tol_ = *(char_ - all_names_) >> (no_case[ratio_tol_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+					sharpen_digits_.name("sharpen_digits_");
+					sharpen_digits_ = *(char_ - all_names_) >> (no_case[sharpen_digits_name] >> ':') >> qi::uint_[_val=_1] >> ';';
+
+
+
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, algorithm::config::Sharpening<T>(), ascii::space_type > root_rule_;
+
+				qi::rule<Iterator, T(), ascii::space_type > func_res_tol_, ratio_tol_;
+				qi::rule<Iterator, unsigned int(), ascii::space_type > sharpen_digits_;
+
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+				
+				
+			}; //re: Sharpening
+
+			template<typename Iterator, typename T, typename Skipper> 
+			struct ConfigSettingParser<Iterator, algorithm::config::Regeneration<T>, T, Skipper> : qi::grammar<Iterator, algorithm::config::Regeneration<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "algorithm::config::Regeneration")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string regen_remove_inf_name = "regenremoveinf";
+					std::string slice_before_name = "slicetolbeforeeg";
+					std::string slice_during_name = "slicetolduringeg";
+					std::string slice_final_name = "slicefinaltol";
+					std::string higher_dim_check_name = "regenhigherdimtest";
+					std::string start_level_name = "regenstartlevel";
+
+
+					root_rule_.name("config::Regeneration");
+					
+					root_rule_ = ((regen_remove_inf_[phx::bind( [this](algorithm::config::Regeneration<T> & S, int num)
+														   {
+															   S.remove_infinite_endpoints = static_cast<bool>(num);
+														   }, _val, _1 )]
+								   ^ higher_dim_check_[phx::bind( [this](algorithm::config::Regeneration<T> & S, int num)
+															 {
+																 S.higher_dimension_check = static_cast<bool>(num);
+															 }, _val, _1 )]
+								   ^ start_level_[phx::bind( [this](algorithm::config::Regeneration<T> & S, int num)
+															 {
+																 S.start_level = num;
+															 }, _val, _1 )]
+								   ^ slice_before_[phx::bind( [this](algorithm::config::Regeneration<T> & S, T num)
+															 {
+																 S.newton_before_endgame = num;
+															 }, _val, _1 )]
+								   ^ slice_during_[phx::bind( [this](algorithm::config::Regeneration<T> & S, T num)
+															 {
+																 S.newton_during_endgame = num;
+															 }, _val, _1 )]
+								   ^ slice_final_[phx::bind( [this](algorithm::config::Regeneration<T> & S, T num)
+															 {
+																 S.final_tolerance = num;
+															 }, _val, _1 )]
+								   )
+								  >> -no_setting_) | no_setting_;
+					
+					all_names_ = (no_case[regen_remove_inf_name] >> ':') | 
+								 (no_case[higher_dim_check_name] >> ':') |
+								 (no_case[start_level_name] >> ':') |
+								 (no_case[slice_before_name] >> ':') |
+								 (no_case[slice_during_name] >> ':') |
+								 (no_case[slice_final_name] >> ':')
+								 ;
+					
+
+					auto str_to_T = [this](T & num, std::string str)
+									   {
+										   num = bertini::NumTraits<T>::FromString(str);
+									   };
+
+
+					higher_dim_check_.name("higher_dim_check_");
+					higher_dim_check_ = *(char_ - all_names_) >> (no_case[higher_dim_check_name] >> ':') >> qi::int_[_val=_1] >> ';';
+
+					start_level_.name("start_level_");
+					start_level_ = *(char_ - all_names_) >> (no_case[start_level_name] >> ':') >> qi::int_[_val=_1] >> ';';
+
+					regen_remove_inf_.name("regen_remove_inf_");
+					regen_remove_inf_ = *(char_ - all_names_) >> (no_case[regen_remove_inf_name] >> ':') >> qi::int_[_val=_1] >> ';';
+
+
+
+					slice_before_.name("slice_before_");
+					slice_before_ = *(char_ - all_names_) >> (no_case[slice_before_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+					slice_during_.name("slice_during_");
+					slice_during_ = *(char_ - all_names_) >> (no_case[slice_during_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+					slice_final_.name("slice_final_");
+					slice_final_ = *(char_ - all_names_) >> (no_case[slice_final_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+
+
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, algorithm::config::Regeneration<T>(), ascii::space_type > root_rule_;
+
+				qi::rule<Iterator, T(), ascii::space_type > slice_before_, slice_during_, slice_final_;
+				qi::rule<Iterator, int(), ascii::space_type > regen_remove_inf_, start_level_, higher_dim_check_;
+
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+				
+				
+			}; //re: Regeneration
+
+
+			template<typename Iterator, typename T, typename Skipper> 
+			struct ConfigSettingParser<Iterator, algorithm::config::PostProcessing<T>, T, Skipper> : qi::grammar<Iterator, algorithm::config::PostProcessing<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "algorithm::config::PostProcessing")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string real_thresh_name = "imagthreshold";
+					std::string endpoint_finite_name = "endpointfinitethreshold";
+					std::string same_point_name = "endpointsamethreshold";
+
+
+
+					root_rule_.name("config::PostProcessing");
+					
+					root_rule_ = ((real_threshold_[phx::bind( [this](algorithm::config::PostProcessing<T> & S, T num)
+															 {
+																 S.real_threshold = num;
+															 }, _val, _1 )]
+								   ^ endpoint_finite_[phx::bind( [this](algorithm::config::PostProcessing<T> & S, T num)
+															 {
+																 S.endpoint_finite_threshold = num;
+															 }, _val, _1 )]
+								   ^ same_point_[phx::bind( [this](algorithm::config::PostProcessing<T> & S, T num)
+															 {
+																 S.same_point_tolerance = num;
+															 }, _val, _1 )]
+								   )
+								  >> -no_setting_) | no_setting_;
+					
+					all_names_ = (no_case[real_thresh_name] >> ':') |
+								 (no_case[endpoint_finite_name] >> ':') |
+								 (no_case[same_point_name] >> ':')
+								 ;
+					
+
+					auto str_to_T = [this](T & num, std::string str)
+									   {
+										   num = bertini::NumTraits<T>::FromString(str);
+									   };
+
+					real_threshold_.name("real_thresh_");
+					real_threshold_ = *(char_ - all_names_) >> (no_case[real_thresh_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+					endpoint_finite_.name("endpoint_finite_");
+					endpoint_finite_ = *(char_ - all_names_) >> (no_case[endpoint_finite_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+					same_point_.name("same_point_");
+					same_point_ = *(char_ - all_names_) >> (no_case[same_point_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+
+
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, algorithm::config::PostProcessing<T>(), ascii::space_type > root_rule_;
+
+				qi::rule<Iterator, T(), ascii::space_type > real_threshold_, endpoint_finite_, same_point_;
+
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+				
+				
+			}; //re: PostProcessing
+
+
+
+			template<typename Iterator, typename T, typename Skipper> //boost::spirit::unused_type
+			struct ConfigSettingParser<Iterator, config::Meta, T, Skipper> : qi::grammar<Iterator, config::Meta(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::Meta")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					tracktype_.add("-4", config::classic::AlgoChoice::EvalFunctions);
+					tracktype_.add("-3", config::classic::AlgoChoice::EvalFunctionJacobian);
+					tracktype_.add("-2", config::classic::AlgoChoice::NewtonIteration);
+					tracktype_.add("-1", config::classic::AlgoChoice::NewtonIterationCondNum);
+					tracktype_.add("0", config::classic::AlgoChoice::ZeroDim);
+					tracktype_.add("1", config::classic::AlgoChoice::NID);
+					tracktype_.add("2", config::classic::AlgoChoice::SampleComponent);
+					tracktype_.add("3", config::classic::AlgoChoice::MembershipTest);
+					tracktype_.add("4", config::classic::AlgoChoice::ExtractWitnessSet);
+					tracktype_.add("5", config::classic::AlgoChoice::WitnessSetProjection);
+					tracktype_.add("6", config::classic::AlgoChoice::IsosingularStab);
+					
+					std::string setting_name = "tracktype";
+					
+					
+					root_rule_.name("config::Meta");
+					
+					root_rule_ = (config_name_[_val = _1] >> -no_setting_) | no_setting_[_val = config::Meta::RKF45];
+					
+					config_name_.name("tracktype_");
+					config_name_ = *(char_ - (no_case[setting_name] >> ':')) >> (no_case[setting_name] >> ':') >> tracktype_[_val = _1] >> ';';
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - no_case[setting_name]);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, config::Meta(), ascii::space_type > root_rule_, config_name_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_;
+				
+				qi::symbols<char,config::classic::AlgoChoice> tracktype_;
+				
+				
+			}; //re: Meta
+
+
+
+		} // re: namespace classic
+		
+	}// re: namespace parsing
+}// re: namespace bertini

--- a/core/include/bertini2/io/parsing/settings_parsers/base.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/base.hpp
@@ -1,0 +1,59 @@
+//This file is part of Bertini 2.
+//
+//bertini2/io/parsing/settings_parsers/base.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/io/parsing/settings_parsers/base.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/io/parsing/settings_parsers/base.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+
+/**
+ \file bertini2/io/parsing/settings_parsers/base.hpp
+ 
+ \brief Provides the base type for config settings parsers
+ */
+
+#pragma once
+
+
+
+
+#include "bertini2/io/parsing/qi_files.hpp"
+#include "bertini2/io/parsing/number_rules.hpp"
+
+namespace bertini {
+	namespace parsing {
+		namespace classic {
+
+			namespace qi = ::boost::spirit::qi;
+			namespace ascii = ::boost::spirit::ascii;
+			
+			
+			/**
+			 Qi Parser object for parsing config settings  This ensures we can provide backwards compatibility with Bertini Classic input files.
+			 
+			 This is a base case template, which we specialize below
+			 */
+			template<typename Iterator, typename Structure, typename T = double, typename Skipper = ascii::space_type> //boost::spirit::unused_type
+			struct ConfigSettingParser : qi::grammar<Iterator, Structure(), Skipper>
+			{ 
+			};
+			
+
+		} // re: namespace classic
+		
+	}// re: namespace parsing
+}// re: namespace bertini

--- a/core/include/bertini2/io/parsing/settings_parsers/endgames.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/endgames.hpp
@@ -1,0 +1,531 @@
+//This file is part of Bertini 2.
+//
+//bertini2/io/parsing/settings_parsers/endgames.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/io/parsing/settings_parsers/endgames.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/io/parsing/settings_parsers/endgames.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+
+/**
+ \file bertini2/io/parsing/settings_parsers/endgames.hpp
+ 
+ \brief Provides the parsing rules for endgames-related settings in bertini2.
+ */
+
+#pragma once
+
+
+#include "bertini2/io/parsing/settings_parsers/base.hpp"
+#include "bertini2/endgames/config.hpp"
+
+
+namespace bertini {
+	namespace parsing {
+		namespace classic {
+
+			
+			
+			
+			
+			
+			
+			
+			
+			/**
+
+			 */
+			template<typename Iterator, typename T, typename Skipper> //boost::spirit::unused_type
+			struct ConfigSettingParser<Iterator, config::Security<T>, T, Skipper> : qi::grammar<Iterator, config::Security<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::SecurityType")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string level_name = "securitylevel";
+					std::string maxnorm_name = "securitymaxnorm";
+					
+					
+					root_rule_.name("config::Security");
+					
+					root_rule_ = ((security_level_[phx::bind( [this](config::Security<T> & S, int l)
+															 {
+																 S.level = l;
+															 }, _val, _1 )]
+								   ^ security_max_norm_[phx::bind( [this](config::Security<T> & S, T norm)
+																  {
+																	  S.max_norm = norm;
+																  }, _val, _1 )])
+								  >> -no_setting_) | no_setting_;
+					
+					all_names_ = (no_case[level_name] >> ':') | (no_case[maxnorm_name] >> ':');
+					
+					security_level_.name("security_level_");
+					security_level_ = *(char_ - all_names_) >> (no_case[level_name] >> ':') >> qi::int_[_val = _1] >> ';';
+					
+					security_max_norm_.name("security_max_norm_");
+					security_max_norm_ = *(char_ - all_names_) >> (no_case[maxnorm_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, config::Security<T>(), ascii::space_type > root_rule_;
+				qi::rule<Iterator, int(), ascii::space_type > security_level_;
+				qi::rule<Iterator, T(), ascii::space_type > security_max_norm_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+				
+				
+			}; //re: SecurityParser
+			
+			
+			
+			
+			
+			/**
+
+			 */
+			template<typename Iterator, typename T, typename Skipper> //boost::spirit::unused_type
+			struct ConfigSettingParser<Iterator, config::Endgame<T>, T, Skipper> : qi::grammar<Iterator, config::Endgame<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::EndgameType")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string samplefactor_name = "samplefactor";
+					std::string numpoints_name = "numsamplepoints";
+					std::string mintrack_name = "nbhdradius";
+					
+					
+					root_rule_.name("config::Endgame");
+					
+					root_rule_ = ((sample_factor_[phx::bind( [this](config::Endgame<T> & S, T num)
+															{
+																S.sample_factor = num;
+															}, _val, _1 )]
+								   ^ min_track_[phx::bind( [this](config::Endgame<T> & S, T num)
+														  {
+															  S.min_track_time = num;
+														  }, _val, _1 )]
+								   ^ num_sample_[phx::bind( [this](config::Endgame<T> & S, unsigned num)
+															  {
+																  S.num_sample_points = num;
+															  }, _val, _1 )])
+								  
+								  >> -no_setting_)
+					| no_setting_;
+					
+					
+					all_names_ = (no_case[samplefactor_name] >> ':') | (no_case[numpoints_name] >> ':')| (no_case[mintrack_name] >> ':');
+					
+					sample_factor_.name("sample_factor_");
+					sample_factor_ = *(char_ - all_names_) >> (no_case[samplefactor_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					min_track_.name("min_track_");
+					min_track_ = *(char_ - all_names_) >> (no_case[mintrack_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					num_sample_.name("num_sample_");
+					num_sample_ = *(char_ - all_names_) >> (no_case[numpoints_name] >> ':')
+					>> qi::uint_[_val=_1] >> ';';
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, config::Endgame<T>(), ascii::space_type > root_rule_;
+				qi::rule<Iterator, T(), ascii::space_type > sample_factor_, min_track_;
+				qi::rule<Iterator, unsigned int(), ascii::space_type > num_sample_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+			}; //re: EndgameParser
+			
+			
+			
+			
+			
+			/**
+
+			 */
+			template<typename Iterator, typename T, typename Skipper> //boost::spirit::unused_type
+			struct ConfigSettingParser<Iterator, config::PowerSeries, T, Skipper> : qi::grammar<Iterator, config::PowerSeries(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::PowerSeriesType")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string maxcycle_name = "maxcyclenum";
+					
+					
+					root_rule_.name("config::PowerSeries");
+					
+					root_rule_ = (max_cycle_[phx::bind( [this](config::PowerSeries & S, unsigned num)
+													   {
+														   S.max_cycle_number = num;
+													   }, _val, _1 )]
+								  
+								  >> -no_setting_)
+					| no_setting_;
+					
+					
+					
+					all_names_ = eps >> (no_case[maxcycle_name] >> ':');
+					
+					max_cycle_.name("max_cycle_");
+					max_cycle_ = *(char_ - all_names_) >> (no_case[maxcycle_name] >> ':') >> qi::uint_[_val=_1] >> ';';
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, config::PowerSeries(), Skipper> root_rule_;
+				qi::rule<Iterator, unsigned int(), ascii::space_type > max_cycle_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+			}; //re: PowerSeriesParser
+			
+			
+			
+			
+			
+			/**
+
+			 */
+			template<typename Iterator, typename T, typename Skipper> //boost::spirit::unused_type
+			struct ConfigSettingParser<Iterator, config::Cauchy<T>, T, Skipper> : qi::grammar<Iterator, config::Cauchy<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::CauchyType")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string cyclecutoff_name = "cycletimecutoff";
+					std::string ratiocutoff_name = "ratiotimecutoff";
+					
+					
+					root_rule_.name("config::Cauchy");
+					
+					root_rule_ = ((cycle_cutoff_[phx::bind( [this](config::Cauchy<T> & S, T num)
+														   {
+															   S.cycle_cutoff_time = num;
+														   }, _val, _1 )]
+								   ^ ratio_cutoff_[phx::bind( [this](config::Cauchy<T> & S, T num)
+															 {
+																 S.ratio_cutoff_time = num;
+															 }, _val, _1 )])
+								  >> -no_setting_) | no_setting_;
+					
+					all_names_ = (no_case[cyclecutoff_name] >> ':') | (no_case[ratiocutoff_name] >> ':');
+					
+					cycle_cutoff_.name("cycle_cutoff_");
+					cycle_cutoff_ = *(char_ - all_names_) >> (no_case[cyclecutoff_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					ratio_cutoff_.name("ratio_cutoff_");
+					ratio_cutoff_ = *(char_ - all_names_) >> (no_case[ratiocutoff_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, config::Cauchy<T>(), ascii::space_type > root_rule_;
+				qi::rule<Iterator, T(), ascii::space_type > cycle_cutoff_, ratio_cutoff_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+				
+				
+			}; //re: CauchyParser
+
+			
+
+			template<typename Iterator, typename T, typename Skipper> //boost::spirit::unused_type
+			struct ConfigSettingParser<Iterator, config::TrackBack, T, Skipper> : qi::grammar<Iterator, config::TrackBack(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::TrackBack")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string min_cycle_name = "mincycletrackback";
+					std::string junk_removal_name = "junkremovaltrackback";
+					std::string maxdepth_name = "maxldtdepth";
+
+					root_rule_.name("config::TrackBack");
+					
+					root_rule_ = root_rule_ = ((min_cycle_[phx::bind( [this](config::TrackBack & S, unsigned num)
+																	   {
+																		   S.minimum_cycle = num;
+																	   }, _val, _1 )]
+											   ^ junk_removal_[phx::bind( [this](config::TrackBack & S, int num)
+																		 {
+																			 S.junk_removal_test = static_cast<bool>(num);
+																		 }, _val, _1 )]
+											   ^ max_depth_[phx::bind( [this](config::TrackBack & S, unsigned num)
+																	   {
+																		   S.max_depth_LDT = num;
+																	   }, _val, _1 )]
+											  )
+											  >> -no_setting_) | no_setting_;
+					
+					
+					
+					all_names_ = eps >> (no_case[min_cycle_name] >> ':') |
+										(no_case[junk_removal_name] >> ':') |
+										(no_case[maxdepth_name] >> ':');
+					
+					min_cycle_.name("min_cycle_");
+					min_cycle_ = *(char_ - all_names_) >> (no_case[min_cycle_name] >> ':') >> qi::uint_[_val=_1] >> ';';
+					
+					junk_removal_.name("junk_removal_");
+					junk_removal_ = *(char_ - all_names_) >> (no_case[junk_removal_name] >> ':') >> qi::int_[_val=_1] >> ';';
+
+					max_depth_.name("max_depth_");
+					max_depth_ = *(char_ - all_names_) >> (no_case[maxdepth_name] >> ':') >> qi::uint_[_val=_1] >> ';';
+
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, config::TrackBack(), Skipper> root_rule_;
+				qi::rule<Iterator, unsigned int(), ascii::space_type > min_cycle_, max_depth_;
+				qi::rule<Iterator, int(), ascii::space_type > junk_removal_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+			}; //re: TrackBackParser
+
+
+
+
+
+		} // re: namespace classic
+		
+	}// re: namespace parsing
+}// re: namespace bertini

--- a/core/include/bertini2/io/parsing/settings_parsers/tracking.hpp
+++ b/core/include/bertini2/io/parsing/settings_parsers/tracking.hpp
@@ -1,0 +1,696 @@
+//This file is part of Bertini 2.
+//
+//bertini2/io/parsing/settings_parsers/tracking.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/io/parsing/settings_parsers/tracking.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/io/parsing/settings_parsers/tracking.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+
+/**
+ \file bertini2/io/parsing/settings_parsers/tracking.hpp
+ 
+ \brief Provides the parsing rules for tracking-related settings in bertini2.
+ */
+
+#pragma once
+
+
+#include "bertini2/io/parsing/settings_parsers/base.hpp"
+#include "bertini2/trackers/config.hpp"
+
+
+namespace bertini {
+	namespace parsing {
+		namespace classic {
+
+			
+			namespace {
+				using namespace bertini::tracking;
+			}
+			/**
+			 Qi Parser object for parsing config settings  This ensures we can provide backwards compatibility with Bertini Classic input files.
+			 
+			 To use this parser, construct an object of its type, then use it to parse.
+			 
+			 \code
+			 ConfigT conf
+			 std::string str = "tracktype: 1; tracktolbeforeeg: 1e-8; \n";
+			 
+			 std::string::const_iterator iter = str.begin();
+			 std::string::const_iterator end = str.end();
+			 
+			 
+			 bertini::ConfigSettingParser<std::string::const_iterator, ConfigT> S;
+			 
+			 
+			 bool s = phrase_parse(iter, end, S,boost::spirit::ascii::space, conf);
+			 
+			 \endcode
+			 
+			 \brief Qi Parser object for parsing config file to determine settings.
+			 
+			 */
+			template<typename Iterator, typename T, typename Skipper> //boost::spirit::unused_type
+			struct ConfigSettingParser<Iterator, PrecisionType, T, Skipper> : qi::grammar<Iterator, PrecisionType(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::PrecisionType")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					precisiontype_.add("0", PrecisionType::Fixed);
+					precisiontype_.add("1", PrecisionType::Adaptive);
+					precisiontype_.add("2", PrecisionType::Adaptive);
+					
+					
+					
+					
+					root_rule_.name("config::PrecisionType");
+					
+					root_rule_ = (config_name_[_val = _1] >> -no_setting_) | no_setting_[_val = PrecisionType::Adaptive];
+					
+					config_name_.name("precisiontype_");
+					config_name_ = *(char_ - (no_case["mptype"]>>':')) >> (no_case["mptype"] >> ':') >> precisiontype_[_val = _1] >> ';';
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - no_case["mptype:"]);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, PrecisionType(), ascii::space_type > root_rule_, config_name_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_;
+				
+				qi::symbols<char,PrecisionType> precisiontype_;
+				
+				
+			}; //re: PrecisionTypeParser
+			
+			
+			
+			
+			
+			
+			
+			
+			/**
+
+			 */
+			template<typename Iterator, typename T, typename Skipper> //boost::spirit::unused_type
+			struct ConfigSettingParser<Iterator, config::Predictor, T, Skipper> : qi::grammar<Iterator, config::Predictor(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::PredictorType")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					predictor_.add("-1", config::Predictor::Constant);
+					predictor_.add("0", config::Predictor::Euler);
+					predictor_.add("1", config::Predictor::Heun);
+					predictor_.add("2", config::Predictor::RK4);
+					predictor_.add("3", config::Predictor::Heun);
+					predictor_.add("4", config::Predictor::RKNorsett34);
+					predictor_.add("5", config::Predictor::RKF45);
+					predictor_.add("6", config::Predictor::RKCashKarp45);
+					predictor_.add("7", config::Predictor::RKDormandPrince56);
+					predictor_.add("8", config::Predictor::RKVerner67);
+					
+					
+					std::string setting_name = "odepredictor";
+					
+					
+					root_rule_.name("config::Predictor");
+					
+					root_rule_ = (config_name_[_val = _1] >> -no_setting_) | no_setting_[_val = config::Predictor::RKF45];
+					
+					config_name_.name("predictor_");
+					config_name_ = *(char_ - (no_case[setting_name] >> ':')) >> (no_case[setting_name] >> ':') >> predictor_[_val = _1] >> ';';
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - no_case[setting_name]);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, config::Predictor(), ascii::space_type > root_rule_, config_name_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_;
+				
+				qi::symbols<char,config::Predictor> predictor_;
+				
+				
+			}; //re: PredictorTypeParser
+			
+			
+			
+			
+			
+			
+			
+			
+			
+			
+			
+			
+			
+			
+			
+			
+			
+			
+			/**
+
+			 */
+			template<typename Iterator, typename T, typename Skipper> //boost::spirit::unused_type
+			struct ConfigSettingParser<Iterator, config::Stepping<T>, T, Skipper> : qi::grammar<Iterator, config::Stepping<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::SteppingType")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string maxstep_name = "maxstepsize";
+					std::string stepsuccess_name = "stepsuccessfactor";
+					std::string stepfail_name = "stepfailfactor";
+					std::string stepsincrease_name = "stepsforincrease";
+					std::string maxnumsteps_name = "maxnumbersteps";
+					
+					
+					root_rule_.name("config::Stepping");
+					
+					root_rule_ = ((max_step_size_[phx::bind( [this](config::Stepping<T> & S, T num)
+															{
+																S.max_step_size = num;
+															}, _val, _1 )]
+								   ^ stepsize_success_[phx::bind( [this](config::Stepping<T> & S, T num)
+																 {
+																	 S.step_size_success_factor = num;
+																 }, _val, _1 )]
+								   ^ stepsize_fail_[phx::bind( [this](config::Stepping<T> & S, T num)
+															  {
+																  S.step_size_fail_factor = num;
+															  }, _val, _1 )]
+								   ^ steps_increase_[phx::bind( [this](config::Stepping<T> & S, unsigned num)
+																	 {
+																		 S.consecutive_successful_steps_before_stepsize_increase = num;
+																	 }, _val, _1 )]
+								   ^ max_num_steps_[phx::bind( [this](config::Stepping<T> & S, unsigned num)
+																	{
+																		S.max_num_steps = num;
+																	}, _val, _1 )])
+								  
+								  >> -no_setting_)
+					| no_setting_;
+					
+					
+					all_names_ = (no_case[maxstep_name] >> ':') | (no_case[stepsuccess_name] >> ':')|
+					(no_case[stepfail_name] >> ':')| (no_case[stepsincrease_name] >> ':') | (no_case[maxnumsteps_name] >> ':');
+					
+					max_step_size_.name("max_step_size_");
+					max_step_size_ = *(char_ - all_names_) >> (no_case[maxstep_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					stepsize_success_.name("stepsize_success_");
+					stepsize_success_ = *(char_ - all_names_) >> (no_case[stepsuccess_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					stepsize_fail_.name("stepsize_fail_");
+					stepsize_fail_ = *(char_ - all_names_) >> (no_case[stepfail_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( [this](T & num, std::string str)
+														   {
+															   num = bertini::NumTraits<T>::FromString(str);
+														   }, _val, _1 )] >> ';';
+					
+					steps_increase_.name("steps_increase_");
+					steps_increase_ = *(char_ - all_names_) >> (no_case[stepsincrease_name] >> ':') >> qi::uint_[_val=_1] >> ';';
+					
+					max_num_steps_.name("max_num_steps_");
+					max_num_steps_ = *(char_ - all_names_) >> (no_case[maxnumsteps_name] >> ':') >> qi::uint_[_val=_1] >> ';';
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, config::Stepping<T>(), ascii::space_type > root_rule_;
+				qi::rule<Iterator, T(), ascii::space_type > max_step_size_, stepsize_success_,
+				stepsize_fail_;
+				qi::rule<Iterator, unsigned int(), ascii::space_type > steps_increase_, max_num_steps_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+				
+				
+			}; //re: SteppingParser
+			
+			
+			
+			
+			
+			/**
+
+			 */
+			template<typename Iterator, typename T, typename Skipper> //boost::spirit::unused_type
+			struct ConfigSettingParser<Iterator, config::Newton, T, Skipper> : qi::grammar<Iterator, config::Newton(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::NewtonType")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string maxits_name = "maxnewtonits";
+					
+					
+					root_rule_.name("config::Newton");
+					
+					root_rule_ = (max_its_[phx::bind( [this](config::Newton & S, unsigned num)
+													 {
+														 S.max_num_newton_iterations = num;
+													 }, _val, _1 )]
+								  
+								  >> -no_setting_)
+					| no_setting_;
+					
+					
+					
+					all_names_ = eps >> (no_case[maxits_name] >> ':');
+					
+					max_its_.name("max_its_");
+					max_its_ = *(char_ - no_case[maxits_name]) >> (no_case[maxits_name] >> ':') >> qi::uint_[_val=_1] >> ';';
+					
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, config::Newton(), Skipper> root_rule_;
+				qi::rule<Iterator, unsigned int(), ascii::space_type > max_its_;
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+			}; //re: NewtonParser
+			
+			
+			
+
+			/**
+			As of this writing, there are no meaningful settings in FixedPrecisionConfig, 
+			so this parser is ... empty
+			*/
+			template<typename Iterator, typename T, typename Skipper>
+			struct ConfigSettingParser<Iterator, config::FixedPrecisionConfig<T>, T, Skipper> : qi::grammar<Iterator, config::FixedPrecisionConfig<T>(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "config::FixedPrecision")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+
+					
+					root_rule_.name("config::FixedPrecision");
+					root_rule_ = eps[_val = config::FixedPrecisionConfig<T>()] >> omit[*(char_)];
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+				}
+				
+				
+			private:
+				qi::rule<Iterator, config::FixedPrecisionConfig<T>(), ascii::space_type > root_rule_;
+			}; //re: FixedPrecisionConfig Parser
+
+			
+
+
+
+
+
+			using AdaptiveMultiplePrecisionConfig = config::AdaptiveMultiplePrecisionConfig;
+			template<typename Iterator, typename T, typename Skipper> 
+			struct ConfigSettingParser<Iterator, AdaptiveMultiplePrecisionConfig, T, Skipper> : qi::grammar<Iterator, AdaptiveMultiplePrecisionConfig(), Skipper>
+			{
+				
+				ConfigSettingParser() : ConfigSettingParser::base_type(root_rule_, "AdaptiveMultiplePrecisionConfig")
+				{
+					namespace phx = boost::phoenix;
+					using qi::_1;
+					using qi::_2;
+					using qi::_3;
+					using qi::_4;
+					using qi::_val;
+					using qi::eps;
+					using qi::lit;
+					using qi::char_;
+					using qi::omit;
+					using boost::spirit::lexeme;
+					using boost::spirit::as_string;
+					using boost::spirit::ascii::no_case;
+					
+					
+					
+					std::string coefficient_bound_name = "coefficientbound";
+					std::string degree_bound_name = "degreebound";
+					std::string lin_solve_error_bnd_name = "epsilon";
+					std::string jac_eval_err_bnd_name = "phi";
+					std::string func_eval_err_bnd_name = "psi";
+					std::string safety_one_name = "ampsafetydigits1";
+					std::string safety_two_name = "ampsafetydigits2";
+					std::string max_prec_name = "ampmaxprec";
+					std::string consec_steps_prec_dec_name = "maxstepsprecisiondecrease";
+					std::string max_num_prec_decs_name = "maxnumprecdecreases";
+
+					root_rule_.name("config::AMP");
+					
+					root_rule_ = ((coefficient_bound_[phx::bind( [this](config::AdaptiveMultiplePrecisionConfig & S, mpfr_float num)
+														   {
+															   S.coefficient_bound = num;
+														   }, _val, _1 )]
+								   ^ degree_bound_[phx::bind( [this](config::AdaptiveMultiplePrecisionConfig & S, mpfr_float num)
+															 {
+																 S.degree_bound = num;
+															 }, _val, _1 )]
+								   ^ lin_solve_error_bnd_[phx::bind( [this](config::AdaptiveMultiplePrecisionConfig & S, mpfr_float num)
+															 {
+																 S.epsilon = num;
+															 }, _val, _1 )]
+								   ^ jac_eval_err_bnd_[phx::bind( [this](config::AdaptiveMultiplePrecisionConfig & S, mpfr_float num)
+															 {
+																 S.Phi = num;
+															 }, _val, _1 )]
+								   ^ func_eval_err_bnd_[phx::bind( [this](config::AdaptiveMultiplePrecisionConfig & S, mpfr_float num)
+															 {
+																 S.Psi = num;
+															 }, _val, _1 )]
+								   ^ safety_one_[phx::bind( [this](config::AdaptiveMultiplePrecisionConfig & S, int num)
+															 {
+																 S.safety_digits_1 = num;
+															 }, _val, _1 )]
+								   ^ safety_two_[phx::bind( [this](config::AdaptiveMultiplePrecisionConfig & S, int num)
+															 {
+																 S.safety_digits_2 = num;
+															 }, _val, _1 )]
+								   ^ max_prec_[phx::bind( [this](config::AdaptiveMultiplePrecisionConfig & S, unsigned num)
+															 {
+																 S.maximum_precision = num;
+															 }, _val, _1 )]
+								   ^ consec_steps_prec_dec_[phx::bind( [this](config::AdaptiveMultiplePrecisionConfig & S, unsigned num)
+															 {
+																 S.consecutive_successful_steps_before_precision_decrease = num;
+															 }, _val, _1 )]
+								   ^ max_num_prec_decs_[phx::bind( [this](config::AdaptiveMultiplePrecisionConfig & S, unsigned num)
+															 {
+																 S.max_num_precision_decreases = num;
+															 }, _val, _1 )]
+								   )
+								  >> -no_setting_) | no_setting_;
+					
+					all_names_ = (no_case[coefficient_bound_name] >> ':') | 
+								 (no_case[degree_bound_name] >> ':') |
+								 (no_case[lin_solve_error_bnd_name] >> ':') |
+								 (no_case[jac_eval_err_bnd_name] >> ':') |
+								 (no_case[func_eval_err_bnd_name] >> ':') |
+								 (no_case[safety_one_name] >> ':') |
+								 (no_case[safety_two_name] >> ':') |
+								 (no_case[max_prec_name] >> ':') |
+								 (no_case[consec_steps_prec_dec_name] >> ':') |
+								 (no_case[max_num_prec_decs_name] >> ':')
+								 ;
+					
+
+					auto str_to_T = [this](mpfr_float & num, std::string str)
+									   {
+									   	std::cout << str << std::endl;
+										   num = bertini::NumTraits<T>::FromString(str);
+									   };
+
+
+					degree_bound_.name("degree_bound_");
+					degree_bound_ = *(char_ - all_names_) >> (no_case[degree_bound_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+					
+					coefficient_bound_.name("coefficient_bound_");
+					coefficient_bound_ = *(char_ - all_names_) >> (no_case[coefficient_bound_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+					
+					lin_solve_error_bnd_.name("lin_solve_error_bnd_");
+					lin_solve_error_bnd_ = *(char_ - all_names_) >> (no_case[lin_solve_error_bnd_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+					jac_eval_err_bnd_.name("jac_eval_err_bnd_");
+					jac_eval_err_bnd_ = *(char_ - all_names_) >> (no_case[jac_eval_err_bnd_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+					func_eval_err_bnd_.name("func_eval_err_bnd_");
+					func_eval_err_bnd_ = *(char_ - all_names_) >> (no_case[func_eval_err_bnd_name] >> ':')
+					>> mpfr_rules.number_string_[phx::bind( str_to_T, _val, _1 )] >> ';';
+
+					safety_one_.name("safety_one_");
+					safety_one_ = *(char_ - all_names_) >> (no_case[safety_one_name] >> ':') >> qi::int_[_val=_1] >> ';';
+
+					safety_two_.name("safety_two_");
+					safety_two_ = *(char_ - all_names_) >> (no_case[safety_two_name] >> ':') >> qi::int_[_val=_1] >> ';';
+
+					max_prec_.name("max_prec_");
+					max_prec_ = *(char_ - all_names_) >> (no_case[max_prec_name] >> ':') >> qi::uint_[_val=_1] >> ';';
+
+					consec_steps_prec_dec_.name("consec_steps_prec_dec_");
+					consec_steps_prec_dec_ = *(char_ - all_names_) >> (no_case[consec_steps_prec_dec_name] >> ':') >> qi::uint_[_val=_1] >> ';';
+
+					max_num_prec_decs_.name("max_num_prec_decs_");
+					max_num_prec_decs_ = *(char_ - all_names_) >> (no_case[max_num_prec_decs_name] >> ':') >> qi::uint_[_val=_1] >> ';';
+
+
+					no_setting_.name("no_setting_");
+					no_setting_ = *(char_ - all_names_);
+					
+					no_decl_.name("no_decl_");
+					no_decl_ = *(char_);
+					
+					
+					
+					
+					using phx::val;
+					using phx::construct;
+					using namespace qi::labels;
+					qi::on_error<qi::fail>
+					( root_rule_ ,
+					 std::cout<<
+					 val("config parser could not complete parsing. Expecting ")<<
+					 _4<<
+					 val(" here: ")<<
+					 construct<std::string>(_3,_2)<<
+					 std::endl
+					 );
+					
+					
+					
+				}
+				
+				
+			private:
+				qi::rule<Iterator, AdaptiveMultiplePrecisionConfig(), ascii::space_type > root_rule_;
+
+				qi::rule<Iterator, mpfr_float(), ascii::space_type > degree_bound_, coefficient_bound_, lin_solve_error_bnd_, jac_eval_err_bnd_, func_eval_err_bnd_;
+				qi::rule<Iterator, int(), ascii::space_type > safety_one_, safety_two_;
+				qi::rule<Iterator, unsigned int(), ascii::space_type > max_prec_, consec_steps_prec_dec_, max_num_prec_decs_;
+
+				qi::rule<Iterator, ascii::space_type, std::string()> no_decl_, no_setting_, all_names_;
+				rules::LongNum<Iterator> mpfr_rules;
+				
+				
+				
+			}; //re: AMPParser
+
+
+
+
+
+		} // re: namespace classic
+		
+	}// re: namespace parsing
+}// re: namespace bertini

--- a/core/include/bertini2/io/parsing/system_parsers.hpp
+++ b/core/include/bertini2/io/parsing/system_parsers.hpp
@@ -69,4 +69,28 @@ namespace bertini {
 		} // re: namespace classic
 		
 	}// re: namespace parsing
+
+	inline
+	System::System(std::string const& input)
+	{
+		System sys;
+		
+		parsing::classic::SystemParser<std::string::const_iterator> S;
+		
+		std::string::const_iterator iter = input.begin();
+		std::string::const_iterator end = input.end();
+		
+		bool s = phrase_parse(iter, end, S,boost::spirit::ascii::space, sys);
+		
+		if (!s || iter!=end)
+		{
+			throw std::runtime_error("unable to correctly parse string in construction of system");
+		}
+		
+		using std::swap;
+		swap(sys,*this);
+	}
+	
 }// re: namespace bertini
+
+

--- a/core/include/bertini2/io/parsing/system_rules.hpp
+++ b/core/include/bertini2/io/parsing/system_rules.hpp
@@ -374,25 +374,6 @@ namespace bertini {
 	} //re: namespace parsing
 	
 	
-	inline
-	System::System(std::string const& input)
-	{
-		System sys;
-		
-		parsing::classic::SystemParser<std::string::const_iterator> S;
-		
-		std::string::const_iterator iter = input.begin();
-		std::string::const_iterator end = input.end();
-		
-		bool s = phrase_parse(iter, end, S,boost::spirit::ascii::space, sys);
-		
-		if (!s || iter!=end)
-		{
-			throw std::runtime_error("unable to correctly parse string in construction of system");
-		}
-		
-		using std::swap;
-		swap(sys,*this);
-	}
+	
 
 } // re: namespace bertini

--- a/core/include/bertini2/mpfr_complex.hpp
+++ b/core/include/bertini2/mpfr_complex.hpp
@@ -1554,6 +1554,13 @@ namespace bertini {
 		DefaultPrecision(prev_precision);
 	}
 
+	inline 
+	bertini::complex RandomUnit(unsigned num_digits)
+	{
+		bertini::complex a;
+		RandomUnit(a,num_digits);
+		return a;
+	}
 	using mpfr = bertini::complex;
 } // re: namespace bertini
 

--- a/core/include/bertini2/mpfr_extensions.hpp
+++ b/core/include/bertini2/mpfr_extensions.hpp
@@ -50,6 +50,16 @@ Particularly includes Boost.Serialize code for the mpfr_float, gmp_rational, and
 
 namespace bertini{
 
+	/**
+	\brief Overload * for unsigned * complex<double>
+	*/
+	inline
+	std::complex<double> operator*(unsigned i, std::complex<double> z)
+	{
+		z*=i;
+		return z;
+	}
+
 #ifdef BMP_EXPRESSION_TEMPLATES
 	using mpfr_float = boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_on>; 
 	using mpz_int = boost::multiprecision::number<boost::multiprecision::backends::gmp_int, boost::multiprecision::et_on>;

--- a/core/include/bertini2/nag_algorithms/common/algorithm_base.hpp
+++ b/core/include/bertini2/nag_algorithms/common/algorithm_base.hpp
@@ -1,41 +1,47 @@
 //This file is part of Bertini 2.
 //
-//system.hpp is free software: you can redistribute it and/or modify
+//nag_algorithms/common/algorithm_base.hpp is free software: you can redistribute it and/or modify
 //it under the terms of the GNU General Public License as published by
 //the Free Software Foundation, either version 3 of the License, or
 //(at your option) any later version.
 //
-//system.hpp is distributed in the hope that it will be useful,
+//nag_algorithms/common/algorithm_base.hpp is distributed in the hope that it will be useful,
 //but WITHOUT ANY WARRANTY; without even the implied warranty of
 //MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //GNU General Public License for more details.
 //
 //You should have received a copy of the GNU General Public License
-//along with system.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//along with nag_algorithms/common/algorithm_base.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license, 
 // as well as COPYING.  Bertini2 is provided with permitted 
 // additional terms in the b2/licenses/ directory.
 
 // individual authors of this file include:
-// Tim Hodges, Colorado State University
+// daniel brake, university of notre dame
 
 /**
-\file system.hpp 
+\file nag_algorithms/common/algorithm_base.hpp
 
-\brief Collects the various header files which define the Bertini2 systems.
+\brief provides a common base type for algorithms to inherit from, for the abstraction layer above for calling them from blackbox-type programs
 */
-
 
 #pragma once
 
-#include "bertini2/system/precon.hpp"
-#include "bertini2/system/start_systems.hpp"
-#include "bertini2/system/system.hpp"
+namespace bertini{
 
+namespace algorithm {
 
+	struct AnyAlgorithm
+	{
 
+		virtual 
+		void Run() = 0;
 
+		virtual ~AnyAlgorithm() = default;
+	};
+}
+}
 

--- a/core/include/bertini2/nag_algorithms/common/config.hpp
+++ b/core/include/bertini2/nag_algorithms/common/config.hpp
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with nag_algorithms/config.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license, 
 // as well as COPYING.  Bertini2 is provided with permitted 
@@ -108,4 +108,13 @@ struct ZeroDim
 	std::string path_variable_name = "ZERO_DIM_PATH_VARIABLE";
 };
 
-} } } // namespaces
+
+
+}// config
+
+// a forward declare
+template <typename T>
+	struct AlgoTraits;
+
+
+} } // namespaces

--- a/core/include/bertini2/nag_algorithms/common/config.hpp
+++ b/core/include/bertini2/nag_algorithms/common/config.hpp
@@ -34,6 +34,25 @@ using SolnCont = std::vector<T>;
 
 		namespace config{
 
+namespace classic{
+
+enum class AlgoChoice
+{
+	EvalFunctions = -4,
+	EvalFunctionJacobian = -3,
+	NewtonIteration = -2,
+	NewtonIterationCondNum = -1,
+	ZeroDim = 0,
+	NID = 1,
+	SampleComponent = 2,
+	MembershipTest = 3,
+	ExtractWitnessSet = 4,
+	WitnessSetProjection = 5,
+	IsosingularStab = 6
+}
+
+} // namespace classic
+
 
 template<typename T>
 struct Tolerances
@@ -65,7 +84,7 @@ struct Sharpening
 {
 	unsigned sharpendigits; ///< how many digits should be correct after sharpening.
 	
-	std::function<Vec<T>> sharpen_method_; ///< function taking a vector, and sharpening it.
+	// std::function<Vec<T>> sharpen_method_; ///< function taking a vector, and sharpening it.
 
 	T function_residual_tolerance = Eigen::NumTraits<T>::dummy_precision(); ///< A polynomial (or any function, really) evaluated at a point is considered to be 0 if the magnitude is smaller than this value.  See also RatioTolerance.  **Note that this value depends on the current default precision when this scruct is constructed.**
 
@@ -79,7 +98,7 @@ struct Regeneration
 	bool remove_infinite_endpoints = true; ///<  Bool indicating whether endpoints during the regeneration start point buildup step which are infinite should be discarded.  If you are not interested in infinite solutions, ensure this is true.  RegenRemoveInf
 
 	bool higher_dimension_check = true; ///< RegenHigherDimTest
-
+	unsigned start_level = 0;
 	T newton_before_endgame; ///< The tolerance for tracking before reaching the endgame.  SliceTolBeforeEG
 	T newton_during_endgame; ///< The tolerance for tracking during the endgame.  SliceTolDuringEG
 	T final_tolerance; ///< The final tolerance to track to, using the endgame.  SliceFinalTol
@@ -108,7 +127,10 @@ struct ZeroDim
 	std::string path_variable_name = "ZERO_DIM_PATH_VARIABLE";
 };
 
-
+struct Meta
+{
+	classic::AlgoChoice tracktype = 0;
+};
 
 }// config
 

--- a/core/include/bertini2/nag_algorithms/common/policies.hpp
+++ b/core/include/bertini2/nag_algorithms/common/policies.hpp
@@ -121,7 +121,7 @@ public:
 
 
 		/**
-		This system management policy makes it so that the zero dim algorithm makes a clone of the supplied system when the algorithm is created.  The zerodim algorithm will homogenize the system (that's why you want a clone, so it leaves your original system untouched), form a start system (of your type, inferred from the template parameter for the zerodim alg), and couple the two together into the homotopy used to track.
+		This system management policy makes it so that the zero dim algorithm makes a clone of the supplied system when the algorithm is created.  The zerodim algorithm, and others, will homogenize the system (that's why you want a clone, so it leaves your original system untouched), form a start system (of your type, inferred from the template parameter for the zerodim alg), and couple the two together into the homotopy used to track.
 
 		If you don't want it to take copies, or homogenize, etc, use a different policy.
 
@@ -154,7 +154,7 @@ public:
 			/**
 			Simply forward on the systems for the constructor.  The AtConstruct function is to be called by the user of this policy, at construct time.
 			*/
-			CloneGiven(SystemType const& target) : target_system_(target)
+			CloneGiven(SystemType const& target) : target_system_(AtConstruct(target))
 			{}
 
 
@@ -193,7 +193,7 @@ public:
 			}
 
 			static
-			void FormHomotopy(SystemType & homotopy, SystemType const& start, StartSystemType const& target, std::string const& path_variable_name)
+			void FormHomotopy(SystemType & homotopy, SystemType const& target, StartSystemType const& start, std::string const& path_variable_name)
 			{
 				auto t = MakeVariable(path_variable_name); 
 
@@ -220,7 +220,7 @@ public:
 				// now we populate the start system
 				FormStart(StartSystem(), TargetSystem());
 
-				FormHomotopy(Homotopy(), StartSystem(), TargetSystem(), path_variable_name);
+				FormHomotopy(Homotopy(), TargetSystem(), StartSystem(), path_variable_name);
 			}
 
 
@@ -310,40 +310,8 @@ public:
 				return std::ref(sys);
 			}
 
-			/**
-			\brief Don't do anything to the target system to prepare it for tracking.  
-
-			It's assumed it was passed in ready to track.
-			*/
-			static
-			void PrepareTarget(SystemType const& sys)
-			{ }
-
-
-			/**
-			\brief Do nothing to form the start system.  Had to have been given when constructing.
-			*/
-			static void FormStart(SystemType const& start, SystemType const& target)
-			{ }
-
-			/**
-			\brief Do nothing to form the homotopy.  Had to have been given when constructing.
-			*/
-			static
-			void FormHomotopy(SystemType const& homotopy, SystemType const& target, StartSystemType const& start, std::string const& path_variable_name)
-			{ }
-
 			void SystemSetup(std::string const& path_variable_name) const
-			{
-				PrepareTarget(TargetSystem());
-
-				// now we populate the start system
-				FormStart(StartSystem(), TargetSystem());
-
-				FormHomotopy(Homotopy(), StartSystem(), TargetSystem(), path_variable_name);
-
-				
-			}
+			{ }
 
 		};
 	} // ns policy

--- a/core/include/bertini2/nag_algorithms/midpath_check.hpp
+++ b/core/include/bertini2/nag_algorithms/midpath_check.hpp
@@ -42,7 +42,7 @@ namespace bertini{
 	namespace algorithm{
 
 		
-		template<typename StartSystemT, typename RealType, typename ComplexType, typename MetaDataType>
+		template<typename RealType, typename ComplexType, typename MetaDataType>
 		struct MidpathChecker : public detail::Configured<config::MidPath<RealType>>
 		{
 			using MidPathConfT = config::MidPath<RealType>;
@@ -50,18 +50,17 @@ namespace bertini{
 			using BoundaryData = SolnCont< MetaDataType >;
 			using PathIndT = unsigned long long;
 			
+
+			MidpathChecker() = default;
+
 			/**
 			\brief Construct a MidpathChecker, given the system it is checking, and the tolerance which should be used to tell whether two points are the same.  
 
 			\note The tolerance should be *lower* than the tracking tolerance used to compute these points.
 			*/
 			template<typename ...T>
-			MidpathChecker( StartSystemT start_system, T const& ...config) : AlgConf(config...)
+			MidpathChecker( T const& ...config) : AlgConf(config...)
 			{
-				// boundary_same_point_tolerance_ = tol;
-				
-				start_system_ = start_system;
-				
 				passed_ = true;
 			}
 			
@@ -130,62 +129,67 @@ namespace bertini{
 			 \returns A Data object which stores data about crossed paths
 			 
 			*/
-			bool Check(BoundaryData const& boundary_data)
+			template <typename StartSystemT>
+			bool Check(BoundaryData const& boundary_data, StartSystemT const& start_system)
 			{
 				for (PathIndT ii = 0; ii < boundary_data.size(); ++ii)
 				{
+					if ( boundary_data[ii].success_code != tracking::SuccessCode::Success)
+							continue;
+
 					const Vec<ComplexType>& solution_ii = boundary_data[ii].path_point;
-										
+					const auto start_ii = start_system.template StartPoint<ComplexType>(ii);
+
 					for (PathIndT jj = ii+1; jj < boundary_data.size(); ++jj)
 					{
-						if ( boundary_data[ii].success_code == tracking::SuccessCode::Success)
+						if ( boundary_data[jj].success_code != tracking::SuccessCode::Success)
+							continue;
+
+						const Vec<ComplexType>& solution_jj = boundary_data[jj].path_point;
+						const Vec<ComplexType> diff_sol = solution_ii - solution_jj;
+						
+						if ((diff_sol.template lpNorm<Eigen::Infinity>()/solution_ii.template lpNorm<Eigen::Infinity>()) < SamePointTol())
 						{
-							const Vec<ComplexType>& solution_jj = boundary_data[jj].path_point;
-							const Vec<ComplexType> diff_sol = solution_ii - solution_jj;
+							bool i_already_stored = false;
+							bool j_already_stored = false;
+							// Check if start points are the same
 							
-							if ((diff_sol.template lpNorm<Eigen::Infinity>()/solution_ii.template lpNorm<Eigen::Infinity>()) < SamePointTol())
+							const auto start_jj = start_system.template StartPoint<ComplexType>(jj);
+							auto diff_start = start_ii - start_jj;
+							bool same_start = (diff_start.template lpNorm<Eigen::Infinity>() > SamePointTol());
+							
+							
+							// Check if path has already been stored in crossed_paths_
+							for(auto& v : crossed_paths_)
 							{
-								bool i_already_stored = false;
-								bool j_already_stored = false;
-								// Check if start points are the same
-								const auto& start_ii = start_system_.template StartPoint<ComplexType>(ii);
-								const auto& start_jj = start_system_.template StartPoint<ComplexType>(jj);
-								auto diff_start = start_ii - start_jj;
-								bool same_start = (diff_start.norm() > SamePointTol());
-								
-								
-								// Check if path has already been stored in crossed_paths_
-								for(auto& v : crossed_paths_)
+								if(v.index() == ii)
 								{
-									if(v.index() == ii)
-									{
-										v.crossed_with(std::make_pair(jj,same_start));
-										i_already_stored = true;
-										v.rerun(same_start);
-									}
-									if(v.index() == jj)
-									{
-										v.crossed_with(std::make_pair(ii,same_start));
-										j_already_stored = true;
-										v.rerun(same_start);
-									}
+									v.crossed_with(std::make_pair(jj,same_start));
+									i_already_stored = true;
+									v.rerun(same_start);
 								}
-								
-								// If not already stored, create CrossedPath object and add to crossed_paths_
-								if(!i_already_stored)
+								if(v.index() == jj)
 								{
-									CrossedPath tempPath(ii, jj, same_start);
-									crossed_paths_.push_back(tempPath);
+									v.crossed_with(std::make_pair(ii,same_start));
+									j_already_stored = true;
+									v.rerun(same_start);
 								}
-								if(!j_already_stored)
-								{
-									CrossedPath tempPath(jj, ii, same_start);
-									crossed_paths_.push_back(tempPath);
-								}
-								
-								passed_ = false;
-								
 							}
+							
+							// If not already stored, create CrossedPath object and add to crossed_paths_
+							if(!i_already_stored)
+							{
+								CrossedPath tempPath(ii, jj, same_start);
+								crossed_paths_.push_back(tempPath);
+							}
+							if(!j_already_stored)
+							{
+								CrossedPath tempPath(jj, ii, same_start);
+								crossed_paths_.push_back(tempPath);
+							}
+							
+							passed_ = false;
+							
 						}
 					}
 				}
@@ -193,7 +197,7 @@ namespace bertini{
 			};
 			
 			
-			std::vector<CrossedPath> GetCrossedPaths()
+			const std::vector<CrossedPath> GetCrossedPaths() const
 			{
 				return crossed_paths_;
 			}
@@ -201,8 +205,6 @@ namespace bertini{
 			
 			
 		private:
-			// RealType boundary_same_point_tolerance_;
-			StartSystemT start_system_;
 			
 			std::vector<CrossedPath> crossed_paths_; // Data for all paths that crossed on last check
 			bool passed_;  // Did the check pass?

--- a/core/include/bertini2/nag_algorithms/output.hpp
+++ b/core/include/bertini2/nag_algorithms/output.hpp
@@ -1,0 +1,225 @@
+//This file is part of Bertini 2.
+//
+//bertini2/nag_algorithms/output.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/nag_algorithms/output.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/nag_algorithms/output.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license, 
+// as well as COPYING.  Bertini2 is provided with permitted 
+// additional terms in the b2/licenses/ directory.
+
+
+/**
+\file bertini2/nag_algorithms/output.hpp 
+
+\brief Provides some outputting classes for printing results of running algorithms
+
+You can also provide your own, that's the point of these policies.
+*/
+
+#pragma once
+
+#include "bertini2/nag_algorithms/zero_dim_solve.hpp"
+#include "bertini2/io/generators.hpp"
+
+
+namespace bertini {
+namespace algorithm {
+namespace output {
+
+/**
+\brief Prints data from algorithms
+*/
+template <typename AlgoT>
+struct Outputter
+{ };
+
+
+template <typename ...T>
+struct Classic
+{};
+
+
+template <typename A, typename B, typename C, typename D, template<typename, typename> class E>
+struct Classic <ZeroDim<A,B,C,D,E>>
+{
+	using ZDT = ZeroDim<A,B,C,D,E>;
+
+	template <typename OutT>
+	static
+	void All(OutT & out, ZDT const& zd)
+	{
+		out << "\n\n\n MAINDATA \n\n\n";
+		MainData(out, zd);
+
+		out << "\n\n\n RAWDATA \n\n\n";
+		RawData(out, zd);
+	}
+
+	
+	template <typename OutT>
+	static
+	void MainData(OutT & out, ZDT const& zd)
+	{
+		NumVariables(out, zd);
+		Variables(out, zd,"\n\n");
+
+		const auto& s = zd.FinalSolutions();
+		const auto& m = zd.FinalSolutionMetadata();
+		const auto n = s.size();
+		for (decltype(s.size()) ii{0}; ii<n; ++ii)
+		{
+			if (zd.FinalSolutionMetadata()[ii].endgame_success == tracking::SuccessCode::NeverStarted)
+				continue;
+			
+			EndPointMDFull(ii, out, zd);
+			EndPoint(ii, out, zd,"\n\n");
+		}
+
+		out << "\n\n";
+		TargetSystem(out,zd,"\n\n");
+
+		StartSystem(out,zd,"\n\n");
+
+		Homotopy(out,zd,"\n\n");
+	}
+
+	template <typename OutT>
+	static 
+	void RawData(OutT & out, ZDT const& zd)
+	{
+		const auto n = zd.FinalSolutions().size();
+		NumVariables(out, zd,"\n\n");
+		for (decltype(zd.FinalSolutions().size()) ii{0}; ii<n; ++ii)
+		{
+			if (zd.FinalSolutionMetadata()[ii].endgame_success == tracking::SuccessCode::NeverStarted)
+				continue;
+			EndPointMDRaw(ii,out,zd,"\n\n");
+		}
+
+		out << "\n\n";
+		TargetSystem(out,zd,"\n\n");
+	}
+
+
+	template <typename OutT>
+	static 
+	void NumVariables(OutT & out, ZDT const& zd, std::string const& additional = "\n")
+	{
+		const auto& sys = zd.TargetSystem();
+		out << sys.NumVariables() << additional;
+	}
+
+
+	template <typename OutT>
+	static 
+	void Variables(OutT & out, ZDT const& zd, std::string const& additional = "\n")
+	{
+		const auto& sys = zd.TargetSystem();
+		const auto& vars = sys.VariableOrdering();
+		for (const auto& x : vars)
+			out << *x << ' ';
+		out << additional;
+	}
+
+
+	template <typename OutT>
+	static 
+	void TargetSystem(OutT & out, ZDT const& zd, std::string const& additional = "\n")
+	{
+		out << zd.TargetSystem() << additional;
+	}
+
+	template <typename OutT>
+	static 
+	void StartSystem(OutT & out, ZDT const& zd, std::string const& additional = "\n")
+	{
+		out << zd.StartSystem() << additional;
+	}
+
+	template <typename OutT>
+	static 
+	void Homotopy(OutT & out, ZDT const& zd, std::string const& additional = "\n")
+	{
+		out << zd.Homotopy() << additional;
+	}
+
+	template <typename IndexT, typename OutT>
+	static
+	void EndPoint(IndexT const& ind, OutT & out, ZDT const& zd, std::string const& additional = "")
+	{	
+		generators::Classic::generate(boost::spirit::ostream_iterator(out), zd.FinalSolutions()[ind]);
+		out << additional;
+	}
+
+	template <typename IndexT, typename OutT>
+	static
+	void EndPointDehom(IndexT const& ind, OutT & out, ZDT const& zd, std::string const& additional = "")
+	{	
+		DefaultPrecision(Precision(zd.FinalSolutions()[ind]));
+
+		generators::Classic::generate(boost::spirit::ostream_iterator(out), zd.TargetSystem().DehomogenizePoint(zd.FinalSolutions()[ind]));
+		out << additional;
+	}
+
+	template <typename IndexT, typename OutT>
+	static
+	void EndPointMDFull(IndexT const& ind, OutT & out, ZDT const& zd, std::string const& additional = "\n")
+	{
+		const auto& data = zd.FinalSolutionMetadata()[ind];
+		out << data.path_index << '\n'
+			<< data.solution_index << '\n'
+			<< data.condition_number << '\n'
+			<< data.function_residual << '\n'
+			<< data.newton_residual << '\n';
+		generators::Classic::generate(boost::spirit::ostream_iterator(out), data.final_time_used);
+		out << '\n' << data.max_precision_used << '\n';
+
+		generators::Classic::generate(boost::spirit::ostream_iterator(out), data.time_of_first_prec_increase);
+		out << '\n' << data.accuracy_estimate << '\n'
+			<< data.accuracy_estimate_user_coords << '\n'
+			<< data.cycle_num << '\n'
+			<< data.multiplicity << '\n'
+			<< data.pre_endgame_success << ' ' << data.endgame_success << '\n';
+		out << additional;
+	}
+
+
+
+	template <typename IndexT, typename OutT>
+	static
+	void EndPointMDRaw(IndexT const& ind, OutT & out, ZDT const& zd, std::string const& additional = "\n")
+	{
+		const auto& pt = zd.FinalSolutions()[ind];
+		const auto& data = zd.FinalSolutionMetadata()[ind];
+		out << data.path_index << '\n'
+			<< Precision(pt) << '\n';
+		EndPoint(ind, out, zd);
+		out << data.function_residual << '\n'
+			<< data.condition_number << '\n'
+			<< data.newton_residual << '\n';
+		generators::Classic::generate(boost::spirit::ostream_iterator(out), data.final_time_used);
+		out << '\n' << data.accuracy_estimate << '\n';
+		generators::Classic::generate(boost::spirit::ostream_iterator(out), data.time_of_first_prec_increase);
+		out << '\n' << data.cycle_num << '\n'
+			<< data.endgame_success << '\n'
+			<< additional;
+	}
+
+
+};
+
+} // namespace output
+} // namespace algorithm
+} // namespace bertini

--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -15,17 +15,18 @@
 //
 // Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
-// See <http://www.gnu.org/licenses/> for a copy of the license, 
-// as well as COPYING.  Bertini2 is provided with permitted 
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
 // additional terms in the b2/licenses/ directory.
 
 
 /**
-\file bertini2/nag_algorithms/zero_dim_solve/algorithm.hpp 
+\file bertini2/nag_algorithms/zero_dim_solve/algorithm.hpp
 
-\brief Provides the algorithm for computing all zero-dimensional solutions for an algberaic system.  
+\brief Provides the algorithm for computing all zero-dimensional solutions for an algberaic system.
 */
 
+#pragma once
 
 #include "bertini2/num_traits.hpp"
 
@@ -38,48 +39,77 @@
 
 #include "bertini2/nag_algorithms/common/config.hpp"
 #include "bertini2/nag_algorithms/common/policies.hpp"
+#include <chrono>
+
 
 namespace bertini {
 
 	namespace algorithm {
 
-		template<	typename TrackerType, typename EndgameType, 
-					typename SystemType, typename StartSystemType, 
-					template<typename,typename> class SystemManagementP = policy::CloneGiven >
-		struct ZeroDim : 
-							public Observable<>, 
+
+/**
+forward declare of ZeroDim algorithm
+*/
+template<	typename TrackerType, typename EndgameType,
+			typename SystemType, typename StartSystemType,
+			template<typename,typename> class SystemManagementP = policy::CloneGiven >
+struct ZeroDim;
+
+
+
+/**
+specify the traits for the algorithm.  this is why we need the forward declare
+*/
+template<typename TrackerType, typename EndgameType,
+			typename SystemType, typename StartSystemType,
+			template<typename,typename> class SystemManagementP>
+struct AlgoTraits <ZeroDim<TrackerType, EndgameType, SystemType, StartSystemType, SystemManagementP>>
+{
+	using BaseRealType = typename tracking::TrackerTraits<TrackerType>::BaseRealType;
+	using BaseComplexType = typename tracking::TrackerTraits<TrackerType>::BaseComplexType;
+
+	using NeededConfigs = detail::TypeList<
+								config::Tolerances<BaseRealType>,
+								config::PostProcessing<BaseRealType>,
+								config::ZeroDim<BaseComplexType>,
+								config::AutoRetrack<BaseRealType>
+								>;
+};
+
+
+
+/**
+\brief the basic zero dim algorithm, which solves a system.
+*/
+		template<	typename TrackerType, typename EndgameType,
+					typename SystemType, typename StartSystemType,
+					template<typename,typename> class SystemManagementP>
+		struct ZeroDim :
+							public Observable<>,
 							public SystemManagementP<SystemType, StartSystemType>,
 							public detail::Configured<
-								config::Tolerances<typename tracking::TrackerTraits<TrackerType>::BaseRealType>,
-								config::PostProcessing<typename tracking::TrackerTraits<TrackerType>::BaseRealType>,
-								config::ZeroDim<typename tracking::TrackerTraits<TrackerType>::BaseComplexType>,
-								config::AutoRetrack<typename tracking::TrackerTraits<TrackerType>::BaseRealType>>
+								typename AlgoTraits< ZeroDim<TrackerType, EndgameType, SystemType, StartSystemType, SystemManagementP>>::NeededConfigs>
 		{
 			BERTINI_DEFAULT_VISITABLE();
 
 /// a bunch of using statements to reduce typing.
 			using BaseComplexType 	= typename tracking::TrackerTraits<TrackerType>::BaseComplexType;
 			using BaseRealType    	= typename tracking::TrackerTraits<TrackerType>::BaseRealType;
-			
+
 			using PrecisionConfig 	= typename tracking::TrackerTraits<TrackerType>::PrecisionConfig;
 
 			using SolnIndT 			= typename SolnCont<BaseComplexType>::size_type;
-			
-			
+
+
 
 			using SystemManagementPolicy = SystemManagementP<SystemType, StartSystemType>;
 
 			using StoredSystemT = typename SystemManagementPolicy::StoredSystemT;
 			using StoredStartSystemT = typename SystemManagementPolicy::StoredStartSystemT;
 
-// this one is atrocious.  sorry.
-			// todo: factor out these configs into something traits-based
-			using Config = detail::Configured<
-								config::Tolerances<typename tracking::TrackerTraits<TrackerType>::BaseRealType>,
-								config::PostProcessing<typename tracking::TrackerTraits<TrackerType>::BaseRealType>,
-								config::ZeroDim<typename tracking::TrackerTraits<TrackerType>::BaseComplexType>,
-								config::AutoRetrack<typename tracking::TrackerTraits<TrackerType>::BaseRealType>>;
 
+			using Config = detail::Configured<
+								typename AlgoTraits<ZeroDim<TrackerType, EndgameType, SystemType, StartSystemType, SystemManagementP>>::NeededConfigs>;
 			using Config::Get;
 
 
@@ -87,7 +117,6 @@ namespace bertini {
 			using PostProcessing = config::PostProcessing<BaseRealType>;
 			using ZeroDimConf = config::ZeroDim<BaseComplexType>;
 			using AutoRetrack = config::AutoRetrack<BaseRealType>;
-
 
 /// metadata structs
 
@@ -110,17 +139,15 @@ namespace bertini {
 				SolnIndT path_index;     		// path number of the solution
 				SolnIndT solution_index;      	// solution number
 
-
-
 				///// things computed across all of the solve
 				bool precision_changed = false;
 				BaseComplexType time_of_first_prec_increase;    // time value of the first increase in precision
-
+				decltype(DefaultPrecision()) max_precision_used = 0;
 
 
 
 				///// things computed in pre-endgame only
-				tracking::SuccessCode pre_endgame_success;     // success code 
+				tracking::SuccessCode pre_endgame_success = tracking::SuccessCode::NeverStarted;     // success code
 
 
 
@@ -128,11 +155,12 @@ namespace bertini {
 
 				///// things computed in endgame only
 				BaseRealType condition_number; 				// the latest estimate on the condition number
-				BaseRealType newton_residual; 				// the latest newton residual 
+				BaseRealType newton_residual; 				// the latest newton residual
 				BaseComplexType final_time_used;   			// the final value of time tracked to
 				BaseRealType accuracy_estimate; 			// accuracy estimate between extrapolations
+				BaseRealType accuracy_estimate_user_coords;	// accuracy estimate between extrapolations, in natural coordinates
 				unsigned cycle_num;    						// cycle number used in extrapolations
-				tracking::SuccessCode endgame_success;      // success code 
+				tracking::SuccessCode endgame_success = tracking::SuccessCode::NeverStarted;      // success code
 
 
 
@@ -140,7 +168,7 @@ namespace bertini {
 				///// things added by post-processing
 				BaseRealType function_residual; 	// the latest function residual
 
-				int multiplicity; 		// multiplicity
+				int multiplicity = 1; 		// multiplicity
 				bool is_real;       		// real flag:  0 - not real, 1 - real
 				bool is_finite;     		// finite flag: -1 - no finite/infinite distinction, 0 - infinite, 1 - finite
 				bool is_singular;       		// singular flag: 0 - non-sigular, 1 - singular
@@ -150,15 +178,22 @@ namespace bertini {
 			struct EGBoundaryMetaData
 			{
 				Vec<BaseComplexType> path_point;
-				tracking::SuccessCode success_code;
+				tracking::SuccessCode success_code = tracking::SuccessCode::NeverStarted;
 				BaseRealType last_used_stepsize;
+
+				EGBoundaryMetaData() = default;
+				EGBoundaryMetaData(EGBoundaryMetaData const&) = default;
+				EGBoundaryMetaData(Vec<BaseComplexType> const& pt, tracking::SuccessCode const& code, BaseRealType const& ss) :
+					path_point(pt), success_code(code), last_used_stepsize(ss)
+				{}
+					
 			};
 
 
 
 // a few more using statements
 
-			using MidpathT 			= MidpathChecker<StartSystemType, BaseRealType, BaseComplexType, EGBoundaryMetaData>;
+			using MidpathType = MidpathChecker<BaseRealType, BaseComplexType, EGBoundaryMetaData>;
 
 			using SystemManagementPolicy::TargetSystem;
 			using SystemManagementPolicy::StartSystem;
@@ -166,11 +201,11 @@ namespace bertini {
 
 
 
-/// constructors 
+/// constructors
 
 			/**
 			Construct a ZeroDim algorithm object.
-			
+
 			You must at least pass in the system used to track, though the particular arguments required depend on the policies used in your instantiation of ZeroDim.
 
 			\see RefToGiven, CloneGiven
@@ -184,7 +219,7 @@ namespace bertini {
 
 
 
-			
+
 /// setup functions
 
 
@@ -208,7 +243,7 @@ namespace bertini {
 			void DefaultSetup()
 			{
 				DefaultSettingsSetup();
-				
+
 
 				SystemManagementPolicy::SystemSetup(this->template Get<ZeroDimConf>().path_variable_name);
 
@@ -216,12 +251,12 @@ namespace bertini {
 
 				DefaultTrackerSetup();
 				DefaultMidpathSetup();
-				
+
 				setup_complete_ = true;
 			}
 
 
-			
+
 			/**
 			Fills the tolerances and retrack settings from default values.
 			*/
@@ -232,7 +267,7 @@ namespace bertini {
 				this->template Set<ZeroDimConf>(ZeroDimConf());
 				this->template Set<AutoRetrack>(AutoRetrack());
 
-				SetMidpathRetrackTol(this->template Get<Tolerances>().newton_before_endgame);	
+				SetMidpathRetrackTol(this->template Get<Tolerances>().newton_before_endgame);
 			}
 
 			void SetMidpathRetrackTol(BaseRealType const& rt)
@@ -245,19 +280,19 @@ namespace bertini {
 				return midpath_retrack_tolerance_;
 			}
 
-			
+
 			/**
 			call this after setting up the tolerances, etc.
 			*/
 			void DefaultMidpathSetup()
 			{
-				midpath_ = std::make_shared<MidpathT>(StartSystem(), config::MidPath<BaseRealType>());
+				midpath_ = MidpathType(config::MidPath<BaseRealType>());
 			}
 
 
 			void SetMidpath(config::MidPath<BaseRealType> const& mp)
 			{
-				midpath_->Set(mp);
+				midpath_.Set(mp);
 			}
 
 			/**
@@ -267,12 +302,12 @@ namespace bertini {
 			*/
 			void DefaultTrackerSetup()
 			{
-				tracker_ = TrackerType(Homotopy());
+				tracker_.SetSystem(Homotopy());
 				tracker_.Setup(tracking::predict::DefaultPredictor(),
-				              	this->template Get<Tolerances>().newton_before_endgame, 
+				              	this->template Get<Tolerances>().newton_before_endgame,
 				              	this->template Get<Tolerances>().path_truncation_threshold,
 								tracking::config::Stepping<BaseRealType>(), tracking::config::Newton());
-				
+
 				tracker_.PrecisionSetup(PrecisionConfig(Homotopy()));
 			}
 
@@ -280,7 +315,11 @@ namespace bertini {
 			/**
 			\brief Sets the tracker to one you supply to this function.
 
+			Setting the tracker associates the endgame with the tracker you pass in, too.  If this is a problem, and you need this generalized so you can use a different tracker for the pre/endgame zones, please file an issue requesting this feature.
+
 			Assumes you have done all necessary setup to it, including associating it with the homotopy for the ZeroDim algorithm.
+
+			Again, YOU must ensure the tracker is associated with the correct homotopy
 			*/
 			void SetTracker(TrackerType const& new_tracker)
 			{
@@ -289,15 +328,24 @@ namespace bertini {
 			}
 
 			/**
-			\brief Sets the tracker to one you supply to this function.
+			\brief Gets the tracker
 
-			Assumes you have done all necessary setup to it, including associating it with the homotopy for the ZeroDim algorithm.
+			This version gets a const reference to it.
 			*/
 			const TrackerType & GetTracker() const
 			{
 				return tracker_;
 			}
 
+			/**
+			\brief Gets the tracker
+
+			This version gets a mutable reference to it.
+			*/
+			TrackerType & GetTracker()
+			{
+				return tracker_;
+			}
 
 
 ///  endgame specific stuff
@@ -314,9 +362,19 @@ namespace bertini {
 			}
 
 			/**
-			\brief Sets the endgame to one you supply to this function.
+			\brief Gets the endgame
 
-			Assumes you have done all necessary setup to it, including associating it with the homotopy for the ZeroDim algorithm.
+			This version gets a `const` reference to it.
+			*/
+			const EndgameType & GetEndgame() const
+			{
+				return endgame_;
+			}
+
+			/**
+			\brief Gets the endgame
+
+			This version gets a mutable reference to it.
 			*/
 			EndgameType & GetEndgame()
 			{
@@ -328,13 +386,13 @@ namespace bertini {
 			const T & GetFromEndgame() const
 			{
 				return endgame_.template Get<T>();
-			} 
+			}
 
 			template<typename T>
 			void SetToEndgame(T const& t)
 			{
 				endgame_.Set(t);
-			} 
+			}
 
 /// the main functions
 
@@ -343,45 +401,66 @@ namespace bertini {
 			/**
 			\brief Perform the basic Zero Dim solve algorithm.
 
-			This function iterates over all start points to the start system, tracking from each to the endgame boundary.  At the endgame boundary, path crossings are checked for.  Multiple paths which jump onto each other will not be detected, unless you are using a certified tracker, in which case this is prevented in the first place.  
+			This function iterates over all start points to the start system, tracking from each to the endgame boundary.  At the endgame boundary, path crossings are checked for.  Multiple paths which jump onto each other will not be detected, unless you are using a certified tracker, in which case this is prevented in the first place.
 
-			Paths which have crossed are re-run, up to a certain number of times. 
+			Paths which have crossed are re-run, up to a certain number of times.
 
-			Then, the points at the endgame boundary are tracked using the prescribed endgame toward the final time.  
+			Then, the points at the endgame boundary are tracked using the prescribed endgame toward the final time.
 
-			Finally, results are post-processed. 
+			Finally, results are post-processed.
 
 			It is up to you to put the output somewhere.
 			*/
 			void Solve()
 			{
 				PreSolveChecks();
-				
+
 				PreSolveSetup();
-			
+
 				TrackBeforeEG();
 
 				EGBoundaryAction();
 
 				TrackDuringEG();
-				
-				ComputePostTrackMetadata();
+
+				PostEGAction();
 			}
+
+
 
 			/**
-			\brief Outputs the finalized solutions to a target destination
+			\brief Checks whether the algorithm is ready to rock and roll.
 			*/
-			template<class GeneratorT = generators::Classic>
-			void Output() const
-			{
-				
-			}
-
 			bool IsSetupComplete() const
 			{
 				return setup_complete_;
 			}
 
+
+
+			/**
+			\brief Get the final computed solutions
+			*/
+			const auto& FinalSolutions() const
+			{
+				return solutions_post_endgame_;
+			}
+
+			/**
+			\brief Get the metadat associated with the final computed solutions
+			*/
+			const auto& FinalSolutionMetadata() const
+			{
+				return solution_final_metadata_;
+			}
+
+			/**
+			\brief Get the solutions as computed at the endgame boundary
+			*/
+			const auto& EndgameBoundaryData() const
+			{
+				return solutions_at_endgame_boundary_;
+			}
 
 		private:
 
@@ -402,13 +481,13 @@ namespace bertini {
 			{
 				auto num_as_size_t = static_cast<SolnIndT>(num_start_points_);
 
-				solution_metadata_.resize(num_as_size_t);
+				solution_final_metadata_.resize(num_as_size_t);
 				solutions_at_endgame_boundary_.resize(num_as_size_t);
-				endgame_solutions_.resize(num_as_size_t);
+				solutions_post_endgame_.resize(num_as_size_t);
 			}
 
 			/**
-			\brief Track from the start point in time, from each start point of the start system, to the endgame boundary.  
+			\brief Track from the start point in time, from each start point of the start system, to the endgame boundary.
 
 			Results are accumulated into an internally stored variable, solutions_at_endgame_boundary_.
 
@@ -418,7 +497,7 @@ namespace bertini {
 			{
 				DefaultPrecision(this->template Get<ZeroDimConf>().initial_ambient_precision);
 
-				tracker_.SetTrackingTolerance(this->template Get<Tolerances>().newton_before_endgame);
+				GetTracker().SetTrackingTolerance(this->template Get<Tolerances>().newton_before_endgame);
 
 				auto t_start = this->template Get<ZeroDimConf>().start_time;
 				auto t_endgame_boundary = this->template Get<ZeroDimConf>().endgame_boundary;
@@ -428,68 +507,76 @@ namespace bertini {
 					TrackSinglePathBeforeEG(static_cast<SolnIndT>(ii));
 				}
 			}
-			
-			
-			
+
+
+
 			/**
 			 /brief Track a single path before we reach the endgame boundary.
 			*/
 			void TrackSinglePathBeforeEG(SolnIndT soln_ind)
 			{
-				// if you can think of a way to replace this `if` with something meta, please do so.
-				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-				{
-					tracker_.AddObserver(&first_prec_rec_);
-					tracker_.AddObserver(&min_max_prec_);
-				}
+					// if you can think of a way to replace this `if` with something meta, please do so.
+					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+					{
+						GetTracker().AddObserver(&first_prec_rec_);
+						GetTracker().AddObserver(&min_max_prec_);
+					}
 
+					auto& smd = solution_final_metadata_[soln_ind];
+
+					smd.path_index = soln_ind;
+					smd.solution_index = soln_ind;
 
 				DefaultPrecision(this->template Get<ZeroDimConf>().initial_ambient_precision);
 				auto t_start = this->template Get<ZeroDimConf>().start_time;
 				auto t_endgame_boundary = this->template Get<ZeroDimConf>().endgame_boundary;
 				auto start_point = StartSystem().template StartPoint<BaseComplexType>(soln_ind);
-				
-				Vec<BaseComplexType> result;
-				auto tracking_success = tracker_.TrackPath(result, t_start, t_endgame_boundary, start_point);
-				
-				solutions_at_endgame_boundary_[soln_ind] = EGBoundaryMetaData({ result, tracking_success, tracker_.CurrentStepsize() });
-				
-				solution_metadata_[soln_ind].pre_endgame_success = tracking_success;
-				
-				// if you can think of a way to replace this `if` with something meta, please do so.
-				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-				{
-					if (first_prec_rec_.DidPrecisionIncrease())
-					{
-						solution_metadata_[soln_ind].precision_changed = true;
-						solution_metadata_[soln_ind].time_of_first_prec_increase = first_prec_rec_.TimeOfIncrease();
-					}
-					tracker_.RemoveObserver(&first_prec_rec_);
-					tracker_.RemoveObserver(&min_max_prec_);
-				}
 
-			
+				Vec<BaseComplexType> result;
+				auto tracking_success = GetTracker().TrackPath(result, t_start, t_endgame_boundary, start_point);
+
+				solutions_at_endgame_boundary_[soln_ind] = EGBoundaryMetaData({ result, tracking_success, GetTracker().CurrentStepsize() });
+
+					smd.pre_endgame_success = tracking_success;
+
+					// if you can think of a way to replace this `if` with something meta, please do so.
+					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+					{
+						if (first_prec_rec_.DidPrecisionIncrease())
+						{
+							smd.precision_changed = true;
+							smd.time_of_first_prec_increase = first_prec_rec_.TimeOfIncrease();
+						}
+						else
+						GetTracker().RemoveObserver(&first_prec_rec_);
+						GetTracker().RemoveObserver(&min_max_prec_);
+						using std::max;
+						smd.max_precision_used =
+							max(smd.max_precision_used, min_max_prec_.MaxPrecision());
+					}
+
+
 			}
 
 			void EGBoundaryAction()
 			{
-				auto midcheckpassed = midpath_->Check(solutions_at_endgame_boundary_);
-				
+				auto midcheckpassed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
+
 				unsigned num_resolve_attempts = 0;
 				while (!midcheckpassed && num_resolve_attempts < this->template Get<ZeroDimConf>().max_num_crossed_path_resolve_attempts)
 				{
 					MidpathResolve();
-					midcheckpassed = midpath_->Check(solutions_at_endgame_boundary_);
+					midcheckpassed = midpath_.Check(solutions_at_endgame_boundary_, StartSystem());
 					num_resolve_attempts++;
 				}
 			}
 
-			
+
 			void MidpathResolve()
 			{
 				ShrinkMidpathTolerance();
-				
-				for(auto const& v : midpath_->GetCrossedPaths())
+
+				for(auto const& v : midpath_.GetCrossedPaths())
 				{
 					if(v.rerun())
 					{
@@ -505,7 +592,7 @@ namespace bertini {
 			void ShrinkMidpathTolerance()
 			{
 				midpath_retrack_tolerance_ *= this->template Get<AutoRetrack>().midpath_decrease_tolerance_factor;
-				tracker_.SetTrackingTolerance(midpath_retrack_tolerance_);
+				GetTracker().SetTrackingTolerance(midpath_retrack_tolerance_);
 			}
 
 
@@ -513,13 +600,13 @@ namespace bertini {
 			void TrackDuringEG()
 			{
 
-				tracker_.SetTrackingTolerance(this->template Get<Tolerances>().newton_during_endgame);
+				GetTracker().SetTrackingTolerance(this->template Get<Tolerances>().newton_during_endgame);
 
 				for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
 				{
 					auto soln_ind = static_cast<SolnIndT>(ii);
 
-					if (solution_metadata_[soln_ind].pre_endgame_success != tracking::SuccessCode::Success)
+					if (solution_final_metadata_[soln_ind].pre_endgame_success != tracking::SuccessCode::Success)
 						continue;
 
 					TrackSinglePathDuringEG(soln_ind);
@@ -529,48 +616,76 @@ namespace bertini {
 
 			void TrackSinglePathDuringEG(SolnIndT soln_ind)
 			{
-				// if you can think of a way to replace this `if` with something meta, please do so.
-				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-				{
-					if (!first_prec_rec_.DidPrecisionIncrease())
+
+					auto& smd = solution_final_metadata_[soln_ind];
+					// if you can think of a way to replace this `if` with something meta, please do so.
+					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
 					{
-						tracker_.AddObserver(&first_prec_rec_);
-						tracker_.AddObserver(&min_max_prec_);
+						if (!smd.precision_changed)
+							GetTracker().AddObserver(&first_prec_rec_);
+						GetTracker().AddObserver(&min_max_prec_);
 					}
-				}
 
 				const auto& bdry_point = solutions_at_endgame_boundary_[soln_ind].path_point;
 
 
-				tracker_.SetStepSize(solutions_at_endgame_boundary_[soln_ind].last_used_stepsize);
-				tracker_.ReinitializeInitialStepSize(false);
+				GetTracker().SetStepSize(solutions_at_endgame_boundary_[soln_ind].last_used_stepsize);
+				GetTracker().ReinitializeInitialStepSize(false);
 
 				DefaultPrecision(Precision(bdry_point));
 				// we make these fresh so they are in the correct precision to start.
-				auto t_end = this->template Get<ZeroDimConf>().target_time;
-				auto t_endgame_boundary = this->template Get<ZeroDimConf>().endgame_boundary;
+				BaseComplexType t_end = this->template Get<ZeroDimConf>().target_time;
+				BaseComplexType t_endgame_boundary = this->template Get<ZeroDimConf>().endgame_boundary;
 
-				tracking::SuccessCode endgame_success = GetEndgame().Run(BaseComplexType(t_endgame_boundary),bdry_point, t_end);
+				auto eg_success = GetEndgame().Run(t_endgame_boundary, bdry_point, t_end);
+
+				solutions_post_endgame_[soln_ind] = GetEndgame().template FinalApproximation<BaseComplexType>();
 
 
-				// if you can think of a way to replace this `if` with something meta, please do so.
-				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-				{
-					if (first_prec_rec_.DidPrecisionIncrease())
+					// finally, store the metadata as necessary
+					smd.endgame_success = eg_success;
+						// if you can think of a way to replace this `if` with something meta, please do so.
+					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
 					{
-						solution_metadata_[soln_ind].precision_changed = true;
-						solution_metadata_[soln_ind].time_of_first_prec_increase = first_prec_rec_.TimeOfIncrease();
+						if (!smd.precision_changed)
+						{
+							if (first_prec_rec_.DidPrecisionIncrease())
+							{
+								smd.precision_changed = true;
+								smd.time_of_first_prec_increase = first_prec_rec_.TimeOfIncrease();
+							}
+						}
+						GetTracker().RemoveObserver(&first_prec_rec_);
+						GetTracker().RemoveObserver(&min_max_prec_);
+						using std::max;
+						smd.max_precision_used =
+							max(smd.max_precision_used, min_max_prec_.MaxPrecision());
 					}
-					tracker_.RemoveObserver(&first_prec_rec_);
-					tracker_.RemoveObserver(&min_max_prec_);
-				}
+					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
+					{
+						assert(Precision(solutions_post_endgame_[soln_ind])==Precision(GetEndgame().template FinalApproximation<BaseComplexType>()));
+						DefaultPrecision(Precision(solutions_post_endgame_[soln_ind]));
+						TargetSystem().precision(Precision(solutions_post_endgame_[soln_ind]));
+					}
+					smd.function_residual = TargetSystem().Eval(solutions_post_endgame_[soln_ind]).template lpNorm<Eigen::Infinity>();
+					smd.final_time_used = GetEndgame().LatestTime();
+					smd.condition_number = GetTracker().LatestConditionNumber();
+					smd.newton_residual = GetTracker().LatestNormOfStep();
 
-				// finally, store the metadata as necessary
-				solution_metadata_[soln_ind].condition_number = tracker_.LatestConditionNumber();
-				endgame_solutions_[soln_ind] = GetEndgame().template FinalApproximation<BaseComplexType>();
+					smd.accuracy_estimate = GetEndgame().template ApproximateError<BaseRealType>();
+					smd.accuracy_estimate_user_coords =
+						(TargetSystem().DehomogenizePoint(solutions_post_endgame_[soln_ind]) -
+						TargetSystem().DehomogenizePoint(GetEndgame().template PreviousApproximation<BaseComplexType>())).template lpNorm<Eigen::Infinity>();
+					smd.cycle_num = GetEndgame().template CycleNumber();
+					// end metadata gathering
 			}
 
 
+
+			void PostEGAction()
+			{
+				ComputePostTrackMetadata();
+			}
 
 
 
@@ -581,15 +696,33 @@ namespace bertini {
 			*/
 			void ComputePostTrackMetadata()
 			{
-				for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
-				{
-					auto soln_ind = static_cast<SolnIndT>(ii);
-					DefaultPrecision(Precision(endgame_solutions_[soln_ind]));
-					TargetSystem().precision(Precision(endgame_solutions_[soln_ind]));
-					auto function_residuals = TargetSystem().Eval(endgame_solutions_[soln_ind]);
-				}
+				ComputeMultiplicities();
 			}
 
+			void ComputeMultiplicities()
+			{
+				std::vector<std::vector<int>> multiplicity_indices(num_start_points_);
+
+				for (decltype(num_start_points_) ii{0}; ii < num_start_points_; ++ii)
+				{
+					if (solution_final_metadata_[ii].endgame_success!=tracking::SuccessCode::Success)
+						continue;
+
+					for (decltype(num_start_points_) jj{ii+1}; jj < num_start_points_; ++jj)
+					{
+						if (solution_final_metadata_[jj].endgame_success!=tracking::SuccessCode::Success)
+							continue;
+
+						if ( (solutions_post_endgame_[ii] - solutions_post_endgame_[jj]).norm() < this->template Get<PostProcessing>().same_point_tolerance)
+						{
+							multiplicity_indices[ii].push_back(jj);
+							multiplicity_indices[jj].push_back(ii);
+							++solution_final_metadata_[ii].multiplicity;
+							++solution_final_metadata_[jj].multiplicity;
+						}
+					}
+				}
+			}
 
 
 
@@ -611,16 +744,16 @@ namespace bertini {
 			/// function objects used during the algorithm
 			TrackerType tracker_;
 			EndgameType endgame_;
-			std::shared_ptr<MidpathT> midpath_; /// remove shared_ptr plx.
+			MidpathType midpath_;
 
 
 
 			/// computed data
 			SolnCont< EGBoundaryMetaData > solutions_at_endgame_boundary_; // the BaseRealType is the last used stepsize
-			SolnCont<Vec<BaseComplexType> > endgame_solutions_;
-			SolnCont<SolutionMetaData> solution_metadata_;
+			SolnCont<Vec<BaseComplexType> > solutions_post_endgame_;
+			SolnCont<SolutionMetaData> solution_final_metadata_;
 
-			
+
 		}; // struct ZeroDim
 
 

--- a/core/include/bertini2/num_traits.hpp
+++ b/core/include/bertini2/num_traits.hpp
@@ -138,16 +138,16 @@ namespace bertini
 	For doubles, this is trivially 16.
 	*/
 	inline
-	unsigned Precision(const double num)
+	unsigned Precision(double)
 	{
-		return 16;
+		return DoublePrecision();
 	}
 
 	/**
 	For complex doubles, throw if the requested precision is not DoublePrecision.
 	*/
 	inline
-	void Precision(const double num, unsigned prec)
+	void Precision(double, unsigned prec)
 	{
 		if (prec!=DoublePrecision())
 		{
@@ -163,16 +163,16 @@ namespace bertini
 	For complex doubles, this is trivially 16.
 	*/
 	inline
-	unsigned Precision(const std::complex<double> num)
+	unsigned Precision(std::complex<double>)
 	{
-		return 16;
+		return DoublePrecision();
 	}
 
 	/**
 	For complex doubles, throw if the requested precision is not DoublePrecision.
 	*/
 	inline
-	void Precision(const std::complex<double> & num, unsigned prec)
+	void Precision(std::complex<double>, unsigned prec)
 	{
 		if (prec!=DoublePrecision())
 		{

--- a/core/include/bertini2/system/start/user.hpp
+++ b/core/include/bertini2/system/start/user.hpp
@@ -1,0 +1,101 @@
+//This file is part of Bertini 2.
+//
+//bertini2/system/start/user.hpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//bertini2/system/start/user.hpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with bertini2/system/start/user.hpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license, 
+// as well as COPYING.  Bertini2 is provided with permitted 
+// additional terms in the b2/licenses/ directory.
+
+// individual authors of this file include:
+// daniel brake, university of notre dame
+
+/**
+\file bertini2/system/start/user.hpp 
+
+\brief Defines the User-defined start system type.
+
+the user provided start system is merely their system, evaluated at the start time.
+*/
+
+#pragma once
+
+#include "bertini2/system/start_base.hpp"
+#include "bertini2/limbo.hpp"
+
+
+namespace bertini 
+{
+	namespace start_system{
+
+
+		/**
+		\brief The user-provided start system for Numerical Algebraic Geometry
+
+		
+		*/
+		class User : public StartSystem
+		{
+		public:
+			User() = default;
+			virtual ~User() = default;
+			
+			/**
+			 Constructor for making a user-provided start system from another.
+			*/
+			User(System const& s);
+
+
+			
+
+			/**
+			Get the number of start points for this start system.
+			*/
+			unsigned long long NumStartPoints() const override;
+
+			User& operator*=(Nd const& n);
+
+			User& operator+=(System const& sys) = delete;
+			
+		private:
+
+			/**
+			Get the ith start point, in double precision.
+
+			Called by the base StartSystem's StartPoint(index) method.
+			*/
+			Vec<dbl> GenerateStartPoint(dbl,unsigned long long index) const override;
+
+			/**
+			Get the ith start point, in current default precision.
+
+			Called by the base StartSystem's StartPoint(index) method.
+			*/
+			Vec<mpfr> GenerateStartPoint(mpfr,unsigned long long index) const override;
+
+
+			friend class boost::serialization::access;
+
+			template <typename Archive>
+			void serialize(Archive& ar, const unsigned version) {
+				ar & boost::serialization::base_object<StartSystem>(*this);
+			}
+
+		};
+	}
+}
+
+
+

--- a/core/include/bertini2/system/start_systems.hpp
+++ b/core/include/bertini2/system/start_systems.hpp
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "bertini2/system/start/total_degree.hpp"
-
+#include "bertini2/system/start/mhom.hpp"
+#include "bertini2/system/start/user.hpp"
 
 

--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with system.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license, 
 // as well as COPYING.  Bertini2 is provided with permitted 
@@ -89,6 +89,7 @@ namespace bertini {
 		/** 
 		\brief The copy operator, creates a system from a string using the Bertini parser for Bertini classic syntax.
 		*/
+		explicit
 		System(std::string const& input);
 		
 		/** 

--- a/core/include/bertini2/trackers/adaptive_precision_utilities.hpp
+++ b/core/include/bertini2/trackers/adaptive_precision_utilities.hpp
@@ -130,7 +130,9 @@ inline
 unsigned EnsureAtUniformPrecision(TimeCont<mpfr> & times, SampCont<mpfr> & samples)
 {
 	auto def_prec = DefaultPrecision();
-	if (std::any_of(begin(samples),end(samples),[=](auto const& p){return Precision(p)!=def_prec;}))
+	if (std::any_of(begin(times),end(times),[=](auto const& p){return Precision(p)!=def_prec;}) 
+		||
+		std::any_of(begin(samples),end(samples),[=](auto const& p){return Precision(p)!=def_prec;}))
 	{
 		auto max_precision = max(MaxPrecision(samples), MaxPrecision(times));
 

--- a/core/include/bertini2/trackers/base_tracker.hpp
+++ b/core/include/bertini2/trackers/base_tracker.hpp
@@ -132,14 +132,14 @@ namespace bertini{
 
 
 		*/
-		template<class D, typename... NeededTypes>
+		template<class D>
 		class Tracker : 
 			public Observable<>,
 			public detail::Configured<
-				config::Stepping<typename TrackerTraits<D>::BaseRealType>, config::Newton
+				typename TrackerTraits< D >::NeededConfigs
 					>
 		{
-
+			using NeededTypes = typename TrackerTraits< D >::NeededTypes;
 			using BaseComplexType = typename TrackerTraits<D>::BaseComplexType;
 			using BaseRealType = typename TrackerTraits<D>::BaseRealType;
 
@@ -148,12 +148,10 @@ namespace bertini{
 			
 			
 		public:
-			using Config = detail::Configured<
-				config::Stepping<typename TrackerTraits<D>::BaseRealType>, config::Newton
-					>;
-					
-			using Stepping = config::Stepping<typename TrackerTraits<D>::BaseRealType>;
+			using Config = detail::Configured< typename TrackerTraits< D >::NeededConfigs >;
+			using Stepping = config::Stepping<BaseRealType>;
 			using Newton = config::Newton;
+			using PrecConf = typename TrackerTraits< D >::PrecisionConfig;
 
 			Tracker(System const& sys) : tracked_system_(std::ref(sys))
 			{
@@ -296,7 +294,7 @@ namespace bertini{
 								Vec<C> const& start_point, C const& current_time) const
 			{
 
-				static_assert(detail::IsTemplateParameter<C,NeededTypes...>::value,"complex type for refinement must be a used type for the tracker");
+				static_assert(detail::IsTemplateParameter<C,NeededTypes>::value,"complex type for refinement must be a used type for the tracker");
 				return this->AsDerived().RefineImpl(new_space, start_point, current_time);
 			}
 
@@ -324,7 +322,7 @@ namespace bertini{
 			              				typename Eigen::NumTraits<C>::Real>::value,
 			              				"underlying complex type and the type for comparisons must match");
 
-				static_assert(detail::IsTemplateParameter<C,NeededTypes...>::value,"complex type for refinement must be a used type for the tracker");
+				static_assert(detail::IsTemplateParameter<C,NeededTypes>::value,"complex type for refinement must be a used type for the tracker");
 
 				return this->AsDerived().RefineImpl(new_space, start_point, current_time, tolerance, max_iterations);
 			}
@@ -352,6 +350,16 @@ namespace bertini{
 				return predictor_->PredictorMethod();
 			}
 
+
+			/**
+			\brief get a const reference to the system.
+			*/
+			void SetSystem(const System & new_sys)
+			{
+				tracked_system_ = std::ref(new_sys);
+				predictor_->ChangeSystem(tracked_system_);
+				corrector_->ChangeSystem(tracked_system_);
+			}
 
 			/**
 			\brief get a const reference to the system.
@@ -581,17 +589,20 @@ namespace bertini{
 			mutable unsigned num_successful_steps_since_stepsize_increase_; ///< How many successful steps have been taken since increased stepsize.
 			mutable unsigned num_successful_steps_since_precision_decrease_; ///< The number of successful steps since decreased precision.
 
-			mutable std::tuple< Vec<NeededTypes>...> current_space_; ///< The current space value. 
-			mutable std::tuple< Vec<NeededTypes>...> tentative_space_; ///< After correction, the tentative next space value
-			mutable std::tuple< Vec<NeededTypes>...> temporary_space_; ///< After prediction, the tentative next space value.
+			using TupOfVec = typename NeededTypes::ToTupleOfVec;
+			using TupOfReal = typename NeededTypes::ToTupleOfReal;
+			
+			mutable TupOfVec current_space_; ///< The current space value. 
+			mutable TupOfVec tentative_space_; ///< After correction, the tentative next space value
+			mutable TupOfVec temporary_space_; ///< After prediction, the tentative next space value.
 
 
-			mutable std::tuple< typename Eigen::NumTraits<NeededTypes>::Real... > condition_number_estimate_; ///< An estimate on the condition number of the Jacobian		
-			mutable std::tuple< typename Eigen::NumTraits<NeededTypes>::Real... > error_estimate_; ///< An estimate on the error of a step.
-			mutable std::tuple< typename Eigen::NumTraits<NeededTypes>::Real... > norm_J_; ///< An estimate on the norm of the Jacobian
-			mutable std::tuple< typename Eigen::NumTraits<NeededTypes>::Real... > norm_J_inverse_;///< An estimate on the norm of the inverse of the Jacobian
-			mutable std::tuple< typename Eigen::NumTraits<NeededTypes>::Real... > norm_delta_z_; ///< The norm of the change in space resulting from a step.
-			mutable std::tuple< typename Eigen::NumTraits<NeededTypes>::Real... > size_proportion_; ///< The proportion of the space step size, taking into account the order of the predictor.
+			mutable TupOfReal condition_number_estimate_; ///< An estimate on the condition number of the Jacobian		
+			mutable TupOfReal error_estimate_; ///< An estimate on the error of a step.
+			mutable TupOfReal norm_J_; ///< An estimate on the norm of the Jacobian
+			mutable TupOfReal norm_J_inverse_;///< An estimate on the norm of the inverse of the Jacobian
+			mutable TupOfReal norm_delta_z_; ///< The norm of the change in space resulting from a step.
+			mutable TupOfReal size_proportion_; ///< The proportion of the space step size, taking into account the order of the predictor.
 
 
 

--- a/core/include/bertini2/trackers/config.hpp
+++ b/core/include/bertini2/trackers/config.hpp
@@ -140,21 +140,22 @@ namespace bertini
 
 			
 
-			template<typename ComplexType>
+			template<typename RealType>
 			struct FixedPrecisionConfig
 			{
 				/**
 				\brief Construct a ready-to-go set of fixed precision settings from a system.
 				*/
+				explicit
 				FixedPrecisionConfig(System const& sys) 
 				{ }
 
 				FixedPrecisionConfig() = default;
 			};
 
-			template<typename ComplexType>
+			template<typename RealType>
 			inline
-			std::ostream& operator<<(std::ostream & out, FixedPrecisionConfig<ComplexType> const& fpc)
+			std::ostream& operator<<(std::ostream & out, FixedPrecisionConfig<RealType> const& fpc)
 			{
 				return out;
 			}
@@ -243,6 +244,7 @@ namespace bertini
 				AdaptiveMultiplePrecisionConfig() : coefficient_bound(1000), degree_bound(5), safety_digits_1(1), safety_digits_2(1), maximum_precision(300) 
 				{}
 
+				explicit
 				AdaptiveMultiplePrecisionConfig(System const& sys) : AdaptiveMultiplePrecisionConfig()
 				{
 					SetAMPConfigFrom(sys);

--- a/core/include/bertini2/trackers/config.hpp
+++ b/core/include/bertini2/trackers/config.hpp
@@ -33,8 +33,8 @@
 */
 #include "bertini2/mpfr_extensions.hpp"
 #include "bertini2/eigen_extensions.hpp"
-
 #include "bertini2/system/system.hpp"
+#include "bertini2/detail/typelist.hpp"
 
 namespace bertini
 {
@@ -55,110 +55,13 @@ namespace bertini
 
 
 
-		// forward declarations
-		template<class D>
-		class FixedPrecisionTracker;
-		class MultiplePrecisionTracker;
-		class DoublePrecisionTracker;
-
-		namespace config{
-			template<typename T>
-			struct FixedPrecisionConfig;
-			struct AdaptiveMultiplePrecisionConfig;
-		}
-		// end forward declarations
-
-
-
-
-		// now for the TrackerTraits structs, which enable lookup of correct settings objects and types, etc.
-		template<class T>
-		struct TrackerTraits
-		{};
-
-
-
-		template<>
-		struct TrackerTraits<DoublePrecisionTracker>
-		{
-			using BaseComplexType = dbl;
-			using BaseRealType = double;
-			using EventEmitterType = FixedPrecisionTracker<DoublePrecisionTracker>;
-			using PrecisionConfig = config::FixedPrecisionConfig<BaseRealType>;
-			enum {
-				IsFixedPrec = 1,
-				IsAdaptivePrec = 0
-			};
-		};
-
-
-		template<>
-		struct TrackerTraits<MultiplePrecisionTracker>
-		{
-			using BaseComplexType = mpfr;
-			using BaseRealType = mpfr_float;
-			using EventEmitterType = FixedPrecisionTracker<MultiplePrecisionTracker>;
-			using PrecisionConfig = config::FixedPrecisionConfig<BaseRealType>;
-
-			enum {
-				IsFixedPrec = 1,
-				IsAdaptivePrec = 0
-			};
-		};
-
-		class AMPTracker;
-		template<>
-		struct TrackerTraits<AMPTracker>
-		{
-			using BaseComplexType = mpfr;
-			using BaseRealType = mpfr_float;
-			using EventEmitterType = AMPTracker;
-			using PrecisionConfig = config::AdaptiveMultiplePrecisionConfig;
-
-			enum {
-				IsFixedPrec = 0,
-				IsAdaptivePrec = 1
-			};
-		};
-
-
 		
-
-		template<class D>
-		struct TrackerTraits<FixedPrecisionTracker<D> >
-		{
-			using BaseComplexType = typename TrackerTraits<D>::BaseComplexType;
-			using BaseRealType = typename TrackerTraits<D>::BaseRealType;
-			using EventEmitterType = typename TrackerTraits<D>::EventEmitterType;
-			using PrecisionConfig = typename TrackerTraits<D>::PrecisionConfig;
-
-			enum {
-				IsFixedPrec = 1,
-				IsAdaptivePrec = 0
-			};
-		};
-
-
-		namespace endgame{
-		// some forward declarations
-		template<typename Tracker, typename Enable = void>
-		class FixedPrecPowerSeriesEndgame;
-
-		template<typename Tracker, typename Enable = void>
-		class FixedPrecCauchyEndgame;
-
-		class AMPPowerSeriesEndgame;
-		class AMPCauchyEndgame;
-		}
-
-		
-
-
 
 
 		enum class SuccessCode
 		{
-			Success,
+			NeverStarted = -1,
+			Success = 0,
 			HigherPrecisionNecessary,
 			ReduceStepSize,
 			GoingToInfinity,
@@ -245,6 +148,8 @@ namespace bertini
 				*/
 				FixedPrecisionConfig(System const& sys) 
 				{ }
+
+				FixedPrecisionConfig() = default;
 			};
 
 			template<typename ComplexType>
@@ -378,6 +283,113 @@ namespace bertini
 			}
 
 		} //re: namespace config
+
+
+
+		// forward declarations
+		template<class D>
+		class Tracker;
+		template<class D>
+		class FixedPrecisionTracker;
+		class MultiplePrecisionTracker;
+		class DoublePrecisionTracker;
+		
+
+// now for the TrackerTraits structs, which enable lookup of correct settings objects and types, etc.
+		template<class T>
+		struct TrackerTraits
+		{};
+
+
+		
+
+		template<>
+		struct TrackerTraits<DoublePrecisionTracker>
+		{
+			using BaseComplexType = dbl;
+			using BaseRealType = double;
+			using EventEmitterType = FixedPrecisionTracker<DoublePrecisionTracker>;
+			using PrecisionConfig = config::FixedPrecisionConfig<BaseRealType>;
+			enum {
+				IsFixedPrec = 1,
+				IsAdaptivePrec = 0
+			};
+
+			using NeededTypes = detail::TypeList<dbl>;
+			using NeededConfigs = detail::TypeList<
+				config::Stepping<BaseRealType>, 
+				config::Newton,
+				PrecisionConfig
+				>;
+		};
+
+
+		template<>
+		struct TrackerTraits<MultiplePrecisionTracker>
+		{
+			using BaseComplexType = mpfr;
+			using BaseRealType = mpfr_float;
+			using EventEmitterType = FixedPrecisionTracker<MultiplePrecisionTracker>;
+			using PrecisionConfig = config::FixedPrecisionConfig<BaseRealType>;
+
+			enum {
+				IsFixedPrec = 1,
+				IsAdaptivePrec = 0
+			};
+
+			using NeededTypes = detail::TypeList<mpfr>;
+
+			using NeededConfigs = detail::TypeList<
+				config::Stepping<BaseRealType>, 
+				config::Newton,
+				PrecisionConfig
+				>;
+		};
+
+
+		class AMPTracker; // forward declare
+		template<>
+		struct TrackerTraits<AMPTracker>
+		{
+			using BaseComplexType = mpfr;
+			using BaseRealType = mpfr_float;
+			using EventEmitterType = AMPTracker;
+			using PrecisionConfig = config::AdaptiveMultiplePrecisionConfig;
+
+			enum {
+				IsFixedPrec = 0,
+				IsAdaptivePrec = 1
+			};
+
+			using NeededTypes = detail::TypeList<dbl, mpfr>;
+
+			using NeededConfigs = detail::TypeList<
+				config::Stepping<BaseRealType>, 
+				config::Newton,
+				PrecisionConfig
+				>;
+		};
+
+
+		
+
+		template<class D>
+		struct TrackerTraits<FixedPrecisionTracker<D> > : public TrackerTraits<D>
+		{ 
+			using BaseComplexType = typename TrackerTraits<D>::BaseComplexType;
+			using BaseRealType = typename TrackerTraits<D>::BaseRealType;
+			using EventEmitterType = typename TrackerTraits<D>::EventEmitterType;
+			using PrecisionConfig = typename TrackerTraits<D>::PrecisionConfig;
+
+			enum {
+				IsFixedPrec = 0,
+				IsAdaptivePrec = 1
+			};
+
+			using NeededTypes = typename TrackerTraits<D>::NeededTypes;
+			using NeededConfigs = typename TrackerTraits<D>::NeededConfigs;
+		};
+
 	} // re: namespace tracking 
 } // re: namespace bertini
 

--- a/core/include/bertini2/trackers/explicit_predictors.hpp
+++ b/core/include/bertini2/trackers/explicit_predictors.hpp
@@ -860,11 +860,6 @@ namespace bertini{
 						if (!std::is_same<ComplexType,dbl>::value)
 						{
 							assert(Precision(dhdxref)==current_precision_);
-							if (Precision(LUref.matrixLU())!=current_precision_)
-							{
-								std::cout << Precision(LUref.matrixLU())<< " " << DefaultPrecision() << " " << current_precision_ << '\n';
-								std::cout << LUref.matrixLU() << std::endl;
-							}
 							assert(Precision(LUref.matrixLU())==current_precision_);
 						}
 

--- a/core/include/bertini2/trackers/fixed_precision_tracker.hpp
+++ b/core/include/bertini2/trackers/fixed_precision_tracker.hpp
@@ -56,7 +56,7 @@ namespace bertini{
 		\brief Functor-like class for tracking paths on a system
 		*/
 		template<class DerivedT>
-		class FixedPrecisionTracker : public Tracker<FixedPrecisionTracker<DerivedT>, typename TrackerTraits<DerivedT>::BaseComplexType>
+		class FixedPrecisionTracker : public Tracker<FixedPrecisionTracker<DerivedT>>
 		{	
 		public:
 
@@ -69,7 +69,7 @@ namespace bertini{
 			virtual ~FixedPrecisionTracker() = default;
 
 			using EmitterType = FixedPrecisionTracker<DerivedT>;
-			using Base = Tracker<FixedPrecisionTracker<DerivedT>, BaseComplexType>;
+			using Base = Tracker<FixedPrecisionTracker<DerivedT>>;
 
 			using Config =  typename Base::Config;
 			FORWARD_GET_CONFIGURED

--- a/core/src/detail/Makemodule.am
+++ b/core/src/detail/Makemodule.am
@@ -6,7 +6,8 @@ detail_header_files = \
 	include/bertini2/detail/visitable.hpp \
 	include/bertini2/detail/visitor.hpp \
 	include/bertini2/detail/is_template_parameter.hpp \
-	include/bertini2/detail/enable_permuted_arguments.hpp 
+	include/bertini2/detail/enable_permuted_arguments.hpp \
+	include/bertini2/detail/typelist.hpp
 
 detail = $(detail_header_files)
 

--- a/core/src/system/Makemodule.am
+++ b/core/src/system/Makemodule.am
@@ -9,7 +9,8 @@ system_header_files = \
 	include/bertini2/system/start_systems.hpp \
 	include/bertini2/system/system.hpp \
 	include/bertini2/system/start/total_degree.hpp \
-	include/bertini2/system/start/mhom.hpp
+	include/bertini2/system/start/mhom.hpp \
+	include/bertini2/system/start/user.hpp
 
 
 system_source_files = \
@@ -18,7 +19,8 @@ system_source_files = \
 	src/system/start_base.cpp \
 	src/system/system.cpp \
 	src/system/start/total_degree.cpp \
-	src/system/start/mhom.cpp
+	src/system/start/mhom.cpp \
+	src/system/start/user.cpp
 
 system = $(system_header_files) $(system_source_files)
 
@@ -36,7 +38,8 @@ systeminclude_HEADERS = \
 	include/bertini2/system/start_base.hpp \
 	include/bertini2/system/start_systems.hpp \
 	include/bertini2/system/system.hpp \
-	include/bertini2/system/start/mhom.hpp
+	include/bertini2/system/start/mhom.hpp \
+	include/bertini2/system/start/user.hpp
 	
 	
 	
@@ -45,7 +48,8 @@ startincludedir = $(includedir)/bertini2/system/start/
 
 startinclude_HEADERS = \
 	include/bertini2/system/start/total_degree.hpp \
-	include/bertini2/system/start/mhom.hpp
+	include/bertini2/system/start/mhom.hpp \
+	include/bertini2/system/start/user.hpp
 
 
 

--- a/core/src/system/precon.cpp
+++ b/core/src/system/precon.cpp
@@ -29,7 +29,7 @@
 namespace bertini{
 	namespace system {
 
-
+// has multiplicity 3 root at origin, and 3 infinite roots
 System Precon::GriewankOsborn()
 {
 	using Var = std::shared_ptr<node::Variable>;

--- a/core/src/system/start/total_degree.cpp
+++ b/core/src/system/start/total_degree.cpp
@@ -57,14 +57,12 @@ namespace bertini {
 			
 
 			auto deg = s.Degrees();
-			for (auto iter : deg)
-				degrees_.push_back((size_t) iter);
+			for (const auto& d : deg)
+				degrees_.push_back(static_cast<const size_t>(d));
 
 			CopyVariableStructure(s);
 
 			random_values_.resize(s.NumFunctions());
-
-
 			for (unsigned ii = 0; ii < s.NumFunctions(); ++ii)
 				random_values_[ii] = MakeRational(node::Rational::Rand());
 
@@ -94,7 +92,7 @@ namespace bertini {
 		unsigned long long TotalDegree::NumStartPoints() const
 		{
 			unsigned long long num_start_points = 1;
-			for (auto iter : degrees_)
+			for (const auto& iter : degrees_)
 				num_start_points*=iter;
 			return num_start_points;
 		}
@@ -113,8 +111,10 @@ namespace bertini {
 				offset = 1;
 			}
 
+			auto two_i_pi = std::acos(-1.0) * dbl(0,2);
+
 			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
-				start_point(ii+offset) = exp( std::acos(-1) * dbl(0,2) * double(indices[ii]) / double(degrees_[ii])  ) * pow(random_values_[ii]->Eval<dbl>(), double(1) / double(degrees_[ii]));
+				start_point(ii+offset) = exp( two_i_pi * static_cast<double>(indices[ii]) / static_cast<double>(degrees_[ii])  ) * pow(random_values_[ii]->Eval<dbl>(), 1.0 / static_cast<double>(degrees_[ii]));
 
 			if (IsPatched())
 				RescalePointToFitPatchInPlace(start_point);
@@ -135,11 +135,12 @@ namespace bertini {
 				offset = 1;
 			}
 
-			auto two_i = mpfr(0,2);
+			
 			auto one = mpfr(1);
+			auto two_i_pi = mpfr(0,2) * acos( mpfr_float(-1) );
 
 			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
-				start_point(ii+offset) = exp( acos( mpfr_float(-1) ) * two_i * mpfr_float(indices[ii]) / mpfr_float(degrees_[ii])  ) * pow(random_values_[ii]->Eval<mpfr>(), one / degrees_[ii]);
+				start_point(ii+offset) = exp( two_i_pi * mpfr_float(indices[ii]) / degrees_[ii]  ) * pow(random_values_[ii]->Eval<mpfr>(), one / degrees_[ii]);
 
 			if (IsPatched())
 				RescalePointToFitPatchInPlace(start_point);

--- a/core/src/system/start/user.cpp
+++ b/core/src/system/start/user.cpp
@@ -1,0 +1,92 @@
+//This file is part of Bertini 2.
+//
+//mhom.cpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//mhom.cpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with mhom.cpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license, 
+// as well as COPYING.  Bertini2 is provided with permitted 
+// additional terms in the b2/licenses/ directory.
+
+// individual authors of this file include:
+// daniel brake, university of notre dame
+
+#include "bertini2/system/start/user.hpp"
+
+
+BOOST_CLASS_EXPORT(bertini::start_system::User);
+
+
+namespace bertini {
+
+	namespace start_system {
+
+		// constructor for User start system, from any other *suitable* system.
+		User::User(System const& s)
+		{
+
+			if (s.NumHomVariableGroups() > 0)
+				throw std::runtime_error("a homogeneous variable group is present.  currently unallowed");
+
+
+			if (s.NumTotalFunctions() != s.NumVariables())
+				throw std::runtime_error("attempting to construct total degree start system from non-square target system");
+
+			if (s.HavePathVariable())
+				throw std::runtime_error("attempting to construct total degree start system, but target system has path varible declared already");			
+
+			if (!s.IsPolynomial())
+				throw std::runtime_error("attempting to construct total degree start system from non-polynomial target system");
+		}
+
+		
+		User& User::operator*=(Nd const& n)
+		{
+			*this *= n;
+			return *this;
+		}
+		
+		
+
+		unsigned long long User::NumStartPoints() const
+		{
+			return 0;
+		}
+
+
+		
+		Vec<dbl> User::GenerateStartPoint(dbl,unsigned long long index) const
+		{
+			Vec<dbl> start_point(NumVariables());
+
+			return start_point;
+		}
+
+
+		Vec<mpfr> User::GenerateStartPoint(mpfr,unsigned long long index) const
+		{
+			Vec<mpfr> start_point(NumVariables());
+
+			return start_point;
+		}
+
+		inline
+		User operator*(User td, std::shared_ptr<node::Node> const& n)
+		{
+			td *= n;
+			return td;
+		}
+
+	} // namespace start_system
+} //namespace bertini

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -768,13 +768,14 @@ namespace bertini
     		Vec<mpfr> randy = RandomOfUnits<mpfr>(NumVariables());
     		Vec<mpfr> f_vals;
     		if (HavePathVariable())
-    			f_vals = Eval(randy, mpfr::rand());
+    			f_vals = Eval(randy, mpfr::RandomUnit());
     		else
     			f_vals = Eval(randy);
 	    	
 	    	auto dh_dx = Jacobian<mpfr>();
 	    	
-			bound = max(f_vals.array().abs().maxCoeff(),dh_dx.array().abs().maxCoeff(), bound);
+			bound = max(f_vals.array().abs().maxCoeff(),
+				         dh_dx.array().abs().maxCoeff(), bound);
 		}
     	return bound;
 	}

--- a/core/test/available_tests.txt
+++ b/core/test/available_tests.txt
@@ -1,0 +1,9 @@
+b2_class_test
+b2_classic_compatibility_test
+endgames_test
+generating_test
+nag_algorithms_test
+nag_datatypes_test
+pool_test
+settings_test
+tracking_basics_test

--- a/core/test/blackbox/Makemodule.am
+++ b/core/test/blackbox/Makemodule.am
@@ -1,0 +1,15 @@
+#this is test/blackbox/Makemodule.am
+
+
+EXTRA_PROGRAMS += blackbox_test
+TESTS += blackbox_test
+
+blackbox_test_SOURCES = \
+	test/blackbox/blackbox.cpp \
+	test/blackbox/zerodim.cpp \
+	test/blackbox/parsing.cpp
+
+blackbox_test_LDADD = $(BOOST_FILESYSTEM_LIB) $(BOOST_SYSTEM_LIB)  $(BOOST_CHRONO_LIB) $(BOOST_REGEX_LIB) $(BOOST_TIMER_LIB) $(MPI_CXXLDFLAGS) $(BOOST_UNIT_TEST_FRAMEWORK_LIB) $(BOOST_SERIALIZATION_LIB) $(BOOST_LOG_LIB) $(BOOST_LOG_SETUP_LIB) $(BOOST_THREAD_LIB) libbertini2.la
+
+blackbox_test_CXXFLAGS = $(BOOST_CPPFLAGS)
+

--- a/core/test/blackbox/blackbox.cpp
+++ b/core/test/blackbox/blackbox.cpp
@@ -1,0 +1,51 @@
+//This file is part of Bertini 2.
+//
+//test/blackbox/blackbox.cpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//test/blackbox/blackbox.cpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with test/blackbox/blackbox.cpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license, 
+// as well as COPYING.  Bertini2 is provided with permitted 
+// additional terms in the b2/licenses/ directory.
+
+// individual authors of this file include:
+// daniel brake, university of notre dame
+
+
+//test/blackbox/blackbox.cpp
+//
+
+
+ 
+#define BOOST_TEST_DYN_LINK 1
+
+//this #define MUST appear before #include <boost/test/unit_test.hpp>
+#define BOOST_TEST_MODULE "Bertini 2 Blackbox Testing"
+#include <boost/test/unit_test.hpp>
+
+
+#include "logging.hpp"
+
+
+using sec_level = boost::log::trivial::severity_level;
+
+using LoggingInit = bertini::LoggingInit;
+
+
+BOOST_GLOBAL_FIXTURE( LoggingInit );
+
+
+
+
+

--- a/core/test/blackbox/parsing.cpp
+++ b/core/test/blackbox/parsing.cpp
@@ -1,0 +1,83 @@
+//This file is part of Bertini 2.
+//
+//test/blackbox/parsing.cpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//test/blackbox/parsing.cpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with test/blackbox/parsing.cpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license, 
+// as well as COPYING.  Bertini2 is provided with permitted 
+// additional terms in the b2/licenses/ directory.
+
+// individual authors of this file include:
+// dani brake, university of notre dame
+
+#include <boost/test/unit_test.hpp>
+
+#include "bertini2/system/precon.hpp"
+#include "bertini2/blackbox/global_configs.hpp"
+
+#include "bertini2/io/parsing.hpp"
+
+
+BOOST_AUTO_TEST_SUITE(blackbox_test)
+
+BOOST_AUTO_TEST_SUITE(parsing_configs)
+
+using namespace bertini;
+
+BOOST_AUTO_TEST_CASE(parse1)
+{
+	
+	using AllConfsD = blackbox::config::Configs::All<double>::type;
+	using AllConfsMP = blackbox::config::Configs::All<mpfr_float>::type;
+
+std::string config = 
+R"(outputlevel: 0;
+randomseed: 72;
+tracktype: 1;
+odepredictor: 8;
+finaltol: 1e-12;
+endgamenum: 2;
+numsamplepoints: 8;
+samplefactor: 0.8;
+maxcyclenum: 6;
+ampmaxprec: 3096;
+ampsafetydigits1: 0;
+ampsafetydigits2: 0;
+maxstepsize: 0.05;
+maxnumbersteps: 20000;
+securitylevel: 1;
+EndpointFiniteThreshold: 1e10;
+pathtruncationthreshold: 1e10;
+endgamebdry: 0.001;
+stepsforincrease: 10;
+stepfailfactor: 0.45;
+stepsuccessfactor: 1.5;
+functiontolerance: 1e-7;
+tracktolbeforeeg: 1e-8;
+tracktolduringeg: 1e-8;
+sharpendigits: 60;
+condnumthreshold: 1e300;
+maxstepsbeforenewton: 0;
+maxnewtonits: 1;)";
+
+	auto results_double = bertini::parsing::classic::ConfigParser<double, AllConfsD>::Parse(config);
+	auto results_mp = bertini::parsing::classic::ConfigParser<mpfr_float, AllConfsMP>::Parse(config);
+}
+
+
+
+BOOST_AUTO_TEST_SUITE_END() // end the parsing sub-suite
+
+BOOST_AUTO_TEST_SUITE_END() // end the blackbox suite

--- a/core/test/blackbox/zerodim.cpp
+++ b/core/test/blackbox/zerodim.cpp
@@ -1,0 +1,62 @@
+//This file is part of Bertini 2.
+//
+//test/blackbox/zerodim.cpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//test/blackbox/zerodim.cpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with test/blackbox/zerodim.cpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) 2017 by Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license, 
+// as well as COPYING.  Bertini2 is provided with permitted 
+// additional terms in the b2/licenses/ directory.
+
+// individual authors of this file include:
+// dani brake, university of notre dame
+
+#include <boost/test/unit_test.hpp>
+
+#include "bertini2/blackbox/switches_zerodim.hpp"
+#include "bertini2/system/precon.hpp"
+
+
+BOOST_AUTO_TEST_SUITE(blackbox_test)
+
+BOOST_AUTO_TEST_SUITE(zero_dim)
+
+using namespace bertini;
+
+BOOST_AUTO_TEST_CASE(make_zero_dim_defaults)
+{
+	auto sys = system::Precon::GriewankOsborn();
+	blackbox::ZeroDimRT my_runtime_type_options; // make defaults
+
+	auto zd_ptr = blackbox::MakeZeroDim(my_runtime_type_options, sys);
+}
+
+
+
+BOOST_AUTO_TEST_CASE(make_zero_dim_nondefaults)
+{
+	auto sys = system::Precon::GriewankOsborn();
+	blackbox::ZeroDimRT my_runtime_type_options; // make defaults
+	my_runtime_type_options.start = bertini::blackbox::type::Start::MHom;
+	my_runtime_type_options.tracker = bertini::blackbox::type::Tracker::FixedDouble;
+	my_runtime_type_options.endgame = bertini::blackbox::type::Endgame::Cauchy;
+	auto zd_ptr = blackbox::MakeZeroDim(my_runtime_type_options, sys);
+
+	
+	// zd_ptr->DefaultSetup();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // end the zerodim sub-suite
+
+BOOST_AUTO_TEST_SUITE_END() // end the blackbox suite

--- a/core/test/classes/eigen_test.cpp
+++ b/core/test/classes/eigen_test.cpp
@@ -96,11 +96,7 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 			for (int jj=0; jj<size; jj++)
 				jj!=ii? B(ii,jj) = -1.0/(ii+1) + double(rand()) /  RAND_MAX : B(ii,jj) = 0;
 		
-		
-//		boost::timer::auto_cpu_timer t;
 		C = A.lu().solve(B);
-//		std::cout << C << std::endl;
-//		std::cout << "pure double time to solve:" << std::endl;
 		//add statement on the value of C to actually test
 
 	}
@@ -122,12 +118,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 		for (int ii=0; ii<size; ii++)
 			for (int jj=0; jj<size; jj++)
 				jj!=ii? B(ii,jj) = -1.0/(ii+1.0) + bertini::mpfr_float(rand()) /  bertini::mpfr_float(RAND_MAX) : B(ii,jj) = 0;
-		
-		
-//		boost::timer::auto_cpu_timer t;
+
 		C = A.lu().solve(B);
-//		std::cout << C << std::endl;
-//		std::cout << "mpfr_float pure 16 time to solve:" << std::endl;
 	}
 
 
@@ -141,7 +133,7 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 		using mpfr = bertini::mpfr_float;
 		using mpfr_matrix = Eigen::Matrix<mpfr, Eigen::Dynamic, Eigen::Dynamic>;
 
-		mpfr::default_precision(50);
+		bertini::DefaultPrecision(100);
 		
 		mpfr_matrix A = KahanMatrix(size, mpfr(0.285)), B(size,size), C;
 		
@@ -150,15 +142,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 				(jj!=ii) ? B(ii,jj) = -1.0/(ii+1) + mpfr(rand()) /  mpfr(RAND_MAX) : B(ii,jj) = mpfr(0.0);
 			}
 		}
-		
-		
-	
-		
-//		boost::timer::auto_cpu_timer t;
 		C = A.lu().solve(B);
-//		std::cout << C << std::endl;
-//		std::cout << "mpfr_float pure 100 time to solve:" << std::endl;
-		
+
 	}
 
 
@@ -179,12 +164,7 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 				jj!=ii? B(ii,jj) = -1.0/(ii+1) + double(rand()) / double(RAND_MAX) : B(ii,jj) = 0;
 		
 		
-		
-		
-//		boost::timer::auto_cpu_timer t;
 		C = A.lu().solve(B);
-//		std::cout << C << std::endl;
-//		std::cout << "std::complex time to solve:" << std::endl;
 	}
 	
 	
@@ -203,12 +183,7 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 			for (int jj=0; jj<size; jj++)
 				jj!=ii? B(ii,jj) = bertini::complex( bertini::complex(-1)/bertini::complex(ii+1) + bertini::complex(rand()) / bertini::complex(RAND_MAX)) : B(ii,jj) = bertini::complex(0);
 		
-//		boost::timer::auto_cpu_timer t;
 		C = A.lu().solve(B);
-		
-		
-//		std::cout << C << std::endl;
-//		std::cout << "bertini::complex precision 100 time to solve:" << std::endl;
 	}
 
 		
@@ -304,6 +279,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(large_change_multiprecision)
 	{
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		bertini::mpfr_float p = pow(mpfr_float(10),-mpfr_float(CLASS_TEST_MPFR_DEFAULT_DIGITS));
 
 		BOOST_CHECK( bertini::IsLargeChange(mpfr_float(1.0),p));
@@ -341,31 +318,33 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 		double n = A.norm();
 	}
 
-		BOOST_AUTO_TEST_CASE(dot_product_with_mpfr_type)
-		{
-			
-			using data_type = bertini::mpfr;
-			
-			Eigen::Matrix<data_type, 3, 1> v(data_type(2),data_type(4),data_type(3));
-			Eigen::Matrix<data_type, 3, 1> w(data_type(1),data_type(2),data_type(-1));
+	BOOST_AUTO_TEST_CASE(dot_product_with_mpfr_type)
+	{
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
-			data_type result = v.dot(w);
-			data_type exact(7);
-			
-			BOOST_CHECK_EQUAL(result, exact);
-			
-		}
+		using data_type = bertini::mpfr;
+		
+		Eigen::Matrix<data_type, 3, 1> v(data_type(2),data_type(4),data_type(3));
+		Eigen::Matrix<data_type, 3, 1> w(data_type(1),data_type(2),data_type(-1));
+
+		data_type result = v.dot(w);
+		data_type exact(7);
+		
+		BOOST_CHECK_EQUAL(result, exact);
+		
+	}
 
 
 	BOOST_AUTO_TEST_CASE(svd_with_mpfr_type)
 	{
-		
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using data_type = bertini::mpfr;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> A(2,2);
 		A << data_type(2), data_type(1), data_type(1), data_type(2);
 		
-		// this is commented out because et_on breaks this with eigen 3.2.7.  this issue is fixed with upcoming eigen release.  hence, we need to control et_on/et_off with a compile-time option and requirements on the version of eigen used.
+		// this breaks with boost multiprecision et_on with eigen 3.2.7.
 		Eigen::JacobiSVD<Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic>> svd(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
 		
 		
@@ -376,14 +355,15 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(scalar_multiplication_mpfr_mpfr)
 	{
-		
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using data_type = bertini::mpfr;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> A(2,2);
 		A << data_type(2), data_type(1), data_type(1), data_type(2);
 		
 		data_type a(1);
-		// this is commented out because et_on breaks this with eigen 3.2.7.  this issue is fixed with upcoming eigen release.  hence, we need to control et_on/et_off with a compile-time option and requirements on the version of eigen used.
+		// this breaks with boost multiprecision et_on with eigen 3.2.7.
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> B = a*A;
 		B = A*a;
 	}
@@ -391,7 +371,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(scalar_multiplication_mpfr_int)
 	{
-		
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using data_type = bertini::mpfr;
 		
 		data_type q(1);
@@ -411,7 +392,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(scalar_multiplication_mpfr_long)
 	{
-		
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using data_type = bertini::mpfr;
 		
 		data_type q(1);
@@ -430,7 +412,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(scalar_multiplication_mpfr_mpz_int)
 	{
-		
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using data_type = bertini::mpfr;
 		
 		data_type q(1);
@@ -468,7 +451,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(self_multiplication_mpfr_mpfr)
 	{
-		
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using data_type = bertini::mpfr;
 		
 		Eigen::Matrix<data_type, Eigen::Dynamic, Eigen::Dynamic> A(2,2);
@@ -482,7 +466,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(self_multiplication_mpfr_int)
 	{
-		
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using data_type = bertini::mpfr;
 		
 		data_type q(1);
@@ -499,7 +484,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(self_multiplication_mpfr_long)
 	{
-		
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using data_type = bertini::mpfr;
 		
 		data_type q(1);
@@ -513,7 +499,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(self_multiplication_mpfr_mpz_int)
 	{
-		
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using data_type = bertini::mpfr;
 		
 		data_type q(1);
@@ -527,6 +514,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(change_precision_mpfr_float)
 	{
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using bertini::Precision;
 		using data_type = bertini::mpfr_float;
 		
@@ -539,6 +528,8 @@ BOOST_AUTO_TEST_SUITE(kahan_matrix_solving_LU)
 
 	BOOST_AUTO_TEST_CASE(change_precision_mpfr_complex)
 	{
+		bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 		using bertini::Precision;
 		using data_type = bertini::mpfr;
 		

--- a/core/test/classes/eigen_test.cpp
+++ b/core/test/classes/eigen_test.cpp
@@ -60,6 +60,25 @@ BOOST_AUTO_TEST_CASE(expressions_of_mpfr_floats)
 
 }
 
+BOOST_AUTO_TEST_CASE(size_object_sensible_vec)
+{
+	bertini::Vec<bertini::dbl> v(3);
+	BOOST_CHECK_EQUAL(v.rows(),3);
+	BOOST_CHECK_EQUAL(v.cols(),1);
+
+	BOOST_CHECK(!bertini::IsEmpty(v));
+}
+
+
+BOOST_AUTO_TEST_CASE(size_object_sensible_mat)
+{
+	bertini::Mat<bertini::dbl> v(3,4);
+	BOOST_CHECK_EQUAL(v.rows(),3);
+	BOOST_CHECK_EQUAL(v.cols(),4);
+
+	BOOST_CHECK(!bertini::IsEmpty(v));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 

--- a/core/test/classes/start_system_test.cpp
+++ b/core/test/classes/start_system_test.cpp
@@ -270,6 +270,8 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_total_degree_start_system)
 
 BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points)
 {
+	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+	
 	bertini::System sys;
 	Var x = MakeVariable("x"), y = MakeVariable("y"), z = MakeVariable("z");
 
@@ -287,10 +289,13 @@ BOOST_AUTO_TEST_CASE(quadratic_cubic_quartic_start_points)
 	{
 		auto start = TD.StartPoint<dbl>(ii);
 		auto function_values = TD.Eval(start);
-		
+		const auto& vs = TD.RandomValues();
+
 		for (size_t jj = 0; jj < function_values.size(); ++jj)
-			BOOST_CHECK(abs(function_values(jj)) < relaxed_threshold_clearance_d);
+			BOOST_CHECK(abs(function_values(jj)) < 
+				abs(vs[jj]->Eval<dbl>())*relaxed_threshold_clearance_d);
 	}
+	
 
 	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
@@ -378,10 +383,7 @@ BOOST_AUTO_TEST_CASE(start_system_total_degree_nonpolynomial_should_throw)
 BOOST_AUTO_TEST_CASE(total_degree_start_system_coefficient_bound_degree_bound)
 {
 	/*
-	In this example we take a decoupled system, homogenize and patch it. Track to endgame boundary and then run our endgame on the space
-	values we have. 
-
-	Take note that in this example we have two successes while the other hit a min track time. This is accounted for. 
+	In this example we take a decoupled system, homogenize and patch it.
 	*/
 	DefaultPrecision(30);
 

--- a/core/test/classes/system_test.cpp
+++ b/core/test/classes/system_test.cpp
@@ -42,6 +42,7 @@
 
 
 #include "bertini2/system/system.hpp"
+#include "bertini2/system/precon.hpp"
 #include "bertini2/io/parsing/system_parsers.hpp"
 
 
@@ -1003,6 +1004,34 @@ BOOST_AUTO_TEST_CASE(variable_group_sizes_and_degrees_affvargrp)
 	BOOST_CHECK_EQUAL(size_of_each_var_gp[1], 2);
 }
 
+
+
+BOOST_AUTO_TEST_CASE(clone_system_new_variables_evaluation)
+{
+	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+	auto sys = bertini::system::Precon::GriewankOsborn();
+	Vec<mpfr> x1(2), x2(2);
+	x1(0) = bertini::RandomUnit(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+	x1(1) = bertini::RandomUnit(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
+	auto f = sys.Eval(x1);
+
+	auto sys_clone = bertini::Clone(sys);
+
+	x2(0) = mpfr{2};
+	x2(1) = mpfr{3};
+
+	auto f_clone = sys_clone.Eval(x2);
+
+	BOOST_CHECK_EQUAL(mpfr(2.5), f_clone(0));
+	BOOST_CHECK_EQUAL(mpfr(-1), f_clone(1));
+
+	auto f_clone2 = sys_clone.Eval(x1);
+	auto f2 = sys.Eval<mpfr>();
+
+	BOOST_CHECK_EQUAL(f,f2);
+	BOOST_CHECK_EQUAL(f_clone2,f2);
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/core/test/classes/system_test.cpp
+++ b/core/test/classes/system_test.cpp
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with system_test.cpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license, 
 // as well as COPYING.  Bertini2 is provided with permitted 
@@ -28,10 +28,10 @@
 //  Copyright (c) 2015 West Texas A&M University. All rights reserved.
 //
 // also modified by
-//  Daniel Brake
+//  Dani Brake
 //  University of Notre Dame
 //  ACMS
-//  Spring, Summer 2015
+//  Spring, Summer 2015, Spring 2017
 
 /**
 \file system_test.cpp Unit testing for the bertini::System class.
@@ -425,6 +425,7 @@ BOOST_AUTO_TEST_CASE(system_evaluate_double)
 */
 BOOST_AUTO_TEST_CASE(system_evaluate_mpfr)
 {
+	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
 
 	std::string str = "function f; variable_group x1, x2; y = x1*x2; f = y*y;";
 
@@ -749,6 +750,8 @@ BOOST_AUTO_TEST_CASE(system_dehomogenize_FIFO_one_aff_group_two_ungrouped_vars_a
 */
 BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_linear)
 {
+	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 	Var x = MakeVariable("x");
 	Var t = MakeVariable("t");
 
@@ -759,7 +762,7 @@ BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_linear)
 	S.AddFunction(x-t);
 
 	mpfr_float coefficient_bound = S.CoefficientBound();
-	BOOST_CHECK(coefficient_bound < mpfr_float("3"));
+	BOOST_CHECK(coefficient_bound < mpfr_float("10"));
 	BOOST_CHECK(coefficient_bound > mpfr_float("0.5"));
 }
 
@@ -770,6 +773,8 @@ BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_linear)
 */
 BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_quartic)
 {
+	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 	bertini::System sys;
 	Var x = MakeVariable("x"), y = MakeVariable("y"), z = MakeVariable("z");
 
@@ -793,6 +798,8 @@ BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_quartic)
 */
 BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_homogenized_quartic)
 {
+	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 	bertini::System sys;
 	Var x = MakeVariable("x"), y = MakeVariable("y"), z = MakeVariable("z");
 
@@ -817,6 +824,8 @@ BOOST_AUTO_TEST_CASE(system_estimate_coeff_bound_homogenized_quartic)
 */
 BOOST_AUTO_TEST_CASE(system_estimate_degree_bound_linear)
 {
+	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 	Var x = MakeVariable("x");
 	Var t = MakeVariable("t");
 
@@ -837,6 +846,8 @@ BOOST_AUTO_TEST_CASE(system_estimate_degree_bound_linear)
 */
 BOOST_AUTO_TEST_CASE(system_estimate_degree_bound_quartic)
 {
+	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 	bertini::System sys;
 	Var x = MakeVariable("x"), y = MakeVariable("y"), z = MakeVariable("z");
 
@@ -860,6 +871,8 @@ BOOST_AUTO_TEST_CASE(system_estimate_degree_bound_quartic)
 */
 BOOST_AUTO_TEST_CASE(system_multiply_by_node)
 {
+	bertini::DefaultPrecision(CLASS_TEST_MPFR_DEFAULT_DIGITS);
+
 	bertini::System sys1, sys2;
 	Var x = MakeVariable("x"), y = MakeVariable("y"), z = MakeVariable("z");
 
@@ -891,7 +904,6 @@ BOOST_AUTO_TEST_CASE(system_multiply_by_node)
 */
 BOOST_AUTO_TEST_CASE(concatenate_two_systems)
 {
-
 	bertini::System sys1, sys2;
 	Var x = MakeVariable("x"), y = MakeVariable("y"), z = MakeVariable("z");
 

--- a/core/test/endgames/generic_cauchy_test.hpp
+++ b/core/test/endgames/generic_cauchy_test.hpp
@@ -124,15 +124,14 @@ BOOST_AUTO_TEST_CASE(circle_track_cycle_num_1)
 
 	cauchy_times.push_back(ComplexFromString("0.1"));
 	cauchy_samples.push_back(Vec<BCT>(1));
+	cauchy_samples.back() << ComplexFromString("7.999999999999999e-01", "2.168404344971009e-19"); // 
 
 	const auto& time = cauchy_times.back();
 	const auto& sample = cauchy_samples.back();
 
-	cauchy_samples.back() << ComplexFromString("7.999999999999999e-01", "2.168404344971009e-19"); // 
-
 	auto first_track_success =  my_endgame.CircleTrack(time,origin,sample);
 
-	BOOST_CHECK((my_endgame.GetCauchySamples<BCT>().back() - sample).norm() < 1e-5);
+	BOOST_CHECK((my_endgame.GetCauchySamples<BCT>().back() - sample).template lpNorm<Eigen::Infinity>() < 1e-5);
 
 }
 
@@ -200,13 +199,13 @@ BOOST_AUTO_TEST_CASE(circle_track_cycle_num_greater_than_1)
 
 	const auto& first_track_sample = my_endgame.GetCauchySamples<BCT>().back();
 
-	BOOST_CHECK((first_track_sample - sample).norm() > 1e-5);
+	BOOST_CHECK((first_track_sample - sample).template lpNorm<Eigen::Infinity>() > 1e-5);
 
 	tracking_success =  my_endgame.CircleTrack(time,origin,first_track_sample);
 
 	const auto& second_track_sample = my_endgame.GetCauchySamples<BCT>().back();
 
-	BOOST_CHECK((second_track_sample - sample).norm() < 1e-5);
+	BOOST_CHECK((second_track_sample - sample).template lpNorm<Eigen::Infinity>() < 1e-5);
 	
 } // end circle_track_mp_cycle_num_greater_than_1
 
@@ -271,7 +270,7 @@ BOOST_AUTO_TEST_CASE(circle_track__nonzero_target_time)
 
 	const auto& first_track_sample = my_endgame.GetCauchySamples<BCT>().back();
 
-	BOOST_CHECK((first_track_sample - sample).norm() < 1e-5);
+	BOOST_CHECK((first_track_sample - sample).template lpNorm<Eigen::Infinity>() < 1e-5);
 
 } // end circle_track_nonzero_target_time
 
@@ -969,8 +968,8 @@ BOOST_AUTO_TEST_CASE(first_approximation_using_pseg)
 
 
 	auto first_approx_success = my_endgame.InitialPowerSeriesApproximation(time,sample,origin,first_approx);
-
-	BOOST_CHECK((first_approx - x_origin).norm() < 1e-2);
+	BOOST_CHECK(first_approx_success == SuccessCode::Success);
+	BOOST_CHECK((first_approx - x_origin).template lpNorm<Eigen::Infinity>() < 1e-2);
 	BOOST_CHECK(my_endgame.CycleNumber() == 3);
 
 }// end first_approximation_using_pseg
@@ -1037,7 +1036,7 @@ BOOST_AUTO_TEST_CASE(first_approximation_using_pseg_nonzero_target_time)
 
 	auto first_approx_success = my_endgame.InitialPowerSeriesApproximation(start_time,start_sample,target_time,first_approx);
 
-	BOOST_CHECK((first_approx - x_to_check_against).norm() < 1e-2);
+	BOOST_CHECK((first_approx - x_to_check_against).template lpNorm<Eigen::Infinity>() < 1e-2);
 	BOOST_CHECK(my_endgame.CycleNumber() == 1);
 
 }// end first_approximation_using_pseg_nonzero_target_time
@@ -1103,7 +1102,7 @@ BOOST_AUTO_TEST_CASE(compute_cauchy_approximation_cycle_num_1)
 	Vec<BCT> first_cauchy_approx;
 	auto code = my_endgame.ComputeCauchyApproximationOfXAtT0<BCT>(first_cauchy_approx);
 
-	BOOST_CHECK((first_cauchy_approx - x_origin).norm() < 1e-5);
+	BOOST_CHECK((first_cauchy_approx - x_origin).template lpNorm<Eigen::Infinity>() < 1e-5);
 
 }// end compute_cauchy_approximation_cycle_num_1
 
@@ -1173,7 +1172,7 @@ BOOST_AUTO_TEST_CASE(compute_cauchy_approximation_cycle_num_greater_than_1)
 	Vec<BCT> first_cauchy_approx;
 	auto code = my_endgame.ComputeCauchyApproximationOfXAtT0<BCT>(first_cauchy_approx);
 
-	BOOST_CHECK((first_cauchy_approx - x_origin).norm() < 1e-5);
+	BOOST_CHECK((first_cauchy_approx - x_origin).template lpNorm<Eigen::Infinity>() < 1e-5);
 }// end compute_cauchy_approximation_cycle_num_greater_than_1
 
 
@@ -1226,7 +1225,7 @@ BOOST_AUTO_TEST_CASE(cauchy_samples_cycle_num_1)
 
 	auto finding_cauchy_samples_success = my_endgame.ComputeCauchySamples(time,origin,sample);
 
-	BOOST_CHECK((my_endgame.GetCauchySamples<BCT>().back() - my_endgame.GetCauchySamples<BCT>().front()).norm() < 1e-5);
+	BOOST_CHECK((my_endgame.GetCauchySamples<BCT>().back() - my_endgame.GetCauchySamples<BCT>().front()).template lpNorm<Eigen::Infinity>() < 1e-5);
 	BOOST_CHECK(my_endgame.GetCauchySamples<BCT>().size() == 4);
 	BOOST_CHECK(my_endgame.CycleNumber() == 1);
 
@@ -1280,7 +1279,7 @@ BOOST_AUTO_TEST_CASE(find_cauchy_samples_cycle_num_greater_than_1)
 
 	auto finding_cauchy_samples_success = my_endgame.ComputeCauchySamples(time,origin,sample);
 
-	BOOST_CHECK((my_endgame.GetCauchySamples<BCT>().back() - my_endgame.GetCauchySamples<BCT>().front()).norm() < 1e-6);
+	BOOST_CHECK((my_endgame.GetCauchySamples<BCT>().back() - my_endgame.GetCauchySamples<BCT>().front()).template lpNorm<Eigen::Infinity>() < 1e-6);
 	BOOST_CHECK_EQUAL(my_endgame.GetCauchySamples<BCT>().size(), 7);
 	BOOST_CHECK_EQUAL(my_endgame.CycleNumber(), 2);
 
@@ -1340,7 +1339,7 @@ BOOST_AUTO_TEST_CASE(full_test_cycle_num_1)
 
 	auto cauchy_endgame_success = my_endgame.Run(time,sample);
 
-	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - solution).norm() < 1e-5);
+	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - solution).template lpNorm<Eigen::Infinity>() < 1e-5);
 	BOOST_CHECK_EQUAL(my_endgame.CycleNumber(), 1);
 
 }// end full_test_cycle_num_1
@@ -1398,7 +1397,7 @@ BOOST_AUTO_TEST_CASE(full_test_cycle_num_greater_than_1)
 
 
 	BOOST_CHECK(cauchy_endgame_success==SuccessCode::Success);
-	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - x_origin).norm() < 1e-5);
+	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - x_origin).template lpNorm<Eigen::Infinity>() < 1e-5);
 	BOOST_CHECK_EQUAL(my_endgame.CycleNumber(), 2);
 }// end full_test_cycle_num_greater_than_1
 
@@ -1459,7 +1458,7 @@ BOOST_AUTO_TEST_CASE(cauchy_endgame_test_cycle_num_greater_than_1_base)
 	auto cauchy_endgame_success = my_endgame.Run(time,sample);
 
 	BOOST_CHECK(cauchy_endgame_success==SuccessCode::Success);
-	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - x_origin).norm() < 1e-5);
+	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - x_origin).template lpNorm<Eigen::Infinity>() < 1e-5);
 	BOOST_CHECK_EQUAL(my_endgame.CycleNumber(), 2);
 }// end cauchy_endgame_test_cycle_num_greater_than_1
 
@@ -1514,7 +1513,7 @@ BOOST_AUTO_TEST_CASE(cauchy_multiple_variables)
 
 	my_endgame.Run(current_time,current_space);
 
-	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - correct).norm() < 1e-11);
+	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - correct).template lpNorm<Eigen::Infinity>() < 1e-11);
 
 }// end cauchy_multiple_variables
 
@@ -1643,7 +1642,7 @@ BOOST_AUTO_TEST_CASE(cauchy_full_run_nonzero_target_time)
 	auto endgame_success = my_endgame.Run(start_time,start_sample,target_time);
 	BOOST_CHECK(endgame_success == SuccessCode::Success);
 
-	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - x_to_check_against).norm() < 1e-10);
+	BOOST_CHECK((my_endgame.FinalApproximation<BCT>() - x_to_check_against).template lpNorm<Eigen::Infinity>() < 1e-10);
 
 }// end cauchy_full_run_nonzero_target_time
 
@@ -1837,12 +1836,13 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system)
 	tracker.PrecisionSetup(precision_config);
 	
 	unsigned num_paths_to_track{1};
-	BCT t_start(1), t_endgame_boundary(0.1);
+	BCT t_start(1);
 	std::vector<Vec<BCT> > solutions;
 	std::vector<Vec<BCT> > homogenized_solutions;
 	for (unsigned ii = 0; ii < num_paths_to_track; ++ii)
 	{
 		DefaultPrecision(ambient_precision);
+		BCT t_endgame_boundary{0.1};
 		final_system.precision(ambient_precision);
 		auto start_point = TD.StartPoint<BCT>(ii);
 
@@ -1870,14 +1870,16 @@ BOOST_AUTO_TEST_CASE(total_degree_start_system)
 
 	unsigned num_successful_occurences = 0;
 	unsigned num_min_track_time_reached = 0;
-	for (auto s : homogenized_solutions)
+	for (const auto& s : homogenized_solutions)
 	{
-		DefaultPrecision(ambient_precision);
-		final_system.precision(Precision(s(0)));
+		auto eg_prec = Precision(s);
+		DefaultPrecision(eg_prec);
+		BCT t_endgame_boundary{0.1};
+		final_system.precision(eg_prec);
 		SuccessCode endgame_success = my_endgame.Run(t_endgame_boundary,s);
 		if(endgame_success == SuccessCode::Success)
 		{
-			if((tracker.GetSystem().DehomogenizePoint(my_endgame.FinalApproximation<BCT>())-correct).norm() < 1e-11)
+			if((tracker.GetSystem().DehomogenizePoint(my_endgame.FinalApproximation<BCT>())-correct).template lpNorm<Eigen::Infinity>() < 1e-11)
 			{
 				num_successful_occurences++;
 			}

--- a/core/test/endgames/generic_cauchy_test.hpp
+++ b/core/test/endgames/generic_cauchy_test.hpp
@@ -666,7 +666,7 @@ BOOST_AUTO_TEST_CASE(compare_cauchy_ratios)
 	my_endgame.SetCauchySamples(cauchy_samples);
 
 	auto tracking_success =  my_endgame.CircleTrack(time,origin,sample);
-	BOOST_CHECK(my_endgame.RatioEGOperatingZoneTest<BCT>() == true);
+	BOOST_CHECK(my_endgame.RatioEGOperatingZoneTest<BCT>(origin) == true);
 
 } // end compare cauchy ratios for cauchy class test
 
@@ -728,7 +728,7 @@ BOOST_AUTO_TEST_CASE(compare_cauchy_ratios_cycle_num_greater_than_1)
 	my_endgame.SetCauchySamples(cauchy_samples);
 	
 	auto tracking_success =  my_endgame.CircleTrack(time,origin,sample);
-	BOOST_CHECK(my_endgame.RatioEGOperatingZoneTest<BCT>() == true);
+	BOOST_CHECK(my_endgame.RatioEGOperatingZoneTest<BCT>(origin) == true);
 
 } // end compare cauchy ratios for cycle num greater than 1 cauchy class test
 

--- a/core/test/endgames/generic_pseg_test.hpp
+++ b/core/test/endgames/generic_pseg_test.hpp
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(compute_bound_on_cycle_num)
 	my_endgame.SetTimes(times);
 	my_endgame.SetSamples(samples);
 
-	my_endgame.SetRandVec(samples.back());
+	my_endgame.SetRandVec<BCT>(samples.back().size());
 	my_endgame.ComputeBoundOnCycleNumber<BCT>();
 
 
@@ -409,7 +409,7 @@ BOOST_AUTO_TEST_CASE(compute_cycle_number)
 	my_endgame.SetTimes(times);
 	my_endgame.SetSamples(samples);
 
-	my_endgame.SetRandVec(samples.back());
+	my_endgame.SetRandVec<BCT>(samples.back().size());
 	my_endgame.ComputeCycleNumber<BCT>();
 
 	BOOST_CHECK(my_endgame.CycleNumber() == 1);
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE(compute_approximation_of_x_at_t0)
 
 	Vec<BCT> first_approx;
 	Vec<BCT> approx_1(1);
-	my_endgame.SetRandVec(samples.back());
+	my_endgame.SetRandVec<BCT>(samples.back().size());
 	auto code = my_endgame.ComputeApproximationOfXAtT0(first_approx, origin);
 	approx_1 << ComplexFromString("1.04025","6.86403e-14");
 	BOOST_CHECK(code==SuccessCode::Success);

--- a/core/test/settings/settings_test.cpp
+++ b/core/test/settings/settings_test.cpp
@@ -1,19 +1,19 @@
 //This file is part of Bertini 2.
 //
-//settings_test.cpp is free software: you can redistribute it and/or modify
+//test/settings/settings_test.cpp is free software: you can redistribute it and/or modify
 //it under the terms of the GNU General Public License as published by
 //the Free Software Foundation, either version 3 of the License, or
 //(at your option) any later version.
 //
-//settings_test.cpp is distributed in the hope that it will be useful,
+//test/settings/settings_test.cpp is distributed in the hope that it will be useful,
 //but WITHOUT ANY WARRANTY; without even the implied warranty of
 //MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //GNU General Public License for more details.
 //
 //You should have received a copy of the GNU General Public License
-//along with settings_test.cpp.  If not, see <http://www.gnu.org/licenses/>.
+//along with test/settings/settings_test.cpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2015, 2016 by Bertini2 Development Team
+// Copyright(C) 2015 - 2017 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license, 
 // as well as COPYING.  Bertini2 is provided with permitted 
@@ -22,6 +22,7 @@
 //  Created by Collins, James B. on 8/27/15.
 //  Copyright (c) 2015 West Texas A&M University.
 //
+// additionally authored by Dani Brake, University of Notre Dame
 
 //TODO: make the DYN_LINK change depending on the targeted architecture.  some need it, others don't.
 //if used, this BOOST_TEST_DYN_LINK appear before #include <boost/test/unit_test.hpp>
@@ -606,7 +607,7 @@ BOOST_AUTO_TEST_CASE(all_config_settings_mp)
 	
 	std::string configStr = inputfile.Config();
 	
-	auto sets = GetConfigSettings<mpfr_float, config::Predictor, config::Newton, algorithm::config::Tolerances<mpfr_float>, config::Endgame<mpfr_float>, config::Stepping<mpfr_float>>(configStr);
+	auto sets = ConfigParser<mpfr_float, config::Predictor, config::Newton, algorithm::config::Tolerances<mpfr_float>, config::Endgame<mpfr_float>, config::Stepping<mpfr_float>>::Parse(configStr);
 	
 	config::Stepping<mpfr_float> steps = std::get<config::Stepping<mpfr_float>>(sets);
 	config::Predictor pred = std::get<config::Predictor>(sets);
@@ -636,7 +637,7 @@ BOOST_AUTO_TEST_CASE(all_config_settings_d)
 	
 	std::string configStr = inputfile.Config();
 	
-	auto sets = GetConfigSettings<double, config::Predictor, config::Newton, algorithm::config::Tolerances<double>, config::Endgame<double>, config::Stepping<double>>(configStr);
+	auto sets = ConfigParser<double, config::Predictor, config::Newton, algorithm::config::Tolerances<double>, config::Endgame<double>, config::Stepping<double>>::Parse(configStr);
 	
 	config::Stepping<double> steps = std::get<config::Stepping<double>>(sets);
 	config::Predictor pred = std::get<config::Predictor>(sets);

--- a/core/test/tracking_basics/fixed_precision_tracker_test.cpp
+++ b/core/test/tracking_basics/fixed_precision_tracker_test.cpp
@@ -100,7 +100,6 @@ BOOST_AUTO_TEST_CASE(double_tracker_track_linear)
 
 	auto code = tracker.TrackPath(y_end, t_start, t_end, y_start);
 	BOOST_CHECK(code==SuccessCode::Success);
-	std::cout << code << '\n';
 
 	BOOST_CHECK_EQUAL(y_end.size(),1);
 	BOOST_CHECK(abs(y_end(0)-dbl(0)) < 1e-5);

--- a/core/test/tracking_basics/higher_predictor_test.cpp
+++ b/core/test/tracking_basics/higher_predictor_test.cpp
@@ -29,10 +29,10 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/multiprecision/mpfr.hpp>
-#include "limbo.hpp"
-#include "mpfr_complex.hpp"
+#include "bertini2/limbo.hpp"
+#include "bertini2/mpfr_complex.hpp"
 
-#include "trackers/ode_predictors.hpp"
+#include "bertini2/trackers/ode_predictors.hpp"
 
 
 using System = bertini::System;

--- a/core/test/tracking_basics/newton_correct_test.cpp
+++ b/core/test/tracking_basics/newton_correct_test.cpp
@@ -427,7 +427,7 @@ BOOST_AUTO_TEST_CASE(circle_line_one_corrector_step_double)
 	
 	BOOST_AUTO_TEST_CASE(newton_step_amp_criterion_C_violated_double)
 	{
-		
+		DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 		/*
 		 Using the Griewank Osborne example. Starting at t = 0 where there is a multiplicity 3 isolated solution. We predict
 		 to .1 and try to correct back down. Anywhere except at t = 0, we will have divergence.
@@ -494,6 +494,7 @@ BOOST_AUTO_TEST_CASE(circle_line_one_corrector_step_double)
 	
 	BOOST_AUTO_TEST_CASE(newton_step_amp_criterion_C_violated_mp)
 	{
+		DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 		/*
 		 Using the Griewank Osborne example. Starting at t = 0 where there is a multiplicity 3 isolated solution. We predict
 		 to .1 and try to correct back down. Anywhere except at t = 0, we will have divergence.
@@ -675,7 +676,7 @@ BOOST_AUTO_TEST_CASE(circle_line_one_corrector_step_double)
 	
 	BOOST_AUTO_TEST_CASE(newton_step_diverging_to_infinity_fails_to_converge_d)
 	{
-		
+		DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 		/*
 		 Using the Griewank Osborne example. Starting at t = 0 where there is a multiplicity 3 isolated solution. We predict
 		 to .1 and try to correct back down. Anywhere except at t = 0, we will have divergence.
@@ -730,6 +731,7 @@ BOOST_AUTO_TEST_CASE(circle_line_one_corrector_step_double)
 	
 	BOOST_AUTO_TEST_CASE(newton_step_diverging_to_infinity_fails_to_converge_mp)
 	{
+		DefaultPrecision(TRACKING_TEST_MPFR_DEFAULT_DIGITS);
 		/*
 		 Using the Griewank Osborne example. Starting at t = 0 where there is a multiplicity 3 isolated solution. We predict
 		 to .1 and try to correct back down. Anywhere except at t = 0, we will have divergence. The difference from this

--- a/python/include/system_export.hpp
+++ b/python/include/system_export.hpp
@@ -34,7 +34,7 @@
 #ifndef BERTINI_PYTHON_SYSTEM_EXPORT_HPP
 #define BERTINI_PYTHON_SYSTEM_EXPORT_HPP
 #include <bertini2/system/system.hpp>
-#include <bertini2/system/start_system.hpp>
+#include <bertini2/system/start_systems.hpp>
 
 
 

--- a/python/test/classes/test_classes.py
+++ b/python/test/classes/test_classes.py
@@ -28,11 +28,11 @@
 
 from __future__ import print_function
 
-import mpfr_test
-import function_tree_test
-import differentiation_test
-import system_test
-import parser_test
+import classes.mpfr_test as mpfr_test
+import classes.function_tree_test as function_tree_test
+import classes.differentiation_test as differentiation_test
+import classes.system_test as system_test
+import classes.parser_test as parser_test
 
 import unittest
 

--- a/python/test/tracking/test_tracking.py
+++ b/python/test/tracking/test_tracking.py
@@ -26,8 +26,8 @@
 #   Spring 2016
 # 
 
-import amptracking_test
-import endgame_test
+import tracking.amptracking_test as amptracking_test
+import tracking.endgame_test as endgame_test
 import unittest
 
 


### PR DESCRIPTION
this PR represents a bunch of improvements, sorry not in smaller packets.

we can 
* parse all b1 config structs
* run tests in any order and expect success
* construct zerodim algorithms based on runtime choices

and more.