### PR TITLE
Extend Python support in CI matrix and update cibuildwheel version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -213,7 +213,7 @@ jobs:
             ~/.cache/cibuildwheel
             ~/Library/Caches/Homebrew
             /tmp/boost_1_90_0.tar.bz2
-            /tmp/eigenpy-3.11.0.tar.gz
+            /tmp/eigenpy-3.12.0.tar.gz
           key: ${{ runner.os }}-cibw-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'python/pyproject.toml', 'CMakeLists.txt', 'core/CMakeLists.txt', '.github/workflows/build_and_test.yml') }}
           restore-keys: |
             ${{ runner.os }}-cibw-${{ matrix.python-version }}-
@@ -246,7 +246,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: >
             yum install -y wget gmp-devel mpfr-devel libmpc-devel eigen3-devel libtool &&
             cd /tmp &&
-            { [ -f eigenpy-3.11.0.tar.gz ] || wget -q https://github.com/stack-of-tasks/eigenpy/releases/download/v3.11.0/eigenpy-3.11.0.tar.gz ; }
+            { [ -f eigenpy-3.12.0.tar.gz ] || wget -q https://github.com/stack-of-tasks/eigenpy/releases/download/v3.12.0/eigenpy-3.12.0.tar.gz ; }
           # On macOS, Homebrew's boost-python3 / eigenpy bottles track the current
           # Homebrew default Python (now 3.14), so a cp313 wheel that bundles them
           # imports a libboost_python314.dylib into a 3.13 interpreter and segfaults.
@@ -255,7 +255,7 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: >
             brew install gmp mpfr libmpc eigen@3 &&
             cd /tmp &&
-            { [ -f eigenpy-3.11.0.tar.gz ] || curl -fsSL -o eigenpy-3.11.0.tar.gz https://github.com/stack-of-tasks/eigenpy/releases/download/v3.11.0/eigenpy-3.11.0.tar.gz ; }
+            { [ -f eigenpy-3.12.0.tar.gz ] || curl -fsSL -o eigenpy-3.12.0.tar.gz https://github.com/stack-of-tasks/eigenpy/releases/download/v3.12.0/eigenpy-3.12.0.tar.gz ; }
 
           # Build Boost and eigenpy fresh against the active per-Python interpreter
           # so each wheel bundles a matching libboost_python3X.
@@ -273,8 +273,8 @@ jobs:
             printf 'using python : %s : %s : %s : %s ;\n' "$PY_VER" "$(which python)" "$PY_INC" "$PY_LIB" > user-config.jam &&
             ./b2 install -j$(nproc) --user-config=user-config.jam python=$PY_VER &&
             cd /tmp &&
-            rm -rf eigenpy-3.11.0 && tar zxf eigenpy-3.11.0.tar.gz &&
-            cd eigenpy-3.11.0 && mkdir -p bld && cd bld &&
+            rm -rf eigenpy-3.12.0 && tar zxf eigenpy-3.12.0.tar.gz &&
+            cd eigenpy-3.12.0 && mkdir -p bld && cd bld &&
             cmake .. -DCMAKE_PREFIX_PATH=/tmp/deps-py -DCMAKE_INSTALL_PREFIX=/tmp/deps-py -DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DPython3_EXECUTABLE=$(which python) -DPython3_NumPy_INCLUDE_DIR=$(python -c "import numpy; print(numpy.get_include())") -DBUILD_TESTING=OFF -DCMAKE_INSTALL_DO_STRIP=ON &&
             make -j2 install &&
             find /tmp/deps-py -name '*.so*' -type f | while read f; do
@@ -297,8 +297,8 @@ jobs:
             printf 'using python : %s : %s : %s : %s ;\n' "$PY_VER" "$(which python)" "$PY_INC" "$PY_LIB" > user-config.jam &&
             ./b2 install -j$(sysctl -n hw.ncpu) --user-config=user-config.jam python=$PY_VER hardcode-dll-paths=true dll-path=/tmp/deps-py/lib &&
             cd /tmp &&
-            rm -rf eigenpy-3.11.0 && tar zxf eigenpy-3.11.0.tar.gz &&
-            cd eigenpy-3.11.0 && mkdir -p bld && cd bld &&
+            rm -rf eigenpy-3.12.0 && tar zxf eigenpy-3.12.0.tar.gz &&
+            cd eigenpy-3.12.0 && mkdir -p bld && cd bld &&
             cmake .. -DCMAKE_PREFIX_PATH="/tmp/deps-py;/opt/homebrew" -DCMAKE_INSTALL_PREFIX=/tmp/deps-py -DPython3_EXECUTABLE=$(which python) -DPython3_NumPy_INCLUDE_DIR=$(python -c "import numpy; print(numpy.get_include())") -DBUILD_TESTING=OFF &&
             make -j2 install
           CIBW_BEFORE_BUILD: "pip install scikit-build-core numpy"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -213,6 +213,7 @@ jobs:
             ~/.cache/cibuildwheel
             ~/Library/Caches/Homebrew
             /tmp/boost_1_90_0.tar.bz2
+            /tmp/eigen-3.4.0.tar.gz
             /tmp/eigenpy-3.12.0.tar.gz
           key: ${{ runner.os }}-cibw-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'python/pyproject.toml', 'CMakeLists.txt', 'core/CMakeLists.txt', '.github/workflows/build_and_test.yml') }}
           restore-keys: |
@@ -244,8 +245,12 @@ jobs:
           # against the manylinux2014 system python3 produces a libboost_python39 that
           # all five wheels would then bundle, breaking import on cp310/311/312/313.
           CIBW_BEFORE_ALL_LINUX: >
-            yum install -y wget gmp-devel mpfr-devel libmpc-devel eigen3-devel libtool &&
+            yum install -y wget gmp-devel mpfr-devel libmpc-devel libtool &&
             cd /tmp &&
+            { [ -f eigen-3.4.0.tar.gz ] || wget -q https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz ; } &&
+            rm -rf eigen-3.4.0 && tar xzf eigen-3.4.0.tar.gz &&
+            cmake -S eigen-3.4.0 -B eigen-3.4.0/bld -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release &&
+            cmake --install eigen-3.4.0/bld &&
             { [ -f eigenpy-3.12.0.tar.gz ] || wget -q https://github.com/stack-of-tasks/eigenpy/releases/download/v3.12.0/eigenpy-3.12.0.tar.gz ; }
           # On macOS, Homebrew's boost-python3 / eigenpy bottles track the current
           # Homebrew default Python (now 3.14), so a cp313 wheel that bundles them

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,7 +69,7 @@ jobs:
             echo 'python_versions=["3.11"]' >> $GITHUB_OUTPUT
           elif [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/heads/develop" || "${{ github.ref }}" == refs/tags/* || "${{ inputs.full_matrix }}" == "true" || "${{ github.event.pull_request.base.ref }}" == "develop" || "${{ github.event.pull_request.base.ref }}" == "main" ]]; then
             echo 'os=["ubuntu-latest","macos-14"]' >> $GITHUB_OUTPUT
-            echo 'python_versions=["3.9","3.10","3.11","3.12","3.13"]' >> $GITHUB_OUTPUT
+            echo 'python_versions=["3.9","3.10","3.11","3.12","3.13","3.14"]' >> $GITHUB_OUTPUT
           else
             echo 'os=["ubuntu-latest","macos-14"]' >> $GITHUB_OUTPUT
             echo 'python_versions=["3.11"]' >> $GITHUB_OUTPUT
@@ -192,7 +192,7 @@ jobs:
         run: ctest --output-on-failure --parallel
 
   build_macos_ubuntu_wheels:
-    name: ${{ matrix.os }} Python-${{ matrix.python-version }} wheels 
+    name: ${{ matrix.os }} Python-${{ matrix.python-version }} wheels
     needs: [set_matrix]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -256,7 +256,7 @@ jobs:
             brew install gmp mpfr libmpc eigen@3 &&
             cd /tmp &&
             { [ -f eigenpy-3.11.0.tar.gz ] || curl -fsSL -o eigenpy-3.11.0.tar.gz https://github.com/stack-of-tasks/eigenpy/releases/download/v3.11.0/eigenpy-3.11.0.tar.gz ; }
-          
+
           # Build Boost and eigenpy fresh against the active per-Python interpreter
           # so each wheel bundles a matching libboost_python3X.
           CIBW_BEFORE_BUILD_LINUX: >
@@ -320,7 +320,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v5
         with:
@@ -416,7 +416,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -230,7 +230,7 @@ jobs:
         run: |
           SW_VERS=$(sw_vers -productVersion | cut -d. -f1)
           echo "MACOSX_DEPLOYMENT_TARGET=${SW_VERS}.0" >> $GITHUB_ENV
-      - uses: pypa/cibuildwheel@v2.23
+      - uses: pypa/cibuildwheel@v3
         env:
           # Build cp39 through cp313 for both Linux (manylinux) and macOS.
           # Boost.Python and eigenpy are rebuilt per target Python in BEFORE_BUILD

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -230,7 +230,7 @@ jobs:
         run: |
           SW_VERS=$(sw_vers -productVersion | cut -d. -f1)
           echo "MACOSX_DEPLOYMENT_TARGET=${SW_VERS}.0" >> $GITHUB_ENV
-      - uses: pypa/cibuildwheel@v3
+      - uses: pypa/cibuildwheel@v3.4.1
         env:
           # Build cp39 through cp313 for both Linux (manylinux) and macOS.
           # Boost.Python and eigenpy are rebuilt per target Python in BEFORE_BUILD


### PR DESCRIPTION
This pull request updates the CI workflow in `.github/workflows/build_and_test.yml` to expand Python version support and update a key build dependency. The main changes ensure that the project is tested and built against the latest Python releases, including Python 3.14, and that the build process uses a newer version of `cibuildwheel`.

**Python version support:**

* Expanded the test and build matrices to include Python 3.12, 3.13, and 3.14, ensuring compatibility and CI coverage for the latest Python versions. [[1]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L72-R72) [[2]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L323-R323) [[3]](diffhunk://#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2L419-R419)

**Build tool update:**

* Upgraded the `pypa/cibuildwheel` action from version `v2.23` to `v3.4.1` to take advantage of new features and improved compatibility with recent Python versions.