### PR TITLE
ci(publish): fix downstream publish skip + rc/a/b prerelease misclassification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,28 +39,33 @@ jobs:
             exit 1
           fi
           echo "OK: tag '$TAG' matches VERSION file '$FILE_VERSION'"
-          echo "$TAG" | grep -Eq '\.(dev|a|b|rc)[0-9]+$' && echo "is_prerelease=true" >> $GITHUB_OUTPUT || echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          # Prerelease iff the tag carries a PEP 440 pre/dev suffix.  Note only `.dev` takes a
+          # leading dot; `a`/`b`/`rc` attach directly (3.0.0rc1), so the alternation must mirror the
+          # validation regex above -- a naive `\.(dev|a|b|rc)` would misread rc1 as a FINAL release
+          # and route it to real PyPI + a GitHub Release instead of TestPyPI.
+          echo "$TAG" | grep -Eq '(\.dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+)$' && echo "is_prerelease=true" >> $GITHUB_OUTPUT || echo "is_prerelease=false" >> $GITHUB_OUTPUT
 
   check_timing_freshness:
     name: Check tutorial timings are fresh
-    # Only gate real releases -- prereleases (.dev/a/b/rc) are exactly when a timing refresh may not
-    # have happened yet, so this job is skipped for them.
-    if: needs.check_version.outputs.is_prerelease == 'false'
     needs: check_version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      # Gate ONLY real releases.  We keep this as a step-level `if` (not a job-level one) so the
+      # JOB always succeeds for prereleases instead of being *skipped*: a skipped `needs` would
+      # propagate a skip through `build_and_test` (a reusable-workflow caller) and silently skip
+      # every publish/docs job under the default `if: success()`.  Prereleases (.dev/a/b/rc) are
+      # exactly when a timing refresh may not have happened yet, so for them this is a no-op pass.
       - name: Verify the scaling-tutorial timings are not stale
+        if: needs.check_version.outputs.is_prerelease == 'false'
         run: python tools/check_timing_freshness.py
 
   build_and_test:
     name: Build and test
+    # No job-level `if`: check_timing_freshness always *succeeds* for prereleases (its gate is a
+    # step), so the default success() gating here -- and, critically, in every downstream publish
+    # job -- works.  A conditional on this reusable-workflow caller would skip all of them.
     needs: [check_version, check_timing_freshness]
-    # A *skipped* freshness check (prerelease) must NOT skip the build -- only a *failed* one should.
-    # GitHub propagates a skipped `needs` as a skip under the default `if: success()`, so spell out
-    # the intent: run unless cancelled, require version-match, and treat freshness as a gate only
-    # when it actually ran and failed (skipped == satisfied).
-    if: ${{ !cancelled() && needs.check_version.result == 'success' && needs.check_timing_freshness.result != 'failure' }}
     uses: ./.github/workflows/build_and_test.yml
 
   publish-to-testpypi:


### PR DESCRIPTION
Two release-blocking bugs in `publish.yml`, both found while shipping `v3.0.0.dev9` (which built green but **published nothing**).

### A. Downstream publish jobs skip even when `build_and_test` succeeds
The previous fix (#267) put a custom `if:` on `build_and_test`. But `build_and_test` is a **reusable-workflow caller** (`uses:`), and a conditional on such a job breaks the implicit `success()` gating of every job that `needs` it — so `publish-to-testpypi` (and pypi/docs) skipped despite `build_and_test` succeeding. The last **working** prerelease (`v2.0.1.dev2`) had no conditional here.

**Fix:** drop `build_and_test`'s `if:` entirely, and move `check_timing_freshness`'s gate from a **job-level** `if` to a **step-level** `if`. The timing job now always *succeeds* for prereleases (its inner step is skipped) instead of being *skipped*, so nothing propagates a skip. Real releases still **fail** the job on stale timings → build correctly skipped.

### B. `rc`/`a`/`b` prereleases misclassified as final releases
`is_prerelease` used `\.(dev|a|b|rc)[0-9]+$`, which requires a leading dot — only `.devN` has one. `3.0.0rc1` therefore classified as `is_prerelease=false` and would route to **real PyPI + a signed GitHub Release**, not TestPyPI. Fixed to mirror the validation regex: `(\.dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+)$`. (This one would have bitten the upcoming `rc1`.)

Verified classifier: `.dev9/a1/b1/rc1 → true`, `3.0.0 → false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)