### PR TITLE
ci(deps): prebuilt manylinux complete build+test env image

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -1,0 +1,78 @@
+name: Build CI deps image 🐳
+
+# Builds the manylinux + prebuilt Boost/Boost.Python + eigenpy image consumed by the
+# wheel matrix in build_and_test.yml, and pushes it to
+# ghcr.io/bertiniteam/b2-manylinux-deps.  The image is tagged by its TOOLCHAIN KEY
+# (boost/eigen/eigenpy + manylinux), so a version bump makes a new tag, never a silent
+# ABI swap.  This runs rarely -- only when the Dockerfile or the pinned versions change,
+# or on demand -- so the ~hour of Boost builds happens here, once, instead of in every
+# wheel run.
+#
+# OWNER: the package lands under whichever org runs this workflow.  It MUST run in
+# bertiniteam/b2 (its GITHUB_TOKEN can only push to that org's GHCR); a run on a fork
+# would (correctly) fail to push to bertiniteam.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [develop]
+    paths:
+      - 'docker/manylinux-deps/**'
+      - '.github/workflows/build-ci-image.yml'
+
+concurrency:
+  group: ci-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Keep in lockstep with BOOST_VERSION / EIGENPY_VERSION in build_and_test.yml.
+  BOOST_VERSION: "1.90.0"
+  EIGEN_VERSION: "3.4.0"
+  EIGENPY_VERSION: "3.13.0"
+  MANYLINUX_TAG: "mlx2_34"
+  IMAGE: ghcr.io/bertiniteam/b2-manylinux-deps
+
+jobs:
+  build-image:
+    name: Build & push manylinux deps image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Compute toolchain tag
+        id: tag
+        run: |
+          KEY="boost${BOOST_VERSION}-eigen${EIGEN_VERSION}-eigenpy${EIGENPY_VERSION}-${MANYLINUX_TAG}"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+          echo "Image: $IMAGE:$KEY"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/manylinux-deps
+          push: true
+          # Tag with the exact toolchain key (what main CI pins to) plus a moving
+          # :latest for humans.  Never pin main CI to :latest -- pin the key.
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.tag.outputs.key }}
+            ${{ env.IMAGE }}:latest
+          build-args: |
+            BOOST_VERSION=${{ env.BOOST_VERSION }}
+            EIGEN_VERSION=${{ env.EIGEN_VERSION }}
+            EIGENPY_VERSION=${{ env.EIGENPY_VERSION }}
+          # GHCR layer cache keeps rebuilds cheap when only one thing changes.
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max

--- a/docker/manylinux-deps/Dockerfile
+++ b/docker/manylinux-deps/Dockerfile
@@ -40,7 +40,26 @@ LABEL org.bertini.boost_version="${BOOST_VERSION}"
 LABEL org.bertini.eigen_version="${EIGEN_VERSION}"
 LABEL org.bertini.eigenpy_version="${EIGENPY_VERSION}"
 
-RUN yum install -y wget gmp-devel mpfr-devel libmpc-devel libtool && yum clean all
+# System layer (CPython-independent): numeric -devel libs, ccache, and OpenMPI so
+# `pip install mpi4py` can build in the wheel *test* venv -- which un-skips the MPI tests
+# (test_mpi_zerodim.py, test_doc_example_scripts.py).  This is the "complete build+test
+# env" idea: everything the Linux wheel run needs, factored here and assembled once.
+RUN yum install -y epel-release \
+ && yum install -y wget gmp-devel mpfr-devel libmpc-devel libtool ccache openmpi openmpi-devel \
+ && yum clean all \
+ && echo /usr/lib64/openmpi/lib > /etc/ld.so.conf.d/openmpi.conf && ldconfig
+
+# OpenMPI's mpicc/mpirun are not on the default PATH on AlmaLinux; expose them so mpi4py
+# builds and (for the dedicated MPI job / serial runs) mpirun is available.
+ENV PATH=/usr/lib64/openmpi/bin:${PATH}
+
+# Pin patchelf 0.17.2.1 (mirrors CIBW_BEFORE_ALL_LINUX): the image's stock patchelf
+# mis-rewrites the bundled bertini2 CLI's ELF and segfaults it at load.
+RUN python3 -m venv /tmp/pe \
+ && /tmp/pe/bin/pip install -q "patchelf==0.17.2.1" \
+ && install -m755 /tmp/pe/bin/patchelf /usr/local/bin/patchelf \
+ && rm -rf /tmp/pe \
+ && patchelf --version
 
 # Eigen (header-only, CPython-independent) -> /usr/local, same as CIBW_BEFORE_ALL_LINUX.
 RUN cd /tmp \

