### PR TITLE
Feature/fix eigen pass by reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ python/build/
 # Python files
 *.pyc
 
-
+python/pybertini_*.log
 
 *.dirstamp
 *.deps

--- a/python/examples/evaluate_system.py
+++ b/python/examples/evaluate_system.py
@@ -1,6 +1,8 @@
 import pybertini as pb
 import numpy as np
 
+pb.default_precision(500)
+
 x = pb.Variable('x')
 y = pb.Variable('y')
 z = pb.Variable('z')
@@ -15,13 +17,12 @@ sys.add_function(5*x**3 + 16*x*y**4 - 17*x*y*z - z**3)
 
 sys.add_variable_group(vg)
 
-C = pb.multiprec.Complex # unpack a type for convenience
+random_complex = lambda : pb.random.complex_in_minus_one_to_one()
 
-gen = lambda : pb.random.complex_in_minus_one_to_one()
-variable_values = np.array([gen(), gen(), gen()])
-
-print(variable_values)
-
-result = sys.eval(variable_values)
+n_iterations = 10000
+print(f'evaluating system at random complex point {n_iterations} times at precision {pb.default_precision()}')
+for ii in range(n_iterations):
+	variable_values = np.array([random_complex(), random_complex(), random_complex()])
+	result = sys.eval(variable_values)
 
 

--- a/python/examples/evaluate_system.py
+++ b/python/examples/evaluate_system.py
@@ -17,8 +17,10 @@ sys.add_variable_group(vg)
 
 C = pb.multiprec.Complex # unpack a type for convenience
 
-gen = lambda : pb.random.complex_in_minus_one_to_one
+gen = lambda : pb.random.complex_in_minus_one_to_one()
 variable_values = np.array([gen(), gen(), gen()])
+
+print(variable_values)
 
 result = sys.eval(variable_values)
 

--- a/python/examples/track_path_constructed_homotopy.py
+++ b/python/examples/track_path_constructed_homotopy.py
@@ -1,0 +1,45 @@
+import pybertini as pb
+
+pb.logging.init()
+# pb.logging.add_file('asdf.txt')
+
+import numpy as np
+
+x = pb.Variable('x')
+y = pb.Variable('y')
+z = pb.Variable('z')
+
+t = pb.Variable('t')
+
+vg = pb.VariableGroup([x,y,z])
+
+f = pb.System()
+
+f.add_function(x-y)
+f.add_function(x**2 + y**2 - 1)
+f.add_function(5*x**3 + 16*x*y**4 - 17*x*y*z - z**3)
+
+f.add_variable_group(vg)
+
+g = pb.system.start_system.TotalDegree(f)
+
+homotopy = t*g + (1-t)*f
+
+homotopy.add_path_variable(t);
+
+
+print(homotopy)
+
+C = pb.multiprec.Complex
+
+tracker = pb.tracking.AMPTracker(homotopy);
+
+print(tracker)
+
+result = np.empty((3,),dtype=C)
+
+start_point = g.start_point_mp(0)
+
+print(start_point)
+
+tracker.track_path(result, C(1) , C(0), start_point)

--- a/python/examples/track_path_constructed_homotopy.py
+++ b/python/examples/track_path_constructed_homotopy.py
@@ -36,7 +36,8 @@ tracker = pb.tracking.AMPTracker(homotopy);
 
 print(tracker)
 
-result = np.empty((3,),dtype=C)
+result = np.empty((3,),dtype=C)  # right now, if i don't preset to the correct size, i get abort traps.
+# there's something deeper wrong with the wrapper i wrote, cuz it should allow resizing, but it's not.
 
 start_point = g.start_point_mp(0)
 

--- a/python/include/endgame_export.hpp
+++ b/python/include/endgame_export.hpp
@@ -80,6 +80,13 @@ namespace bertini{
 				return &BaseEGT::CycleNumber;
 			};
 
+			template <typename T>
+			static 
+			Vec<T> return_final_approximation(EndgameT const& self)
+			{
+				return self.template FinalApproximation<T>();
+			}
+
 		};// EndgameVisitor class
 
 

--- a/python/include/system_export.hpp
+++ b/python/include/system_export.hpp
@@ -121,6 +121,17 @@ namespace bertini{
 				return &SystemBaseT::template Eval<T>;
 			};
 
