### PR TITLE
ci(test): install matplotlib in every test env (close matplotlib skips)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -474,7 +474,7 @@ jobs:
           # (and locally); the older blame on "MPFR 3.1.6" was a misdiagnosis.  Running
           # the full suite here is the in-container proof of the fix.  If it flakes or
           # fails, revert to the import smoke test per ADR-0003 (kept there as fallback).
-          CIBW_TEST_REQUIRES_LINUX: "pytest pytest-timeout numpy sympy pandas networkx"
+          CIBW_TEST_REQUIRES_LINUX: "pytest pytest-timeout numpy sympy pandas networkx matplotlib"
           # The explicit `bertini2 --version` up front is a permanent smoke test of the
           # BUNDLED CLI BINARY: wheel repair rewrites its ELF metadata (patchelf via
           # auditwheel), and a bad rewrite segfaults in the dynamic loader before main()
@@ -611,7 +611,7 @@ jobs:
 
       - name: Run Python tests
         run: |
-          pip install pytest pytest-timeout sympy pandas networkx
+          pip install pytest pytest-timeout numpy sympy pandas networkx matplotlib
           python -m pytest python/test/ -v
 
   test_wheels_windows:
@@ -649,5 +649,5 @@ jobs:
           conda install -y python=${{ matrix.python-version }} --update-deps
           $py = "C:\Miniconda\envs\b2-windows\python.exe"
           & $py -m pip install --no-index --find-links dist/ bertini2
-          & $py -m pip install pytest pytest-timeout sympy pandas networkx networkx
+          & $py -m pip install pytest pytest-timeout numpy sympy pandas networkx matplotlib
           & $py -m pytest python/test/ -v


### PR DESCRIPTION
`records_test.py` and the doc-example tests `importorskip("matplotlib")`, but matplotlib was in **none** of the three test-dep lists, so those tests silently **skipped**.

- Adds `matplotlib` to `CIBW_TEST_REQUIRES_LINUX` and the macOS/Windows test installs.
- Adds `numpy` to the mac/Windows lists for parity (Linux already had it).
- Drops a duplicated `networkx` on the Windows line.

Closes the **matplotlib** skips on all platforms. The remaining skip source is **mpi4py** (whole of `test_mpi_zerodim.py` + `test_doc_example_scripts.py`, module-level `importorskip`), which needs an MPI runtime per platform — handled next via the Linux complete-env image, then macOS/Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)