### PR TITLE
Feature/eigenpy alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-default branch status: <img src="https://bertini2.org/status.png" width="100">
-
 ### Important note on cloning
 
 The recommended method for getting the code for Bertini 2 is to clone from command line using git:

--- a/python/examples/solve_system.py
+++ b/python/examples/solve_system.py
@@ -18,6 +18,7 @@ C = pb.multiprec.Complex
 variable_values = np.array([C(0), C(0)])
 
 result = sys.eval(variable_values)
+print(result)
 
 sys.homogenize()
 sys.auto_patch()

--- a/python/include/endgame_export.hpp
+++ b/python/include/endgame_export.hpp
@@ -13,7 +13,7 @@
 //You should have received a copy of the GNU General Public License
 //along with python/endgame_export.hpp.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Copyright(C) 2016-2018 by Bertini2 Development Team
+// Copyright(C) 2016-2024 by Bertini2 Development Team
 //
 // See <http://www.gnu.org/licenses/> for a copy of the license, 
 // as well as COPYING.  Bertini2 is provided with permitted 
@@ -23,7 +23,7 @@
 //
 //  silviana amethyst
 //  University of Notre Dame
-//  Summer 2016
+//  Summer 2016, Summer 2023, Fall 2024
 //
 //
 //  python/endgame_export.hpp:  Header file for exposing endgames to python.