--- a/docker/manylinux-deps/Dockerfile
+++ b/docker/manylinux-deps/Dockerfile
@@ -1,0 +1,87 @@
+# syntax=docker/dockerfile:1
+#
+# Prebuilt dependencies for bertini2 Linux wheels: Boost (incl. a per-CPython
+# Boost.Python) + eigenpy, on top of the manylinux image cibuildwheel already uses.
+#
+# WHY: the wheel matrix recompiles Boost.Python + eigenpy in every run (the ~hour
+# sink), because libboost_python3X is ABI-locked per CPython.  Baking them into a
+# GHCR image moves that cost out of every run and off the 10 GB Actions-cache ceiling
+# (image storage is a separate, effectively-unbounded quota; the runner layer-caches
+# the pull).  The build recipe below MIRRORS build_and_test.yml's
+# CIBW_BEFORE_ALL/BEFORE_BUILD_LINUX exactly -- just relocated here.
+#
+# ABI CONTRACT (load-bearing): the image *tag* encodes the toolchain
+# (boost/eigen/eigenpy + manylinux), and main CI ASSERTS a match before using it.  A
+# version bump = a new tag = a new image; a stale image can never be silently consumed.
+# This repo has a SIGABRT history from ABI drift (ADR-0006), so this is not optional.
+#
+# Per-CPython prefixes land at /opt/deps/<tag> (e.g. /opt/deps/cp310-cp310).  Main CI
+# points CMAKE_PREFIX_PATH / LD_LIBRARY_PATH at the active Python's prefix.
+#
+# SIZE NOTE: Boost headers (~200 MB) are duplicated across the per-Python prefixes for
+# correctness/simplicity (this mirrors the known-good recipe).  A follow-up can share
+# the CPython-independent headers + non-python libs once and keep only libboost_python
+# + eigenpy per Python -- see README.md.
+
+ARG MANYLINUX_IMAGE=quay.io/pypa/manylinux_2_34_x86_64
+FROM ${MANYLINUX_IMAGE}
+
+# Pins -- MUST stay in lockstep with BOOST_VERSION / EIGENPY_VERSION in build_and_test.yml.
+ARG BOOST_VERSION=1.90.0
+ARG EIGEN_VERSION=3.4.0
+ARG EIGENPY_VERSION=3.13.0
+# CPython tags to build for (manylinux ships these under /opt/python/<tag>).
+ARG PYTHON_TAGS="cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp314-cp314"
+
+LABEL org.opencontainers.image.source="https://github.com/bertiniteam/b2"
+LABEL org.opencontainers.image.description="manylinux_2_34 + prebuilt Boost/Boost.Python + eigenpy for bertini2 wheels"
+# Toolchain stamp -- main CI reads these labels to assert an ABI match.
+LABEL org.bertini.boost_version="${BOOST_VERSION}"
+LABEL org.bertini.eigen_version="${EIGEN_VERSION}"
+LABEL org.bertini.eigenpy_version="${EIGENPY_VERSION}"
+
+RUN yum install -y wget gmp-devel mpfr-devel libmpc-devel libtool && yum clean all
+
+# Eigen (header-only, CPython-independent) -> /usr/local, same as CIBW_BEFORE_ALL_LINUX.
+RUN cd /tmp \
+ && wget -q "https://gitlab.com/libeigen/eigen/-/archive/${EIGEN_VERSION}/eigen-${EIGEN_VERSION}.tar.gz" \
+ && tar xzf "eigen-${EIGEN_VERSION}.tar.gz" \
+ && cmake -S "eigen-${EIGEN_VERSION}" -B /tmp/eigen-bld -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release \
+ && cmake --install /tmp/eigen-bld \
+ && rm -rf /tmp/eigen*
+
+# Fetch Boost + eigenpy sources once.
+RUN cd /tmp \
+ && BU="boost_$(echo "${BOOST_VERSION}" | tr . _)" \
+ && wget -q "https://archives.boost.io/release/${BOOST_VERSION}/source/${BU}.tar.bz2" \
+ && wget -q "https://github.com/stack-of-tasks/eigenpy/releases/download/v${EIGENPY_VERSION}/eigenpy-${EIGENPY_VERSION}.tar.gz"
+
+# Build Boost.Python + eigenpy per CPython into /opt/deps/<tag>.  A fresh Boost tree
+# per Python avoids cross-variant b2 contamination.  Mirrors CIBW_BEFORE_BUILD_LINUX.
+RUN set -eux; cd /tmp; \
+    BU="boost_$(echo "${BOOST_VERSION}" | tr . _)"; \
+    for tag in ${PYTHON_TAGS}; do \
+      PY="/opt/python/${tag}/bin/python"; \
+      [ -x "$PY" ] || { echo "missing interpreter: $PY"; exit 1; }; \
+      PREFIX="/opt/deps/${tag}"; \
+      "$PY" -m pip install -q numpy; \
+      PY_VER="$("$PY" -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')"; \
+      PY_INC="$("$PY" -c 'import sysconfig;print(sysconfig.get_path("include"))')"; \
+      PY_LIB="$("$PY" -c 'import sysconfig;print(sysconfig.get_config_var("LIBDIR") or "")')"; \
+      rm -rf "/tmp/${BU}"; tar xjf "/tmp/${BU}.tar.bz2" -C /tmp; \
+      cd "/tmp/${BU}"; \
+      ./bootstrap.sh --with-python="$PY" --prefix="$PREFIX"; \
+      printf 'using python : %s : %s : %s : %s ;\n' "$PY_VER" "$PY" "$PY_INC" "$PY_LIB" > user-config.jam; \
+      ./b2 install -j"$(nproc)" --user-config=user-config.jam python="$PY_VER" --without-mpi; \
+      cd /tmp; \
+      rm -rf "eigenpy-${EIGENPY_VERSION}"; tar xzf "eigenpy-${EIGENPY_VERSION}.tar.gz"; \
+      cmake -S "eigenpy-${EIGENPY_VERSION}" -B "/tmp/eigenpy-bld-${tag}" \
+        -DCMAKE_PREFIX_PATH="$PREFIX" -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DPython3_EXECUTABLE="$PY" \
+        -DPython3_NumPy_INCLUDE_DIR="$("$PY" -c 'import numpy;print(numpy.get_include())')" \
+        -DBUILD_TESTING=OFF -DCMAKE_INSTALL_DO_STRIP=ON; \
+      cmake --build "/tmp/eigenpy-bld-${tag}" -j2 --target install; \
+      find "$PREFIX" -name '*.so*' -type f -exec strip --strip-unneeded {} + 2>/dev/null || true; \
+      rm -rf "/tmp/eigenpy-bld-${tag}"; \
+    done; \
+    rm -rf "/tmp/${BU}" "/tmp/${BU}.tar.bz2" /tmp/eigenpy-${EIGENPY_VERSION}*

