### PR TITLE
commented out using expression templates

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 
-add_compile_definitions(-DBMP_EXPRESSION_TEMPLATES=1)
+# add_compile_definitions(-DBMP_EXPRESSION_TEMPLATES=1)
 add_compile_options(
     # put things for debug compile here
     $<$<CONFIG:Debug>:-g>

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_PHOENIX_STL_TUPLE_H_")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 
-add_compile_definitions(-DBMP_EXPRESSION_TEMPLATES=1)
+# add_compile_definitions(-DBMP_EXPRESSION_TEMPLATES=1)
 add_compile_options(
     # put things for debug compile here
     $<$<CONFIG:Debug>:-g>


### PR DESCRIPTION
linking fails due to manual template instantiation, so I had to turn off expression templates.

Note: in light testing, turning them on seemed to bring runtime down from ~17s to ~14s, for the `test_endgames` suite for the core.  So having them on DOES save significant time.

It looks like I will have to rewrite some of the core to make this happen, sadly.