### PR TITLE
ci: add `ref` input to docs workflow_dispatch for tag rebuilds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      ref:
+        description: 'Branch, tag, or SHA to check out before building (defaults to the calling workflow''s ref).'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       full_matrix:
@@ -196,6 +201,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Cache cibuildwheel + pip + Homebrew
         uses: actions/cache@v5
         with:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: true
+      ref:
+        description: 'Branch, tag, or SHA to build docs for (defaults to the dispatched ref).'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: docs-${{ github.ref }}
@@ -35,6 +40,7 @@ jobs:
       # Docs only need the ubuntu-latest / python-3.11 wheel; skip the full
       # OS/Python matrix and the wheel/C++ test jobs.
       minimal: true
+      ref: ${{ inputs.ref }}
 
   build_docs:
     name: Build docs
@@ -48,6 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ inputs.ref || github.ref }}
           # gitpython (used by python/docs/source/conf.py to derive version)
           # needs the full history; the default depth=1 leaves it unable to
           # resolve HEAD's commit object on some refs.


### PR DESCRIPTION
GitHub's workflow_dispatch resolves the workflow file from the chosen ref, so build_docs.yml — which only exists on develop — cannot be dispatched against pre-existing tags like v2.0.1. Adds a `ref` input on build_docs.yml and threads it through to the reusable build_and_test call so the wheel and the docs are both built from the requested ref.