### PR TITLE
👷 ci: strip debug symbols from bundled Linux deps to reduce wheel size

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -238,7 +238,8 @@ jobs:
             rm -rf eigenpy-3.11.0 && tar zxf eigenpy-3.11.0.tar.gz &&
             cd eigenpy-3.11.0 && mkdir -p bld && cd bld &&
             cmake .. -DCMAKE_PREFIX_PATH=/tmp/deps-py -DCMAKE_INSTALL_PREFIX=/tmp/deps-py -DPython3_EXECUTABLE=$(which python) -DPython3_NumPy_INCLUDE_DIR=$(python -c "import numpy; print(numpy.get_include())") -DBUILD_TESTING=OFF &&
-            make -j2 install
+            make -j2 install &&
+            find /tmp/deps-py/lib -name '*.so*' -exec strip --strip-debug {} + 2>/dev/null || true
           # On macOS, build all Boost components (including Boost.Python) into /tmp/deps-py
           # so delocate sees only one set of dylibs. boost-base is used only for C++ tests.
           CIBW_BEFORE_BUILD_MACOS: >


### PR DESCRIPTION
libeigenpy is huge with debug symbols, pushing the manylinux wheel over TestPyPI/PyPI's 100 MB per-file limit.