@@ -53,26 +53,20 @@ namespace bertini{
 			
 		private:
 
-			using CT = typename TrackerTraits<typename EndgameT::TrackerType>::BaseComplexType;
-			using RT = typename TrackerTraits<typename EndgameT::TrackerType>::BaseRealType;
+			using BCT = typename TrackerTraits<typename EndgameT::TrackerType>::BaseComplexType;
+			using BRT = typename TrackerTraits<typename EndgameT::TrackerType>::BaseRealType;
 			using BaseEGT = typename EndgameT::BaseEGT;
 
-			template <typename T>
-			using sc_of_time_space = SuccessCode (BaseEGT::*)(T const&, Vec<T> const&);
-			template <typename T>
-			using sc_of_time_space_time = SuccessCode (BaseEGT::*)(T const&, Vec<T> const&, T const&);
+			static
+			SuccessCode WrapRunDefaultTime(EndgameT & self, BCT const& t, const Eigen::Ref<const Vec<BCT>> s){
+				return self.Run(t, s);
+			}
 
-			template <typename T>
-			static sc_of_time_space<T> RunDefaultTime()
-			{
-				return &BaseEGT::Run;
-			};
+			static
+			SuccessCode WrapRunCustomTime(EndgameT & self, BCT const& t, const Eigen::Ref<const Vec<BCT>> s, BCT const& u){
+				return self.Run(t, s, u);
+			}
 
-			template <typename T>
-			static sc_of_time_space_time<T> RunCustomTime()
-			{
-				return &BaseEGT::Run;
-			};
 			
 			using unsigned_of_void = unsigned (BaseEGT::*)() const;
 			static unsigned_of_void GetCycleNumberFn()
@@ -105,8 +99,8 @@ namespace bertini{
 			
 		private:
 
-			using CT = typename TrackerTraits<typename PowerSeriesT::TrackerType>::BaseComplexType;
-			using RT = typename TrackerTraits<typename PowerSeriesT::TrackerType>::BaseRealType;
+			using BCT = typename TrackerTraits<typename PowerSeriesT::TrackerType>::BaseComplexType;
+			using BRT = typename TrackerTraits<typename PowerSeriesT::TrackerType>::BaseRealType;
 
 
 		};// CauchyVisitor class
@@ -128,8 +122,8 @@ namespace bertini{
 			
 		private:
 
-			using CT = typename TrackerTraits<typename CauchyT::TrackerType>::BaseComplexType;
-			using RT = typename TrackerTraits<typename CauchyT::TrackerType>::BaseRealType;
+			using BCT = typename TrackerTraits<typename CauchyT::TrackerType>::BaseComplexType;
+			using BRT = typename TrackerTraits<typename CauchyT::TrackerType>::BaseRealType;
 
 
 		};// CauchyVisitor class

--- a/python/src/endgame_export.cpp
+++ b/python/src/endgame_export.cpp
@@ -56,19 +56,20 @@ namespace bertini{
 			.def("get_tracker", &EndgameT::GetTracker, return_internal_reference<>(),"Get the tracker used in this endgame.  This is the same tracker as you feed the endgame object when you make it.  This is a reference variable")
 			.def("get_system",  &EndgameT::GetSystem,  return_internal_reference<>(),"Get the tracked system.  This is a reference to the internal system.")
 
-			// .def("final_approximation", &EndgameT::template FinalApproximation<BCT>, return_internal_reference<>(),"Get the current approximation of the root, in the ambient numeric type for the tracker being used")
-			.def("final_approximation", &return_final_approximation<BCT>,"get")
+			// .def("final_approximation", &EndgameT::template FinalApproximation<BCT>, return_internal_reference<>(),)
+			.def("final_approximation", &return_final_approximation<BCT>,"Get the current approximation of the root, in the ambient numeric type for the tracker being used")
 
-			.def("run", RunDefaultTime<BCT>(),
+			.def("run", &EndgameBaseVisitor::WrapRunDefaultTime,
 				 (boost::python::arg("start_time"), "start_point"), 
 				 "Run the endgame, from start point and start time, to t=0.  Expects complex numeric type matching that of the tracker being used.")
-			.def("run", RunCustomTime<BCT>(),
+			.def("run", &EndgameBaseVisitor::WrapRunCustomTime,
 				 (boost::python::arg("start_time"), "start_point", "target_time"),
 				 "Run the endgame, from start point and start time, to your choice of target time t.  Expects complex numeric type matching that of the tracker being used.")
-			.def(ObservableVisitor<EndgameT>());
-			;
-		}
 
+			.def(ObservableVisitor<EndgameT>())
+			;
+
+		}
 
 		template<typename EndgameT>
 		template<class PyClass>

--- a/python/src/mpfr_export.cpp
+++ b/python/src/mpfr_export.cpp
@@ -408,17 +408,14 @@ namespace bertini{
 			IMPLICITLY_CONVERTIBLE(long,T);
 			IMPLICITLY_CONVERTIBLE(int64_t,T);
 
+			eigenpy::EigenToPyConverter<Vec<T>>::registration();
+			eigenpy::EigenToPyConverter<Mat<T>>::registration();
 			eigenpy::EigenFromPyConverter<Vec<T>>::registration();
   		eigenpy::EigenFromPyConverter<Mat<T>>::registration();
 
 		}
 
-
 		size_t get_default_align(){return EIGENPY_DEFAULT_ALIGN_BYTES;}
-
-		auto FunctionTakingAVector(Vec<mpfr_complex> const& v){
-			return v.size();
-		}
 
 
 		void ExposeComplex()
@@ -491,8 +488,6 @@ namespace bertini{
 			boost::python::def("precision", &get_precision_vector<mpfr_complex>, "get the precision of a vector of complexes");
 
 			boost::python::def("default_align_bytes", &get_default_align);
-
-			boost::python::def("example_function", &FunctionTakingAVector);
 
 		}
 

--- a/python/test/classes/eigenpy_numpy.py
+++ b/python/test/classes/eigenpy_numpy.py
@@ -1,0 +1,107 @@
+# This file is part of Bertini 2.
+# 
+# python/test/mpfr_test.py is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# python/test/mpfr_test.py is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with python/test/mpfr_test.py.  If not, see <http://www.gnu.org/licenses/>.
+# 
+#  Copyright(C) 2024-2025 by Bertini2 Development Team
+# 
+#  See <http://www.gnu.org/licenses/> for a copy of the license, 
+#  as well as COPYING.  Bertini2 is provided with permitted 
+#  additional terms in the b2/licenses/ directory.
+
+#  individual authors of this file include:
+# 
+#   silviana amethyst
+#   Max Planck Institute of Molecular Cell Biology and Genetics
+#   Fall 2024, Spring 2025
+
+# the purpose of this test suite is to make ensure numpy functionality with the custom types defined by Bertini (via EigenPy).
+
+import numpy as np
+import pybertini as pb
+
+from pybertini import multiprec as mp
+
+import unittest
+import pdb
+
+
+class TestFloat(unittest.TestCase):
+
+    def setUp(self):
+        mp.default_precision(30);
+        self.shape = (5,10)
+
+    def test_make_array_empty(self):
+        A = np.empty(self.shape, dtype = mp.Float) 
+
+        A[0,0] = mp.Float(0)
+
+    def test_make_array_zeros(self):
+        A = np.zeros(self.shape, dtype = mp.Float) 
+
+        A[0,0] = mp.Float(1)
+
+    def test_make_array_zeros_with_conversion(self):
+        A = np.array( np.zeros(self.shape), dtype = mp.Float) 
+
+    def test_make_array_zeros_with_conversion_and_astype_int64(self):
+        A = np.array( np.zeros(self.shape).astype(np.int64), dtype = mp.Float) 
+
+
+    def test_make_array_ones(self):
+        A = np.ones(self.shape, dtype = mp.Float) 
+        A[0,0] = mp.Float(2)
+
+    def test_make_array_ones_with_conversion(self):
+        A = np.array( np.ones(self.shape), dtype = mp.Float) 
+
+    def test_make_array_ones_with_conversion_and_astype_int64(self):
+        A = np.array( np.ones(self.shape).astype(np.int64), dtype = mp.Float) 
+
+
+class TestComplex(unittest.TestCase):
+
+    def setUp(self):
+        mp.default_precision(30);
+        self.shape = (5,10)
+
+    def test_make_array_empty(self):
+        A = np.empty(self.shape, dtype = mp.Complex) 
+
+        A[0,0] = mp.Complex(0)
+
+    def test_make_array_zeros(self):
+        A = np.zeros(self.shape, dtype = mp.Complex) 
+
+        A[0,0] = mp.Complex(1)
+
+    def test_make_array_zeros_with_conversion(self):
+        A = np.array( np.zeros(self.shape), dtype = mp.Complex) 
+
+    def test_make_array_zeros_with_conversion_and_astype_int64(self):
+        A = np.array( np.zeros(self.shape).astype(np.int64), dtype = mp.Complex) 
+
+
+    def test_make_array_ones(self):
+        A = np.ones(self.shape, dtype = mp.Complex) 
+        A[0,0] = mp.Complex(2)
+
+    def test_make_array_ones_with_conversion(self):
+        A = np.array( np.ones(self.shape), dtype = mp.Complex) 
+
+    def test_make_array_ones_with_conversion_and_astype_int64(self):
+        A = np.array( np.ones(self.shape).astype(np.int64), dtype = mp.Complex) 
+
+if __name__ == '__main__':
+    unittest.main();

--- a/python/test/classes/test_classes.py
+++ b/python/test/classes/test_classes.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with python/test/b2_class_test.py.  If not, see <http://www.gnu.org/licenses/>.
 # 
-#  Copyright(C) 2016-2018 by Bertini2 Development Team
+#  Copyright(C) 2016-2025 by Bertini2 Development Team
 # 
 #  See <http://www.gnu.org/licenses/> for a copy of the license, 
 #  as well as COPYING.  Bertini2 is provided with permitted 
@@ -25,6 +25,8 @@
 #   West Texas A&M University
 #   Spring 2016
 # 
+# silviana amethyst
+# spring 2025
 
 from __future__ import print_function
 
@@ -33,13 +35,14 @@ import classes.function_tree_test as function_tree_test
 import classes.differentiation_test as differentiation_test
 import classes.system_test as system_test
 import classes.parser_test as parser_test
+import classes.eigenpy_numpy as eigenpy_numpy
 
 import unittest
 
 
 
 
-mods = (mpfr_test, function_tree_test, differentiation_test, system_test, parser_test)
+mods = (mpfr_test, function_tree_test, differentiation_test, system_test, parser_test, eigenpy_numpy)
 suite = unittest.TestSuite();
 print(mods)
 for tests in mods:

--- a/python/test/tracking/amptracking_test.py
+++ b/python/test/tracking/amptracking_test.py
@@ -90,7 +90,7 @@ class AMPTrackingTest(unittest.TestCase):
 
         y_start = np.array([mpfr_complex(1)]);
 
-        y_end = np.empty(shape=(s.num_variables()),dtype=mpfr_complex);
+        y_end = np.array(np.zeros(shape=(s.num_variables()), dtype=np.int64),dtype=mpfr_complex);
 
         tracker.track_path(y_end, t_start, t_end, y_start);
 
@@ -128,12 +128,12 @@ class AMPTrackingTest(unittest.TestCase):
 
         y_start = np.array([mpfr_complex(1)]);
 
-        y_end = np.empty(shape=(s.num_variables()),dtype=mpfr_complex);
+        y_end = np.array(np.zeros(shape=(s.num_variables()), dtype=np.int64),dtype=mpfr_complex);
 
         tracker.track_path(y_end, t_start, t_end, y_start);
 
         self.assertEqual(y_end.shape, (s.num_variables(),))
-        self.assertLessEqual(mp.abs(y_end[0]-mpfr_complex(1)), 1e-5)
+        self.assertLessEqual(mp.abs(y_end[0]-mpfr_complex(0)), 1e-5)
 
 
 
@@ -164,7 +164,7 @@ class AMPTrackingTest(unittest.TestCase):
 
         y_start = np.array([mpfr_complex(1), mpfr_complex(1)]);
 
-        y_end = np.empty(shape=(s.num_variables()),dtype=mpfr_complex);
+        y_end = np.array(np.zeros(shape=(s.num_variables()), dtype=np.int64),dtype=mpfr_complex);
 
         track_success = tracker.track_path(y_end, t_start, t_end, y_start);
 

--- a/python/test/tracking/endgame_test.py
+++ b/python/test/tracking/endgame_test.py
@@ -99,6 +99,7 @@ class EndgameTest(unittest.TestCase):
         final_system = (1-t)*sys + gamma*t*td;
         final_system.add_path_variable(t);
 
+        print('have final system')
         print(final_system)
         prec_config = AMPConfig(final_system);
 
@@ -106,7 +107,7 @@ class EndgameTest(unittest.TestCase):
         newton_pref = NewtonConfig();
 
 
-
+        print('making tracker')
         tracker = AMPTracker(final_system);
 
         tracker.setup(Predictor.RK4, 1e-5, 1e5, stepping_pref, newton_pref);
@@ -119,15 +120,20 @@ class EndgameTest(unittest.TestCase):
         t_endgame_boundary = mpfr_complex("0.1");
         t_final = mpfr_complex(0);
 
-        bdry_points = [np.empty(dtype=mpfr_complex, shape=(3,)) for i in range(n)]
+        bdry_points = []
+        print("tracking to boundary")
         for i in range(n):
             default_precision(self.ambient_precision);
             final_system.precision(self.ambient_precision);
             start_point = td.start_point_mp(i);
 
-            bdry_pt = np.empty(dtype=mpfr_complex, shape=(3));
+            bdry_pt = np.array( np.zeros( (3)).astype(np.int64),dtype=mpfr_complex)   
+
+            print(dir(bdry_pt))
+
+
             track_success_code = tracker.track_path(bdry_pt,t_start, t_endgame_boundary, start_point);
-            bdry_points[i] = bdry_pt;
+            bdry_points.append(bdry_pt);
 
             self.assertEqual(track_success_code, SuccessCode.Success)
 
@@ -139,12 +145,18 @@ class EndgameTest(unittest.TestCase):
 
 
         final_homogenized_solutions = [np.empty(dtype=mpfr_complex, shape=(3,)) for i in range(n)]
+
+        print('tracking from boundary to final time')
         for i in range(n):
             default_precision(bdry_points[i][0].precision());
             final_system.precision(bdry_points[i][0].precision());
 
-            print(dir(bdry_points[i]))
-            track_success_code = my_endgame.run(mpfr_complex(t_endgame_boundary),bdry_points[i]);
+            print(bdry_points[i])
+
+            bdry_time = mpfr_complex(t_endgame_boundary)
+            print(bdry_time)
+            # print(final_system)
+            track_success_code = my_endgame.run(bdry_time,bdry_points[i]);
             print('qwfp')
             
 


### PR DESCRIPTION
Fixes an issue with calling `Run` on endgames with startpoints from numpy arrays.   

The cause was that I'm not using `Eigen::Ref` for all interface layers with Python.  It's not obvious what the actual problem was, but the fix is to use a wrapper layer of Ref's for any function that accepts Eigen vectors or matrices, whether in/out or just in.