--- a/docker/manylinux-deps/README.md
+++ b/docker/manylinux-deps/README.md
@@ -1,0 +1,55 @@
+# `b2-manylinux-deps` — prebuilt Boost + eigenpy for the wheel matrix
+
+The Linux wheel jobs used to recompile **Boost.Python + eigenpy in every run** — the
+bulk of the ~hour CI. `libboost_python3X` is ABI-locked per CPython, so it can't just be
+built once and shared inside a single run. This image bakes it (and eigenpy) **once per
+CPython**, so wheel builds just link against prebuilt libraries.
+
+## Why an image, not `actions/cache`
+
+The GitHub **Actions cache is 10 GB/repo with LRU eviction**; Boost+eigenpy prefixes
+across (OS × Python) overrun it and thrash. A **GHCR image** lives in a *separate*
+package-storage quota (unbounded for public images) and the runner layer-caches the pull,
+so it sidesteps the ceiling entirely.
+
+## The ABI contract (load-bearing)
+
+Prebuilt `libboost_python` must match, exactly: the manylinux glibc/libstdc++ ABI, the
+CPython ABI, the Boost version, and the Eigen/eigenpy it links. A mismatch is not a build
+error — it's a runtime `SIGABRT`/`SIGSEGV` (this repo has that history, ADR-0006). So:
+
+- The image **tag encodes the toolchain key**:
+  `boost<BOOST>-eigen<EIGEN>-eigenpy<EIGENPY>-mlx2_34`.
+- The versions are also stamped as image **labels** (`org.bertini.*`).
+- **Main CI pins the exact key** (never `:latest`) and **asserts** the labels match its
+  own `BOOST_VERSION`/`EIGENPY_VERSION` before building. Bump a version → new tag → new
+  image; a stale image can never be silently consumed.
+
+## Layout the image provides
+
+- `/opt/deps/<cpXY-cpXY>/` — Boost (incl. `libboost_python3X`) + eigenpy for that CPython.
+- `/usr/local/` — Eigen headers (CPython-independent).
+
+Main CI (`build_and_test.yml`) sets, per active Python tag:
+`CMAKE_PREFIX_PATH=/opt/deps/<tag>` and `LD_LIBRARY_PATH=/opt/deps/<tag>/lib:...`, and its
+`CIBW_BEFORE_BUILD_LINUX` drops from "compile Boost+eigenpy" to a no-op.
+
+## Building / publishing
+
+Built and pushed by `.github/workflows/build-ci-image.yml` → `ghcr.io/bertiniteam/b2-manylinux-deps`.
+Triggers: a push to `develop` touching `docker/manylinux-deps/**`, or manual dispatch.
+It **must run in `bertiniteam/b2`** (its token can only push to that org's GHCR).
+
+**One-time setup:** after the first push, make the package **public** in the org's
+Packages settings so any CI (incl. fork PRs) can pull it without auth. (Owner action —
+GHCR package visibility is a package setting, not something CI can flip.)
+
+## Follow-ups (not yet done)
+
+- **Size:** Boost headers (~200 MB) are duplicated per Python for recipe fidelity. A
+  later pass can install the CPython-independent headers + non-python libs once and keep
+  only `libboost_python` + eigenpy per Python, shrinking the image several-fold.
+- **macOS / Windows:** no container there. The same idea via **prebuilt tarballs as
+  release assets** (also off the 10 GB cache ceiling) is the fast-follow.
+- **Version single-sourcing:** the pins here mirror `build_and_test.yml`'s env. Keep them
+  in lockstep (a mismatch just misses the assert and rebuilds — safe, but slow).

--- a/docker/manylinux-deps/README.md
+++ b/docker/manylinux-deps/README.md
@@ -25,14 +25,23 @@ error — it's a runtime `SIGABRT`/`SIGSEGV` (this repo has that history, ADR-00
   own `BOOST_VERSION`/`EIGENPY_VERSION` before building. Bump a version → new tag → new
   image; a stale image can never be silently consumed.
 
-## Layout the image provides
+## The complete build+test env
+
+The image is the whole Linux env, factored and assembled once — not just the C++ deps:
 
 - `/opt/deps/<cpXY-cpXY>/` — Boost (incl. `libboost_python3X`) + eigenpy for that CPython.
 - `/usr/local/` — Eigen headers (CPython-independent).
+- **OpenMPI** (`/usr/lib64/openmpi`, on `PATH`) — so `pip install mpi4py` builds in the
+  wheel *test* venv, which **un-skips the MPI tests** (`test_mpi_zerodim.py`,
+  `test_doc_example_scripts.py`). Toward the 0-skiptests goal.
+- **ccache** and a **pinned patchelf 0.17.2.1** — moved off `CIBW_BEFORE_ALL_LINUX`.
 
-Main CI (`build_and_test.yml`) sets, per active Python tag:
-`CMAKE_PREFIX_PATH=/opt/deps/<tag>` and `LD_LIBRARY_PATH=/opt/deps/<tag>/lib:...`, and its
-`CIBW_BEFORE_BUILD_LINUX` drops from "compile Boost+eigenpy" to a no-op.
+Main CI (`build_and_test.yml`) then sets, per active Python tag:
+`CMAKE_PREFIX_PATH=/opt/deps/<tag>` and `LD_LIBRARY_PATH=/opt/deps/<tag>/lib:...`;
+`CIBW_BEFORE_ALL_LINUX` collapses to ~nothing and `CIBW_BEFORE_BUILD_LINUX` drops from
+"compile Boost+eigenpy" to a no-op. Python test deps stay in `CIBW_TEST_REQUIRES_LINUX`
+(cibuildwheel's test phase is an isolated venv, so it re-pip-installs them — cheap for
+pure-Python deps; `mpi4py` now *builds* because OpenMPI is present).
 
 ## Building / publishing
 


### PR DESCRIPTION
The Linux wheel matrix recompiles Boost.Python + eigenpy every run (most of the ~hour), and `actions/cache` can't hold them (10 GB/repo ceiling, hit before). Bake the **complete Linux build+test env** into a GHCR image instead — separate storage quota, layer-cached pull.

**Producer only.** This adds the image + its build workflow; the consumer wiring (`CIBW_MANYLINUX_X86_64_IMAGE` + assert-match + gutted `BEFORE_ALL`/`BEFORE_BUILD`) lands in a follow-up once the image is published and confirmed. Nothing consumes the image yet, so this is safe to merge.

### What the image provides
- `/opt/deps/<cpXY>/` — Boost (per-CPython Boost.Python) + eigenpy; `/usr/local` — Eigen.
- **OpenMPI** so `pip install mpi4py` builds in the wheel test venv → **un-skips** the MPI tests (toward 0 skiptests).
- ccache + pinned patchelf 0.17.2.1, moved off `CIBW_BEFORE_ALL_LINUX`.

### Contract
Image tag encodes the toolchain key (`boost…-eigen…-eigenpy…-mlx2_34`); main CI will pin the exact key and **assert** the labels match — a bump = new image, never a silent ABI swap (ADR-0006).

### After first merge (owner)
Make the `b2-manylinux-deps` package **public** in the org's Packages settings so fork-PR CI can pull it.

### Scope
Linux first. macOS (brew open-mpi) and Windows (MS-MPI) follow the same idea via host recipes / prebuilt bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)