### PR TITLE
fix(docs): escape absolute-value bars that RST misread as substitutions (v3.1.0 docs deploy)

### DIFF
--- a/python/bertini/operators.py
+++ b/python/bertini/operators.py
@@ -118,7 +118,7 @@ conj    = _numeric_only('conj',    _nh.conj,    "Complex conjugate(s).")
 round   = _numeric_only('round',   _nh.round,   "Round to N DECIMAL digits, staying mp-native.") # noqa: A001
 sum     = _numeric_only('sum',     _nh.sum,     "Sum of a collection, staying mp-native.")       # noqa: A001
 norm    = _numeric_only('norm',    _nh.norm,    "Euclidean (2-)norm, as real_mp.")
-is_real = _numeric_only('is_real', _nh.is_real, "Is every coordinate real (|imag| < tol)?")
+is_real = _numeric_only('is_real', _nh.is_real, "Is every coordinate real (abs(imag) < tol)?")
 
 
 __all__ = [

--- a/python_bindings/src/mpfr_export.cpp
+++ b/python_bindings/src/mpfr_export.cpp
@@ -355,7 +355,7 @@ namespace bertini{
 				+[](Vec<complex_mp> const& p, Vec<complex_mp> const& q, double tol) -> bool {
 					return bertini::IsDistinct(p, q, tol); },
 				(arg("p"), arg("q"), arg("tol")),
-				"True if points p and q differ by more than tol in the infinity norm (max_i |p_i - q_i|); "
+				"True if points p and q differ by more than tol in the infinity norm (max_i abs(p_i - q_i)); "
 				"False if they are the same to within tol.  The tolerance-based point-equality test "
 				"(issue #304).  Accepts complex_mp or real_mp vectors; different-length points are distinct.");
 			def("is_distinct_up_to",


### PR DESCRIPTION
The **v3.1.0** versioned-docs deploy failed. `build_docs.yml` runs `sphinx-build -b html -W`
(warnings-as-errors), and three docstrings wrote absolute-value / norm notation with **bare pipes**:

```
ERROR: Undefined substitution referenced: "p_i - q_i"  — bertini.multiprec.is_distinct_up_to
ERROR: Undefined substitution referenced: "p_i - q_i"  — bertini.is_distinct_up_to  (top-level re-export)
ERROR: Undefined substitution referenced: "imag"        — bertini.operators.is_real
```

In reStructuredText `|word|` is a **substitution reference**, so Sphinx tried to resolve undefined
substitutions `p_i - q_i` and `imag` and errored out. `is_distinct_up_to` (#305) and `is_real` (#306)
both landed in the 3.1.0 line.

### Fix
Reword the two source strings to `abs(...)` — `max_i abs(p_i - q_i)` and `abs(imag) < tol` — which
read cleanly in Sphinx HTML *and* plain `help()` and carry no RST metacharacters. The other `|…|`
docstrings in the tree are already safe (wrapped in ``inline literals`` or inside code blocks) and
are left untouched.

### Not a package problem
Docstrings only — the released wheels are unaffected. **3.1.0 is already on PyPI and the GitHub
Release is published**; only the docs-site deploy failed.

### Verified
Reproduced the exact failing command locally (`sphinx-build -b html -W --keep-going`): now
**`build succeeded`**, zero substitution errors.

### Root-cause note (for the post-3.1.0 CI pass)
The `-b html -W` build runs **only at docs-deploy time**, not in PR CI (PR CI runs `-b doctest`,
which passed). So this whole class of RST/docstring error is invisible until release. Running the
`-W` html build in PR CI would have caught it — worth adding alongside #312.
