### PR TITLE
ci(deps): install scipy for the eigenpy build in the image

### DIFF
--- a/docker/manylinux-deps/Dockerfile
+++ b/docker/manylinux-deps/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; cd /tmp; \
       PY="/opt/python/${tag}/bin/python"; \
       [ -x "$PY" ] || { echo "missing interpreter: $PY"; exit 1; }; \
       PREFIX="/opt/deps/${tag}"; \
-      "$PY" -m pip install -q numpy; \
+      "$PY" -m pip install -q numpy scipy; \
       PY_VER="$("$PY" -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')"; \
       PY_INC="$("$PY" -c 'import sysconfig;print(sysconfig.get_path("include"))')"; \
       PY_LIB="$("$PY" -c 'import sysconfig;print(sysconfig.get_config_var("LIBDIR") or "")')"; \


### PR DESCRIPTION
The first image build (run 28864470892) failed at eigenpy's cmake: `python.cmake:602 Failed to detect scipy`. eigenpy's configure requires scipy; the Dockerfile installed only numpy per Python, while the working `CIBW_BEFORE_BUILD` recipe installs `numpy scipy`. One-word fix. Merging re-triggers the image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)