### PR TITLE
randomize to any codimension (not just square) + bertini.randomize free function

### DIFF
--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -1243,6 +1243,24 @@ namespace bertini {
 		System Randomize() const;
 
 		/**
+		\brief Randomize down to a chosen number of functions, returning a NEW system.
+
+		Like the auto Randomize(), but instead of squaring to the affine dimension this produces
+		exactly `codimension` generic combinations of this system's natural functions -- the general
+		"randomize down to codimension c" used when studying lower-dimensional components (e.g. in
+		numerical irreducible decomposition), where `codimension` is the number of functions kept.
+		`codimension == 1` yields a single function.  The functions are sorted by descending degree
+		(on a copy -- this system is not mutated) so the `codimension` largest-degree functions land
+		on the identity block, keeping the total-degree path count optimal.
+
+		\param codimension The number of randomized functions to produce.  Must be positive and
+		strictly less than the number of natural functions (randomization must reduce the count).
+		\throws std::runtime_error if `codimension < 1`, or if `codimension` is greater than or equal
+		to the number of natural functions (cannot randomize to the same or more functions).
+		*/
+		System Randomize(int codimension) const;
+
+		/**
 		\brief Randomize using a caller-supplied (exact) coefficient matrix R, leaving the functions
 		in their current order.  R has one row per desired randomized function and one column per
 		natural function of this system.  Returns a NEW system; this one is not mutated.
@@ -1830,6 +1848,16 @@ namespace bertini {
 		/// copy, sorted or not) and a finished coefficient matrix, compute the per-row target
 		/// multidegrees, build the RandomizationBlock, and return a new system carrying it.
 		System AssembleRandomized(std::shared_ptr<System> operand, Mat<complex_mp> coefficients) const;
+
+		/// Build the `codimension` x N coefficient matrix for the auto Randomize paths, sorting the
+		/// operand's functions by descending degree (single affine group) so the `codimension`
+		/// largest-degree functions occupy the identity block, then filling the random tail; for
+		/// several variable groups a dense conjugate-orthonormal matrix is drawn instead.  Mutates
+		/// the operand's function order in the single-group case (the operand is a private copy).
+		/// \param operand The copied system whose natural functions are being combined.
+		/// \param codimension The number of rows (randomized functions) to produce.
+		/// \return The `codimension` x N randomization matrix.
+		Mat<complex_mp> BuildRandomizationMatrix(std::shared_ptr<System> operand, std::size_t codimension) const;
 
 		/**
 		\brief Get the sizes according to the FIFO ordering.

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -1275,36 +1275,31 @@ namespace bertini
 	}
 
 
-	System System::Randomize() const
+	Mat<complex_mp> System::BuildRandomizationMatrix(std::shared_ptr<System> operand, std::size_t codimension) const
 	{
-		const size_t G = NumVariableGroups();
-		const size_t N = NumNaturalFunctions();
-		const size_t n = NumVariables() - NumHomVariableGroups();
+		const size_t G = operand->NumVariableGroups();
+		const size_t N = operand->NumNaturalFunctions();
+		const size_t k = codimension;
 
-		if (N < n)
-			throw std::runtime_error("Randomize: system is underdetermined (fewer functions than variables), so it has no isolated solutions to capture.");
-
-		auto operand = std::make_shared<System>(*this);
-
-		Mat<complex_mp> R(static_cast<Eigen::Index>(n), static_cast<Eigen::Index>(N));
+		Mat<complex_mp> R(static_cast<Eigen::Index>(k), static_cast<Eigen::Index>(N));
 
 		if (G == 1)
 		{
 			// single affine group: sort the operand's functions by descending degree, then R = [I | C].
 			// The identity block makes g_i carry f_i with coefficient 1 (degree d_i); the random tail
 			// C folds the lower-degree functions in, padded by hom-var powers.  deg g_i = d_i, so the
-			// total-degree path count is the product of the n largest degrees -- optimal.
+			// total-degree path count is the product of the k largest degrees -- optimal.
 			//
 			// Only the C tail is random, and it is drawn conjugate-orthonormal (ADR-0041) -- matching
 			// Bertini 1, which builds every random complex matrix unitary.  C being dense leaves the
 			// degree-optimal structure intact: after the descending sort every tail function is lower
 			// degree than row i's leading f_i, so target_md[i] stays d_i regardless of C's nonzeros.
 			operand->ReorderFunctionsByDegreeDecreasing();
-			R.leftCols(static_cast<Eigen::Index>(n)).setIdentity();
-			if (N > n)
-				R.rightCols(static_cast<Eigen::Index>(N - n)) =
+			R.leftCols(static_cast<Eigen::Index>(k)).setIdentity();
+			if (N > k)
+				R.rightCols(static_cast<Eigen::Index>(N - k)) =
 					bertini::RandomConjugateOrthonormalMatrix<complex_mp>(
-						static_cast<unsigned>(n), static_cast<unsigned>(N - n));
+						static_cast<unsigned>(k), static_cast<unsigned>(N - k));
 		}
 		else
 		{
@@ -1312,9 +1307,38 @@ namespace bertini
 			// R with a common (componentwise-max) target multidegree -- correct, and optimal when the
 			// functions share a multidegree.  Drawn conjugate-orthonormal (ADR-0041), like b1.
 			R = bertini::RandomConjugateOrthonormalMatrix<complex_mp>(
-				static_cast<unsigned>(n), static_cast<unsigned>(N));
+				static_cast<unsigned>(k), static_cast<unsigned>(N));
 		}
 
+		return R;
+	}
+
+
+	System System::Randomize() const
+	{
+		const size_t N = NumNaturalFunctions();
+		const size_t n = NumVariables() - NumHomVariableGroups();
+
+		if (N < n)
+			throw std::runtime_error("Randomize: system is underdetermined (fewer functions than variables), so it has no isolated solutions to capture.");
+
+		auto operand = std::make_shared<System>(*this);
+		Mat<complex_mp> R = BuildRandomizationMatrix(operand, n);
+		return AssembleRandomized(operand, std::move(R));
+	}
+
+
+	System System::Randomize(int codimension) const
+	{
+		const size_t N = NumNaturalFunctions();
+
+		if (codimension < 1)
+			throw std::runtime_error("Randomize: codimension must be a positive number of functions.");
+		if (static_cast<size_t>(codimension) >= N)
+			throw std::runtime_error("Randomize: cannot randomize to the same or more functions than the system has; codimension must be less than the number of natural functions.");
+
+		auto operand = std::make_shared<System>(*this);
+		Mat<complex_mp> R = BuildRandomizationMatrix(operand, static_cast<size_t>(codimension));
 		return AssembleRandomized(operand, std::move(R));
 	}
 

--- a/core/test/classes/randomization_block_test.cpp
+++ b/core/test/classes/randomization_block_test.cpp
@@ -206,6 +206,65 @@ BOOST_AUTO_TEST_CASE(underdetermined_throws)
 }
 
 
+// ---- randomize to a chosen codimension -----------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(randomize_to_codimension_one)
+{
+	DefaultPrecision(30);
+	System s = OverdeterminedSingleGroup();   // 3 functions, degrees (2,1,2)
+	BOOST_REQUIRE_EQUAL(s.NumNaturalFunctions(), 3u);
+
+	System r = s.Randomize(1);
+
+	BOOST_CHECK_EQUAL(r.NumNaturalFunctions(), 1u);   // reduced to a single function
+	auto d = r.Degrees();
+	BOOST_REQUIRE_EQUAL(d.size(), 1u);
+	BOOST_CHECK_EQUAL(d[0], 2);                        // leading (top-degree) function after the sort
+	// the original system is NOT mutated
+	BOOST_CHECK_EQUAL(s.NumNaturalFunctions(), 3u);
+}
+
+BOOST_AUTO_TEST_CASE(randomize_to_codimension_matches_square)
+{
+	DefaultPrecision(30);
+	System s = OverdeterminedSingleGroup();           // n = NumVariables - NumHomVariableGroups = 2
+	System r = s.Randomize(2);                          // explicit codimension == the affine dimension
+	BOOST_CHECK_EQUAL(r.NumNaturalFunctions(), 2u);    // same shape as the no-arg square Randomize()
+	BOOST_CHECK_EQUAL(s.Randomize().NumNaturalFunctions(), 2u);
+}
+
+BOOST_AUTO_TEST_CASE(randomize_codimension_zero_throws)
+{
+	DefaultPrecision(30);
+	System s = OverdeterminedSingleGroup();
+	BOOST_CHECK_THROW(s.Randomize(0), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(randomize_codimension_negative_throws)
+{
+	DefaultPrecision(30);
+	System s = OverdeterminedSingleGroup();
+	BOOST_CHECK_THROW(s.Randomize(-1), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(randomize_codimension_ge_num_functions_throws)
+{
+	DefaultPrecision(30);
+	System s = OverdeterminedSingleGroup();            // 3 natural functions
+	BOOST_CHECK_THROW(s.Randomize(3), std::runtime_error);   // == N: not a reduction
+	BOOST_CHECK_THROW(s.Randomize(4), std::runtime_error);   // >  N
+}
+
+BOOST_AUTO_TEST_CASE(codimension_row_matches_expansion)
+{
+	DefaultPrecision(40);
+	System r = OverdeterminedSingleGroup().Randomize(1);   // a single randomized function
+	AgreesWithExpansion(r);
+	r.Homogenize();                                        // exercises the h-power deficit
+	AgreesWithExpansion(r);
+}
+
+
 // ---- evaluation correctness via the expansion oracle ---------------------------------------
 
 BOOST_AUTO_TEST_CASE(affine_single_group_matches_expansion)

--- a/python/bertini/__init__.py
+++ b/python/bertini/__init__.py
@@ -104,6 +104,7 @@ from .tracking import (AMPTracker, DoublePrecisionTracker, MultiplePrecisionTrac
                        SuccessCode, Predictor)
 
 from ._calculus import jacobian
+from ._randomize import randomize
 from .random import random_matrix
 from .random import random_vector, random_real, random_complex
 
@@ -182,7 +183,7 @@ from .operators import (sin, cos, tan, asin, acos, atan, exp, log, sqrt,   # noq
 # "a list of strings defining what symbols in a module will be exported when from <module> import * is used on the module"
 __all__ = ['solve','save','load','annotate','solutions_of','provenance','recording','records_dir','runs','tracks','provenance_graph','plot_chain','Solution','SolveResult','records',
            'Variable','variables','gather_variables','VariableGroup','Named','system','System',
-           'jacobian','random_matrix','random_vector','random_real','random_complex','coefficient','coefficients',
+           'jacobian','randomize','random_matrix','random_vector','random_real','random_complex','coefficient','coefficients',
            'complex_mp','real_mp','int_mp','rational_mp',
            'nag_algorithm','default_precision','is_distinct_up_to',
            'real','imag','conj','arg','norm','is_real',

--- a/python/bertini/_randomize.py
+++ b/python/bertini/_randomize.py
@@ -1,0 +1,18 @@
+"""Top-level ``bertini.randomize`` free function.
+
+A thin, ergonomic wrapper over the :meth:`System.randomize` method so callers can write
+``bertini.randomize(system, codimension)``.  The actual randomization logic lives in the C++ core.
+"""
+
+
+def randomize(system, codimension=None):
+    """Randomize ``system``, returning a NEW system (the original is not mutated).
+
+    When ``codimension`` is omitted the (overdetermined) system is squared down to its affine
+    dimension.  Otherwise the system is randomized down to ``codimension`` functions -- a positive
+    integer strictly less than the number of natural functions (``codimension=1`` yields a single
+    function).
+    """
+    if codimension is None:
+        return system.randomize()
+    return system.randomize(codimension=codimension)

--- a/python/bertini/_system_ops.py
+++ b/python/bertini/_system_ops.py
@@ -154,13 +154,25 @@ def add_products_of_linears(self, factors):
     return self
 
 
-def randomize(self, matrix=None):
-    """Randomize an overdetermined System down to a square one, returning a NEW system.
+def randomize(self, matrix=None, *, codimension=None):
+    """Randomize a System, returning a NEW system (the original is not mutated).
 
-    ``matrix`` is an optional exact coefficient matrix R (one row per randomized function, one
-    column per natural function); when ``None`` bertini builds a generic R.  The original is not
-    mutated.  Coefficients must be exact.
+    With no arguments, an overdetermined System is squared down to its affine dimension.  Pass
+    ``codimension`` to instead randomize down to a chosen number of functions
+    (``sys.randomize(codimension=1)`` yields a single function); it must be a positive integer
+    strictly less than the number of natural functions (randomization must reduce the count).
+    Alternatively pass ``matrix``, an exact coefficient matrix R (one row per randomized function,
+    one column per natural function); its coefficients must be exact.  ``codimension`` and
+    ``matrix`` are mutually exclusive.
     """
+    if codimension is not None and matrix is not None:
+        raise ValueError("randomize: pass either a codimension or a matrix, not both")
+    if codimension is not None:
+        if isinstance(codimension, bool) or not isinstance(codimension, int):
+            raise TypeError("randomize: codimension must be an int")
+        if codimension < 1:
+            raise ValueError("randomize: codimension must be a positive integer")
+        return _native['randomize'](self, codimension)
     if matrix is None:
         return _native['randomize'](self)
     rows = [list(r) for r in matrix]

--- a/python/test/zero_dim/randomize_test.py
+++ b/python/test/zero_dim/randomize_test.py
@@ -162,3 +162,58 @@ def test_float_coefficient_refused():
     original.add_function(2 * x * x - 1)
     with pytest.raises(TypeError):
         original.randomize([[1.5, 0, 0], [0, 1, 0]])   # Python float -> refused
+
+
+# ---- randomize to a chosen codimension -----------------------------------------------------
+
+def _overdetermined_3x2():
+    """The standard 3-function / 2-variable overdetermined system (degrees 2, 1, 2)."""
+    x, y = pb.Variable('x'), pb.Variable('y')
+    s = pb.System()
+    s.add_variable_group(pb.VariableGroup([x, y]))
+    s.add_function(x * x + y * y - 1)
+    s.add_function(x - y)
+    s.add_function(2 * x * x - 1)
+    return s
+
+
+def test_randomize_to_codimension_one():
+    original = _overdetermined_3x2()
+    randomized = original.randomize(codimension=1)
+    assert randomized.num_functions() == 1                  # reduced to a single function
+    assert list(randomized.degrees()) == [2]                 # the top-degree function after the sort
+    assert original.num_functions() == 3                     # original untouched
+
+
+def test_codimension_ge_num_functions_raises():
+    original = _overdetermined_3x2()                         # 3 natural functions
+    with pytest.raises(RuntimeError):
+        original.randomize(codimension=3)                    # == N: not a reduction
+    with pytest.raises(RuntimeError):
+        original.randomize(codimension=4)                    # >  N
+
+
+def test_codimension_non_positive_raises():
+    original = _overdetermined_3x2()
+    with pytest.raises(ValueError):
+        original.randomize(codimension=0)
+    with pytest.raises(ValueError):
+        original.randomize(codimension=-1)
+
+
+def test_codimension_and_matrix_together_raises():
+    original = _overdetermined_3x2()
+    with pytest.raises(ValueError):
+        original.randomize([[1, 0, 0], [0, 1, 0]], codimension=1)
+
+
+def test_free_function_randomize():
+    original = _overdetermined_3x2()
+
+    # the free function forwards to the method
+    assert pb.randomize(original, 1).num_functions() == 1
+    assert pb.randomize(original, codimension=1).num_functions() == 1
+
+    # omitting the codimension squares the system, matching the no-arg method
+    assert pb.randomize(original).num_functions() == 2
+    assert original.num_functions() == 3                     # original untouched

--- a/python_bindings/src/system_export.cpp
+++ b/python_bindings/src/system_export.cpp
@@ -261,13 +261,17 @@ namespace bertini{
 				(arg("self")),
 				"Randomize an overdetermined system (N functions, n variables, N>n) down to a square one, returning a NEW system; this one is left untouched.  The square result has n generic combinations of the original functions, whose isolated solutions still contain this system's -- solve it, then discard the extraneous solutions by re-evaluating this system.  For a single affine variable group the functions are sorted by descending degree and R=[I|C], giving the optimal total-degree path count.")
 			.def("randomize",
+				+[](SystemBaseT const& self, int codimension) { return self.Randomize(codimension); },
+				(arg("self"), arg("codimension")),
+				"Randomize down to `codimension` functions (generic combinations of the natural functions), returning a NEW system; this one is left untouched.  Like the no-arg form, but reduces to a chosen number of functions rather than squaring -- `codimension=1` yields a single function, the general \"randomize down to codimension c\" used for lower-dimensional components.  Raises if codimension < 1 or >= the number of natural functions (randomization must reduce the count).")
+			.def("randomize",
 				+[](SystemBaseT const& self, bertini::Mat<mpfr> const& R) { return self.Randomize(R); },
 				(arg("self"), arg("matrix")),
 				"Randomize using a supplied coefficient matrix R (one row per randomized function, one column per natural function of this system); the functions are kept in their current order.  Returns a NEW system.")
 			.def("randomization_matrix",
 				+[](SystemBaseT const& self) { return self.RandomizationMatrix(); },
 				(arg("self")),
-				"The randomization matrix R (n x N, complex_mp) of a system produced by randomize().  Raises if the system has no randomization block.")
+				"The randomization matrix R (codimension x N, complex_mp) of a system produced by randomize().  Raises if the system has no randomization block.")
 			.def("reorder_functions_by_degree_decreasing", &SystemBaseT::ReorderFunctionsByDegreeDecreasing, (arg("self")),"Change the order of the functions to be in decreasing order")
 			.def("reorder_functions_by_degree_increasing", &SystemBaseT::ReorderFunctionsByDegreeIncreasing, (arg("self")),"Change the order of the functions to be in decreasing order")
 			.def("clear_variables", &SystemBaseT::ClearVariables, (arg("self")), "Remove the variable structure from the system")


### PR DESCRIPTION
## What

`System::Randomize()` could only square an overdetermined system (always `n = NumVariables - NumHomVariableGroups` functions). This adds the ability to randomize down to **any positive number of functions** — the general "randomize to codimension `c`" that numerical irreducible decomposition needs.

- **C++ core:** new `System::Randomize(int codimension)` producing exactly `codimension` generic combinations of the natural functions (`codimension=1` → a single function). The matrix-building logic is factored into a private `BuildRandomizationMatrix` helper shared with the no-arg form, so the descending-degree sort + `[I|C]` structure (optimal total-degree path count) applies to the reduced case too.
- **Python:** `sys.randomize(codimension=1)` (keyword-only, so every existing call — no-arg square, positional matrix, `matrix=` — keeps working), plus the top-level free function `bertini.randomize(system, codimension)`.

## Guards

- `codimension >= 1` (positive).
- `codimension < NumNaturalFunctions()` — cannot randomize to the same or more functions (must reduce the count).

The C++ core (`std::runtime_error` → `RuntimeError`) is the authority for the `< N` bound; the Python friendly layer adds an early `TypeError`/`ValueError` for a non-int / non-positive codimension, and rejects passing both `matrix` and `codimension`. The no-arg `Randomize()` is unchanged (still squares to the affine dimension, keeps its underdetermined guard).

*Note:* `codimension` is only bounded above by `N` (the function count), not by `n` (the variable count) — so randomizing to more functions than variables is permitted, per the "any positive number" intent. Easy to tighten to `<= n` if NID wants that.

## Tests

- **C++** (`randomization_block_test.cpp`): codim-one shape, codim==affine-dim matches square, zero/negative/`>=N` throw, and a codim-1 block eval matching the `ExpandToFunctionTree()` oracle.
- **Python** (`randomize_test.py`): the method, the free function, and every error path.

Doc-lint clean (both new public C++ entities documented); core + bindings build; full randomization suites pass on both sides with no regressions in the other randomize-touching tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)