+
+			// evaluate at arguments passed in, return a vector
+			// in case you wondered how it's done, this is how you enable wrapping of in-place using a Ref.  
+			// this ended up being unnecessary, lol.   but i kept it because it might be useful 
+			// for future reference.
+			template<typename T>
+			static
+			Vec<T> eval_wrap_1(SystemBaseT const& self,  Eigen::Ref<  Vec<T>> x){
+				return self.template Eval<T>(x);
+			}
+
 			template <typename T>
 			using Eval1_ptr = Vec<T> (SystemBaseT::*)(const Vec<T>&) const;
 			template <typename T>

--- a/python/include/tracker_export.hpp
+++ b/python/include/tracker_export.hpp
@@ -68,8 +68,14 @@ namespace bertini{
 			void (TrackerT::*set_predictor_)(Predictor)= &TrackerT::SetPredictor;
 			Predictor (TrackerT::*get_predictor_)(void) const = &TrackerT::GetPredictor;
 			
-
-
+			static
+			SuccessCode track_path_wrap(TrackerT const& self, Eigen::Ref<Vec<CT>> result, CT const& start_time, CT const& end_time, Vec<CT> const& start_point)
+			{
+				Vec<CT> temp_result;
+				auto code = self.TrackPath(temp_result, start_time, end_time, start_point);
+				result = temp_result;
+				return code;
+			}
 
 
 

--- a/python/include/tracker_export.hpp
+++ b/python/include/tracker_export.hpp
@@ -71,7 +71,7 @@ namespace bertini{
 			static
 			SuccessCode track_path_wrap(TrackerT const& self, Eigen::Ref<Vec<CT>> result, CT const& start_time, CT const& end_time, Vec<CT> const& start_point)
 			{
-				Vec<CT> temp_result;
+				Vec<CT> temp_result(self.GetSystem().NumVariables());
 				auto code = self.TrackPath(temp_result, start_time, end_time, start_point);
 				result = temp_result;
 				return code;

--- a/python/pybertini/_version.py
+++ b/python/pybertini/_version.py
@@ -29,5 +29,5 @@
 
 
 
-__version__ = '1.0.alpha4'
+__version__ = '1.0.4'
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 EXCLUDE_FROM_PACKAGES = []
 
 setup(name='pybertini',
-      version='1.0.alpha3',
+      version='1.0.alpha4',
       description='Software for numerical algebraic geometry',
       url='http://github.com/bertiniteam/b2',
       author='Bertini Team',

--- a/python/src/endgame_export.cpp
+++ b/python/src/endgame_export.cpp
@@ -56,7 +56,9 @@ namespace bertini{
 			.def("get_tracker", &EndgameT::GetTracker, return_internal_reference<>(),"Get the tracker used in this endgame.  This is the same tracker as you feed the endgame object when you make it.  This is a reference variable")
 			.def("get_system",  &EndgameT::GetSystem,  return_internal_reference<>(),"Get the tracked system.  This is a reference to the internal system.")
 
-			.def("final_approximation", &EndgameT::template FinalApproximation<BCT>, return_internal_reference<>(),"Get the current approximation of the root, in the ambient numeric type for the tracker being used")
+			// .def("final_approximation", &EndgameT::template FinalApproximation<BCT>, return_internal_reference<>(),"Get the current approximation of the root, in the ambient numeric type for the tracker being used")
+			.def("final_approximation", &return_final_approximation<BCT>,"get")
+
 			.def("run", RunDefaultTime<BCT>(),
 				 (boost::python::arg("start_time"), "start_point"), 
 				 "Run the endgame, from start point and start time, to t=0.  Expects complex numeric type matching that of the tracker being used.")

--- a/python/src/mpfr_export.cpp
+++ b/python/src/mpfr_export.cpp
@@ -473,11 +473,10 @@ namespace bertini{
 
 
 
-			eigenpy::enableEigenPySpecific<bertini::Mat<T>>();
-			eigenpy::enableEigenPySpecific<bertini::Vec<T>>();
-
+			eigenpy::EigenToPyConverter<Vec<T>>::registration();
+			eigenpy::EigenToPyConverter<Mat<T>>::registration();
 			eigenpy::EigenFromPyConverter<Vec<T>>::registration();
-  		eigenpy::EigenFromPyConverter<Mat<T>>::registration();
+			eigenpy::EigenFromPyConverter<Mat<T>>::registration();
 
 		}
 

--- a/python/src/system_export.cpp
+++ b/python/src/system_export.cpp
@@ -69,6 +69,11 @@ namespace bertini{
 			.def("eval", return_Eval2_ptr<dbl>() ,"Evaluate the system in double precision using space and time values passed into this function.  Throws if doesn't use a time variable")
 			.def("eval", return_Eval2_ptr<mpfr>() ,"Evaluate the system in multiple precision using space and time values passed into this function.  Throws if doesn't use a time variable")
 			
+			// these two commented out because i don't need in-place Eigen::Ref wrapping here. 
+			// but if you did, you'd use two lines like this, ha.
+			// .def("eval", &eval_wrap_1<mpfr>)
+			// .def("eval", &eval_wrap_1<dbl>)
+
 			.def("eval_jacobian", return_Jac0_ptr<dbl>() ,"Evaluate the Jacobian (martix of partial derivatives) of the system, using already-set time and space value.")
 			.def("eval_jacobian", return_Jac0_ptr<mpfr>() ,"Evaluate the Jacobian (martix of partial derivatives) of the system, using already-set time and space value.")
 			.def("eval_jacobian", return_Jac1_ptr<dbl>() ,"Evaluate the Jacobian (martix of partial derivatives) of the system, using space values you pass in to this function")

--- a/python/src/tracker_export.cpp
+++ b/python/src/tracker_export.cpp
@@ -40,9 +40,9 @@ namespace bertini{
 			cl
 			.def("setup", &TrackerT::Setup, (boost::python::arg("predictor"), boost::python::arg("tolerance"), boost::python::arg("truncation"), boost::python::arg("stepping"),boost::python::arg("newton")), "Set values for the internal configuration of the tracker.  tolerance and truncation are both real doubles.  predictor is a valid value for predictor choice.  stepping and newton are the config structs from pybertini.tracking.config.")
 
-			.def("track_path", &TrackerT::TrackPath, 
+			.def("track_path", &track_path_wrap, 
 				 (boost::python::arg("result"), "start_time", "end_time", "start_point"), 
-				 "The main function of the tracker, once its set up.  Feed it, in (result, start_time, end_time, start_point")
+				 "The main function of the tracker, once its set up.  The first argument is the output.  Feed it, in (result, start_time, end_time, start_point")
 
 			.def("get_system",&TrackerT::GetSystem,return_internal_reference<>(), "Gets an internal reference to the tracked system.")
 

--- a/python/test/tracking/amptracking_test.py
+++ b/python/test/tracking/amptracking_test.py
@@ -90,11 +90,11 @@ class AMPTrackingTest(unittest.TestCase):
 
         y_start = np.array([mpfr_complex(1)]);
 
-        y_end = np.array([]);
+        y_end = np.empty(shape=(s.num_variables()),dtype=mpfr_complex);
 
         tracker.track_path(y_end, t_start, t_end, y_start);
 
-        self.assertEqual(y_end.rows(), 1)
+        self.assertEqual(y_end.shape, (s.num_variables(),))
         self.assertLessEqual(mp.abs(y_end[0]-mpfr_complex(0)), 1e-5)
 
 
@@ -128,11 +128,11 @@ class AMPTrackingTest(unittest.TestCase):
 
         y_start = np.array([mpfr_complex(1)]);
 
-        y_end = np.array([]);
+        y_end = np.empty(shape=(s.num_variables()),dtype=mpfr_complex);
 
         tracker.track_path(y_end, t_start, t_end, y_start);
 
-        self.assertEqual(y_end.rows(), 1)
+        self.assertEqual(y_end.shape, (s.num_variables(),))
         self.assertLessEqual(mp.abs(y_end[0]-mpfr_complex(1)), 1e-5)
 
 
@@ -164,12 +164,12 @@ class AMPTrackingTest(unittest.TestCase):
 
         y_start = np.array([mpfr_complex(1), mpfr_complex(1)]);
 
-        y_end = np.array([]);
+        y_end = np.empty(shape=(s.num_variables()),dtype=mpfr_complex);
 
         track_success = tracker.track_path(y_end, t_start, t_end, y_start);
 
         self.assertTrue(track_success == SuccessCode.Success)
-        self.assertEqual(y_end.rows(), 2)
+        self.assertEqual(y_end.shape, (s.num_variables(),))
         self.assertLessEqual(mp.abs(y_end[0]-mpfr_complex(0)), 1e-5)
         self.assertLessEqual(mp.abs(y_end[1]-mpfr_complex(0)), 1e-5)
 
@@ -177,7 +177,7 @@ class AMPTrackingTest(unittest.TestCase):
 
         tracker.track_path(y_end, t_start, t_end, y_start);
 
-        self.assertEqual(y_end.rows(), 2)
+        self.assertEqual(y_end.shape, (s.num_variables(),))
         self.assertLessEqual(mp.abs(y_end[0]-mpfr_complex(0)), 1e-5)
         self.assertLessEqual(mp.abs(y_end[1]-mpfr_complex(0)), 1e-5)
 
@@ -186,7 +186,7 @@ class AMPTrackingTest(unittest.TestCase):
 
         tracker.track_path(y_end, t_start, t_end, y_start);
 
-        self.assertEqual(y_end.rows(), 2)
+        self.assertEqual(y_end.shape, (s.num_variables(),))
         self.assertLessEqual(mp.abs(y_end[0]-mpfr_complex(0)), 1e-5)
         self.assertLessEqual(mp.abs(y_end[1]-mpfr_complex(0)), 1e-5)
 
@@ -197,7 +197,7 @@ class AMPTrackingTest(unittest.TestCase):
 
 
         self.assertTrue(track_success == SuccessCode.Success)
-        self.assertEqual(y_end.rows(), 2)
+        self.assertEqual(y_end.shape, (s.num_variables(),))
         self.assertLessEqual(mp.abs(y_end[0]-mpfr_complex(0)), 1e-5)
         self.assertLessEqual(mp.abs(y_end[1]-mpfr_complex(0)), 1e-5)
 
@@ -229,12 +229,13 @@ class AMPTrackingTest(unittest.TestCase):
 
         y_start = np.array([mpfr_complex(0), mpfr_complex(0)]);
 
-        y_end = np.array([]);
+
+        y_end = np.empty(shape=(s.num_variables(),),dtype=mpfr_complex);
 
         track_success = tracker.track_path(y_end, t_start, t_end, y_start);
 
         self.assertTrue(track_success == SuccessCode.SingularStartPoint)
-        self.assertEqual(y_end.rows(), 0)
+        self.assertEqual(y_end.shape, (s.num_variables(),))
 
 
 

--- a/python/test/tracking/endgame_test.py
+++ b/python/test/tracking/endgame_test.py
@@ -111,13 +111,13 @@ class EndgameTest(unittest.TestCase):
         t_endgame_boundary = mpfr_complex("0.1");
         t_final = mpfr_complex(0);
 
-        bdry_points = [np.empty(dtype=mpfr_complex, shape=(0,)) for i in range(n)]
+        bdry_points = [np.empty(dtype=mpfr_complex, shape=(3,)) for i in range(n)]
         for i in range(n):
             default_precision(self.ambient_precision);
             final_system.precision(self.ambient_precision);
             start_point = td.start_point_mp(i);
 
-            bdry_pt = np.empty(dtype=mpfr_complex, shape=(0,));
+            bdry_pt = np.empty(dtype=mpfr_complex, shape=(3,));
             track_success_code = tracker.track_path(bdry_pt,t_start, t_endgame_boundary, start_point);
             bdry_points[i] = bdry_pt;
 
@@ -129,7 +129,7 @@ class EndgameTest(unittest.TestCase):
         my_endgame = AMPCauchyEG(tracker);
 
 
-        final_homogenized_solutions = [np.empty(dtype=mpfr_complex, shape=(0,)) for i in range(n)]
+        final_homogenized_solutions = [np.empty(dtype=mpfr_complex, shape=(3,)) for i in range(n)]
         for i in range(n):
             default_precision(bdry_points[i][0].precision());
             final_system.precision(bdry_points[i][0].precision());


### PR DESCRIPTION
an attempt to get functions which return by pass by reference to be callable using numpy objects from python.

the workaround is super hacky.  i hate it.  the real solution is to actually use `Eigen::Ref` throughout the core.  please make that change (it's not trivial).