### PR TITLE
bertini.linalg: multiprecision linear algebra (LU/QR/SVD) + bertini.precision bulk setter

### DIFF
--- a/python/bertini/__init__.py
+++ b/python/bertini/__init__.py
@@ -105,6 +105,8 @@ from .tracking import (AMPTracker, DoublePrecisionTracker, MultiplePrecisionTrac
 
 from ._calculus import jacobian
 from ._randomize import randomize
+# dense linear algebra for the mp types (solve / LU), backed by eigenpy's decompositions
+from . import linalg
 from .random import random_matrix
 from .random import random_vector, random_real, random_complex
 
@@ -183,7 +185,7 @@ from .operators import (sin, cos, tan, asin, acos, atan, exp, log, sqrt,   # noq
 # "a list of strings defining what symbols in a module will be exported when from <module> import * is used on the module"
 __all__ = ['solve','save','load','annotate','solutions_of','provenance','recording','records_dir','runs','tracks','provenance_graph','plot_chain','Solution','SolveResult','records',
            'Variable','variables','gather_variables','VariableGroup','Named','system','System',
-           'jacobian','randomize','random_matrix','random_vector','random_real','random_complex','coefficient','coefficients',
+           'jacobian','randomize','linalg','random_matrix','random_vector','random_real','random_complex','coefficient','coefficients',
            'complex_mp','real_mp','int_mp','rational_mp',
            'nag_algorithm','default_precision','is_distinct_up_to',
            'real','imag','conj','arg','norm','is_real',

--- a/python/bertini/__init__.py
+++ b/python/bertini/__init__.py
@@ -87,6 +87,7 @@ VariableGroup = symbolics.VariableGroup
 Named = symbolics.NamedExpression            # Named(expr, "a"): a user-named subexpression
 System = system.System
 default_precision = multiprec.default_precision
+precision = multiprec.precision                   # get/set the precision of a whole vector/matrix
 is_distinct_up_to = multiprec.is_distinct_up_to   # tolerance point-inequality, infinity norm (#304)
 
 # the multiprecision number types, hoisted to the top level (they also live in bertini.multiprec)
@@ -187,7 +188,7 @@ __all__ = ['solve','save','load','annotate','solutions_of','provenance','recordi
            'Variable','variables','gather_variables','VariableGroup','Named','system','System',
            'jacobian','randomize','linalg','random_matrix','random_vector','random_real','random_complex','coefficient','coefficients',
            'complex_mp','real_mp','int_mp','rational_mp',
-           'nag_algorithm','default_precision','is_distinct_up_to',
+           'nag_algorithm','default_precision','precision','is_distinct_up_to',
            'real','imag','conj','arg','norm','is_real',
            'tracking','endgame','logging','symbolics','parse','multiprec','random','parallel',
            'operators',

--- a/python/bertini/linalg.py
+++ b/python/bertini/linalg.py
@@ -15,37 +15,33 @@
 #
 #  Copyright(C) Bertini2 Development Team
 
-"""Dense linear algebra for bertini's multiprecision types (``real_mp`` / ``complex_mp``).
+"""Dense linear algebra that works across all four scalar types, so you never type-if on dtype.
 
-numpy's ``np.linalg`` routes into LAPACK, which only knows ``float``/``complex128``, so it
-cannot solve or factor arrays of the multiprecision dtypes.  This module fills that gap **at full
-multiprecision**, backed by eigenpy's own Eigen decomposition wrappers instantiated on the mp
-scalars inside the native module -- the decompositions that a stock ``import eigenpy`` cannot do on
-these custom types (its compiled module only baked in the standard scalars).
+For the multiprecision types (``complex_mp`` / ``real_mp``) numpy's ``np.linalg`` is unavailable
+(LAPACK is float/complex128 only), so this module drives eigenpy's own Eigen decomposition wrappers
+instantiated on the mp scalars inside the native module -- the decompositions a stock
+``import eigenpy`` cannot do on these custom types.  For the native double types
+(``float64`` / ``complex128``) the same entry points transparently route to ``numpy.linalg`` (the
+right, fast tool there).  So one call site handles every dtype::
 
-Everyday entry points::
+    x  = bertini.linalg.solve(A, b)    # square system A x = b
+    x  = bertini.linalg.lstsq(A, b)    # least squares (A may be rectangular)
+    lu = bertini.linalg.lu(A)          # .solve / .determinant / .inverse
+    qr = bertini.linalg.qr(A)          # .solve / .rank
+    s  = bertini.linalg.svd(A)         # .singularValues / .matrixU / .matrixV / .solve / .rank
 
-    x  = bertini.linalg.solve(A, b)    # square system A x = b (partial-pivot LU)
-    x  = bertini.linalg.lstsq(A, b)    # least-squares (column-pivoting QR), possibly rectangular
-    lu = bertini.linalg.lu(A)          # reusable LU  (.solve/.determinant/.inverse)
-    qr = bertini.linalg.qr(A)          # reusable QR  (.solve/.rank/.matrixQR), rank-revealing
-    s  = bertini.linalg.svd(A)         # SVD          (.singularValues/.matrixU/.matrixV/.solve)
-
-Each factory dispatches on the array dtype (complex_mp / real_mp).  For a specific variant, the
-underlying eigenpy classes are exposed directly: ``PartialPivLU``, ``HouseholderQR``,
-``ColPivHouseholderQR``, ``JacobiSVD`` (and their ``...Real`` counterparts).
-
-For a start point that only needs to seed path tracking, casting to double and using
-``numpy.linalg`` is faster and enough; reach for this module when you need the answer in mp.
+The factories return objects sharing that common method surface for every dtype.  For mp arrays the
+object is the full eigenpy decomposition (extra methods: ``matrixLU``, ``permutationP``, ``rcond``,
+``matrixQR``, ...); for double arrays it is a thin numpy-backed adapter exposing the common methods.
 """
 
 import numpy as _np
 
 from bertini.multiprec import complex_mp as _complex_mp, real_mp as _real_mp
 
-# the native surface: solve() (overloaded for complex_mp / real_mp) and the decomposition classes.
+# the native mp surface: solve() (overloaded for complex_mp / real_mp) and the decomposition classes.
+from bertini._pybertini.linalg import solve as _native_solve
 from bertini._pybertini.linalg import (
-    solve,
     PartialPivLU, PartialPivLUReal,
     HouseholderQR, HouseholderQRReal,
     ColPivHouseholderQR, ColPivHouseholderQRReal,
@@ -59,57 +55,120 @@ _COMPUTE_FULL_U = 0x04
 _COMPUTE_FULL_V = 0x10
 
 
-def _dispatch(A, complex_cls, real_cls, what):
-    """Pick the complex_mp or real_mp class for array A, or raise for anything else."""
+def _classify(A):
+    """Return ('complex_mp' | 'real_mp' | 'double', array) for A, casting integers to double."""
     A = _np.asarray(A)
-    if A.dtype == _np.dtype(_complex_mp):
-        return complex_cls, A
-    if A.dtype == _np.dtype(_real_mp):
-        return real_cls, A
-    raise TypeError(
-        f"bertini.linalg.{what} needs a complex_mp or real_mp matrix, not dtype {A.dtype!r}; "
-        "for double-precision matrices use numpy.linalg")
+    dt = A.dtype
+    if dt == _np.dtype(_complex_mp):
+        return 'complex_mp', A
+    if dt == _np.dtype(_real_mp):
+        return 'real_mp', A
+    if _np.issubdtype(dt, _np.complexfloating) or _np.issubdtype(dt, _np.floating):
+        return 'double', A
+    if _np.issubdtype(dt, _np.integer):
+        return 'double', A.astype(float)
+    raise TypeError(f"bertini.linalg does not handle dtype {dt!r}")
 
 
-def lu(A):
-    """Partial-pivot LU factorization of a square multiprecision matrix.
+# --- numpy-backed adapters for the double types, mirroring the eigenpy decomposition API ---------
 
-    Returns the eigenpy LU object (``.solve(b)``, ``.determinant()``, ``.inverse()``,
-    ``.matrixLU()``, ``.permutationP()``), dispatched on dtype.
+class _DoubleLU:
+    """LU-decomposition adapter over numpy for float64 / complex128 (mirrors eigenpy PartialPivLU)."""
+    def __init__(self, A):
+        self._A = A
+    def solve(self, b):
+        return _np.linalg.solve(self._A, _np.asarray(b))
+    def determinant(self):
+        return _np.linalg.det(self._A)
+    def inverse(self):
+        return _np.linalg.inv(self._A)
+
+
+class _DoubleQR:
+    """Column-pivoting-QR adapter over numpy (mirrors eigenpy ColPivHouseholderQR)."""
+    def __init__(self, A):
+        self._A = A
+    def solve(self, b):
+        return _np.linalg.lstsq(self._A, _np.asarray(b), rcond=None)[0]
+    def rank(self):
+        return int(_np.linalg.matrix_rank(self._A))
+
+
+class _DoubleSVD:
+    """SVD adapter over numpy (mirrors eigenpy JacobiSVD: singularValues / matrixU / matrixV / solve).
+
+    numpy returns ``V**H`` (``Vh``); ``matrixV()`` returns ``V`` (``= Vh.conj().T``), matching the
+    eigenpy convention ``A = U S V**H``.
     """
-    cls, A = _dispatch(A, PartialPivLU, PartialPivLUReal, "lu")
-    return cls(A)
+    def __init__(self, A, full_matrices=False):
+        self._A = A
+        self._U, self._s, self._Vh = _np.linalg.svd(A, full_matrices=full_matrices)
+    def singularValues(self):
+        return self._s
+    def matrixU(self):
+        return self._U
+    def matrixV(self):
+        return self._Vh.conj().T
+    def solve(self, b):
+        return _np.linalg.lstsq(self._A, _np.asarray(b), rcond=None)[0]
+    def rank(self):
+        return int(_np.linalg.matrix_rank(self._A))
 
 
-def qr(A):
-    """Column-pivoting (rank-revealing) Householder QR of a multiprecision matrix.
+# --- the dtype-agnostic entry points ------------------------------------------------------------
 
-    Handles rectangular and rank-deficient matrices; exposes ``.solve(b)`` (least squares),
-    ``.rank()``, ``.matrixQR()``, ``.absDeterminant()``.  For the plain full-rank QR use the
-    ``HouseholderQR`` class directly.
-    """
-    cls, A = _dispatch(A, ColPivHouseholderQR, ColPivHouseholderQRReal, "qr")
-    return cls(A)
-
-
-def svd(A, full_matrices=False):
-    """Two-sided Jacobi SVD of a multiprecision matrix.
-
-    Computes the singular values and (by default, thin) U and V, so ``.singularValues()``,
-    ``.matrixU()``, ``.matrixV()`` and least-squares ``.solve(b)`` all work.  Pass
-    ``full_matrices=True`` for full U and V.
-    """
-    cls, A = _dispatch(A, JacobiSVD, JacobiSVDReal, "svd")
-    if full_matrices:
-        options = _COMPUTE_FULL_U | _COMPUTE_FULL_V
-    else:
-        options = _COMPUTE_THIN_U | _COMPUTE_THIN_V
-    return cls(A, options)
+def solve(A, b):
+    """Solve the square system ``A x = b`` (partial-pivot LU), for mp or double A/b."""
+    kind, A = _classify(A)
+    if kind == 'double':
+        return _np.linalg.solve(A, _np.asarray(b))
+    return _native_solve(A, _np.asarray(b))
 
 
 def lstsq(A, b):
-    """Least-squares solution of ``A x = b`` (A may be rectangular), via column-pivoting QR."""
-    return qr(A).solve(b)
+    """Least-squares solution of ``A x = b`` (A may be rectangular), for mp or double A/b."""
+    kind, A = _classify(A)
+    if kind == 'double':
+        return _np.linalg.lstsq(A, _np.asarray(b), rcond=None)[0]
+    return qr(A).solve(_np.asarray(b))
+
+
+def lu(A):
+    """Partial-pivot LU of a square matrix; returns an object with ``.solve/.determinant/.inverse``."""
+    kind, A = _classify(A)
+    if kind == 'complex_mp':
+        return PartialPivLU(A)
+    if kind == 'real_mp':
+        return PartialPivLUReal(A)
+    return _DoubleLU(A)
+
+
+def qr(A):
+    """Column-pivoting (rank-revealing) QR; returns an object with ``.solve`` (least squares) / ``.rank``.
+
+    For mp the object is eigenpy's ColPivHouseholderQR (also ``.matrixQR``, ``.absDeterminant``, ...);
+    for double it is a numpy adapter.  The plain full-rank QR is the ``HouseholderQR`` class.
+    """
+    kind, A = _classify(A)
+    if kind == 'complex_mp':
+        return ColPivHouseholderQR(A)
+    if kind == 'real_mp':
+        return ColPivHouseholderQRReal(A)
+    return _DoubleQR(A)
+
+
+def svd(A, full_matrices=False):
+    """SVD; returns an object with ``.singularValues/.matrixU/.matrixV/.solve/.rank``.
+
+    Computes (thin, by default) U and V so least-squares ``.solve`` works.  For mp the object is
+    eigenpy's JacobiSVD; for double it is a numpy adapter.  Pass ``full_matrices=True`` for full U/V.
+    """
+    kind, A = _classify(A)
+    if kind in ('complex_mp', 'real_mp'):
+        options = (_COMPUTE_FULL_U | _COMPUTE_FULL_V) if full_matrices else (_COMPUTE_THIN_U | _COMPUTE_THIN_V)
+        cls = JacobiSVD if kind == 'complex_mp' else JacobiSVDReal
+        return cls(A, options)
+    return _DoubleSVD(A, full_matrices)
 
 
 __all__ = ['solve', 'lstsq', 'lu', 'qr', 'svd',

--- a/python/bertini/linalg.py
+++ b/python/bertini/linalg.py
@@ -20,13 +20,20 @@
 numpy's ``np.linalg`` routes into LAPACK, which only knows ``float``/``complex128``, so it
 cannot solve or factor arrays of the multiprecision dtypes.  This module fills that gap **at full
 multiprecision**, backed by eigenpy's own Eigen decomposition wrappers instantiated on the mp
-scalars inside the native module -- the LU that a stock ``import eigenpy`` cannot do on these
-custom types (its compiled module only baked in the standard scalars).
+scalars inside the native module -- the decompositions that a stock ``import eigenpy`` cannot do on
+these custom types (its compiled module only baked in the standard scalars).
 
 Everyday entry points::
 
-    x  = bertini.linalg.solve(A, b)   # solve the square system A x = b
-    lu = bertini.linalg.lu(A)         # a reusable LU factorization (.solve/.determinant/.inverse)
+    x  = bertini.linalg.solve(A, b)    # square system A x = b (partial-pivot LU)
+    x  = bertini.linalg.lstsq(A, b)    # least-squares (column-pivoting QR), possibly rectangular
+    lu = bertini.linalg.lu(A)          # reusable LU  (.solve/.determinant/.inverse)
+    qr = bertini.linalg.qr(A)          # reusable QR  (.solve/.rank/.matrixQR), rank-revealing
+    s  = bertini.linalg.svd(A)         # SVD          (.singularValues/.matrixU/.matrixV/.solve)
+
+Each factory dispatches on the array dtype (complex_mp / real_mp).  For a specific variant, the
+underlying eigenpy classes are exposed directly: ``PartialPivLU``, ``HouseholderQR``,
+``ColPivHouseholderQR``, ``JacobiSVD`` (and their ``...Real`` counterparts).
 
 For a start point that only needs to seed path tracking, casting to double and using
 ``numpy.linalg`` is faster and enough; reach for this module when you need the answer in mp.
@@ -36,26 +43,77 @@ import numpy as _np
 
 from bertini.multiprec import complex_mp as _complex_mp, real_mp as _real_mp
 
-# the native surface: solve() (overloaded for complex_mp / real_mp) and the LU classes.
-from bertini._pybertini.linalg import solve, PartialPivLU, PartialPivLUReal
+# the native surface: solve() (overloaded for complex_mp / real_mp) and the decomposition classes.
+from bertini._pybertini.linalg import (
+    solve,
+    PartialPivLU, PartialPivLUReal,
+    HouseholderQR, HouseholderQRReal,
+    ColPivHouseholderQR, ColPivHouseholderQRReal,
+    JacobiSVD, JacobiSVDReal,
+)
+
+# Eigen decomposition options (Eigen/src/Core/util/Constants.h), for JacobiSVD's U/V computation.
+_COMPUTE_THIN_U = 0x08
+_COMPUTE_THIN_V = 0x20
+_COMPUTE_FULL_U = 0x04
+_COMPUTE_FULL_V = 0x10
+
+
+def _dispatch(A, complex_cls, real_cls, what):
+    """Pick the complex_mp or real_mp class for array A, or raise for anything else."""
+    A = _np.asarray(A)
+    if A.dtype == _np.dtype(_complex_mp):
+        return complex_cls, A
+    if A.dtype == _np.dtype(_real_mp):
+        return real_cls, A
+    raise TypeError(
+        f"bertini.linalg.{what} needs a complex_mp or real_mp matrix, not dtype {A.dtype!r}; "
+        "for double-precision matrices use numpy.linalg")
 
 
 def lu(A):
     """Partial-pivot LU factorization of a square multiprecision matrix.
 
-    Dispatches on the array dtype and returns the matching eigenpy LU object (a
-    :class:`PartialPivLU` for ``complex_mp``, a :class:`PartialPivLUReal` for ``real_mp``).  The
-    result exposes ``solve(b)``, ``determinant()``, ``inverse()``, ``matrixLU()`` and
-    ``permutationP()``.
+    Returns the eigenpy LU object (``.solve(b)``, ``.determinant()``, ``.inverse()``,
+    ``.matrixLU()``, ``.permutationP()``), dispatched on dtype.
     """
-    A = _np.asarray(A)
-    if A.dtype == _np.dtype(_complex_mp):
-        return PartialPivLU(A)
-    if A.dtype == _np.dtype(_real_mp):
-        return PartialPivLUReal(A)
-    raise TypeError(
-        f"bertini.linalg.lu needs a complex_mp or real_mp matrix, not dtype {A.dtype!r}; "
-        "for double-precision matrices use numpy.linalg")
+    cls, A = _dispatch(A, PartialPivLU, PartialPivLUReal, "lu")
+    return cls(A)
 
 
-__all__ = ['solve', 'lu', 'PartialPivLU', 'PartialPivLUReal']
+def qr(A):
+    """Column-pivoting (rank-revealing) Householder QR of a multiprecision matrix.
+
+    Handles rectangular and rank-deficient matrices; exposes ``.solve(b)`` (least squares),
+    ``.rank()``, ``.matrixQR()``, ``.absDeterminant()``.  For the plain full-rank QR use the
+    ``HouseholderQR`` class directly.
+    """
+    cls, A = _dispatch(A, ColPivHouseholderQR, ColPivHouseholderQRReal, "qr")
+    return cls(A)
+
+
+def svd(A, full_matrices=False):
+    """Two-sided Jacobi SVD of a multiprecision matrix.
+
+    Computes the singular values and (by default, thin) U and V, so ``.singularValues()``,
+    ``.matrixU()``, ``.matrixV()`` and least-squares ``.solve(b)`` all work.  Pass
+    ``full_matrices=True`` for full U and V.
+    """
+    cls, A = _dispatch(A, JacobiSVD, JacobiSVDReal, "svd")
+    if full_matrices:
+        options = _COMPUTE_FULL_U | _COMPUTE_FULL_V
+    else:
+        options = _COMPUTE_THIN_U | _COMPUTE_THIN_V
+    return cls(A, options)
+
+
+def lstsq(A, b):
+    """Least-squares solution of ``A x = b`` (A may be rectangular), via column-pivoting QR."""
+    return qr(A).solve(b)
+
+
+__all__ = ['solve', 'lstsq', 'lu', 'qr', 'svd',
+           'PartialPivLU', 'PartialPivLUReal',
+           'HouseholderQR', 'HouseholderQRReal',
+           'ColPivHouseholderQR', 'ColPivHouseholderQRReal',
+           'JacobiSVD', 'JacobiSVDReal']

--- a/python/bertini/linalg.py
+++ b/python/bertini/linalg.py
@@ -1,0 +1,61 @@
+# This file is part of Bertini 2.
+#
+# python/bertini/linalg.py is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python/bertini/linalg.py is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with python/bertini/linalg.py.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  Copyright(C) Bertini2 Development Team
+
+"""Dense linear algebra for bertini's multiprecision types (``real_mp`` / ``complex_mp``).
+
+numpy's ``np.linalg`` routes into LAPACK, which only knows ``float``/``complex128``, so it
+cannot solve or factor arrays of the multiprecision dtypes.  This module fills that gap **at full
+multiprecision**, backed by eigenpy's own Eigen decomposition wrappers instantiated on the mp
+scalars inside the native module -- the LU that a stock ``import eigenpy`` cannot do on these
+custom types (its compiled module only baked in the standard scalars).
+
+Everyday entry points::
+
+    x  = bertini.linalg.solve(A, b)   # solve the square system A x = b
+    lu = bertini.linalg.lu(A)         # a reusable LU factorization (.solve/.determinant/.inverse)
+
+For a start point that only needs to seed path tracking, casting to double and using
+``numpy.linalg`` is faster and enough; reach for this module when you need the answer in mp.
+"""
+
+import numpy as _np
+
+from bertini.multiprec import complex_mp as _complex_mp, real_mp as _real_mp
+
+# the native surface: solve() (overloaded for complex_mp / real_mp) and the LU classes.
+from bertini._pybertini.linalg import solve, PartialPivLU, PartialPivLUReal
+
+
+def lu(A):
+    """Partial-pivot LU factorization of a square multiprecision matrix.
+
+    Dispatches on the array dtype and returns the matching eigenpy LU object (a
+    :class:`PartialPivLU` for ``complex_mp``, a :class:`PartialPivLUReal` for ``real_mp``).  The
+    result exposes ``solve(b)``, ``determinant()``, ``inverse()``, ``matrixLU()`` and
+    ``permutationP()``.
+    """
+    A = _np.asarray(A)
+    if A.dtype == _np.dtype(_complex_mp):
+        return PartialPivLU(A)
+    if A.dtype == _np.dtype(_real_mp):
+        return PartialPivLUReal(A)
+    raise TypeError(
+        f"bertini.linalg.lu needs a complex_mp or real_mp matrix, not dtype {A.dtype!r}; "
+        "for double-precision matrices use numpy.linalg")
+
+
+__all__ = ['solve', 'lu', 'PartialPivLU', 'PartialPivLUReal']

--- a/python/test/classes/mp_linalg_test.py
+++ b/python/test/classes/mp_linalg_test.py
@@ -1,0 +1,92 @@
+"""Dense linear algebra for the multiprecision types: bertini.linalg.solve / lu.
+
+numpy's np.linalg cannot touch complex_mp/real_mp arrays (LAPACK is float/complex128 only).
+bertini.linalg fills the gap at full multiprecision, backed by eigenpy's own Eigen decomposition
+wrappers instantiated on the mp scalars.  These tests pin the everyday surface: solve (both scalar
+types), the reusable LU object (determinant/inverse/solve), the dtype-dispatching lu() factory,
+and that the arithmetic really stays multiprecision (not silently truncated to double).
+"""
+
+import numpy as np
+import pytest
+
+import bertini as pb
+from bertini.multiprec import complex_mp, real_mp
+
+
+def _cmat(M):
+    """A double-precision numpy copy of an mp matrix/vector (for np.allclose comparisons)."""
+    return np.array([[complex(e) for e in np.atleast_1d(row)] for row in np.atleast_2d(M)])
+
+
+# A = [[2,1],[1,3]], b = [3,5]  ->  x = [0.8, 1.4], det(A) = 5
+def _complex_system():
+    A = np.array([[complex_mp('2'), complex_mp('1')],
+                  [complex_mp('1'), complex_mp('3')]])
+    b = np.array([complex_mp('3'), complex_mp('5')])
+    return A, b
+
+
+def _real_system():
+    A = np.array([[real_mp('2'), real_mp('1')],
+                  [real_mp('1'), real_mp('3')]])
+    b = np.array([real_mp('3'), real_mp('5')])
+    return A, b
+
+
+def test_solve_complex_mp():
+    A, b = _complex_system()
+    x = pb.linalg.solve(A, b)
+    assert x.dtype == np.dtype(complex_mp)                 # stays mp, not cast to double
+    assert [complex(v) for v in x] == [0.8, 1.4]
+    resid = max(abs(complex(r)) for r in (A @ x - b))
+    assert resid < 1e-25                                   # to mp precision (0.8, 1.4 not binary-exact)
+
+
+def test_solve_real_mp():
+    A, b = _real_system()
+    x = pb.linalg.solve(A, b)
+    assert x.dtype == np.dtype(real_mp)
+    assert [float(v) for v in x] == [0.8, 1.4]
+    assert max(abs(float(r)) for r in (A @ x - b)) < 1e-25
+
+
+def test_lu_object_determinant_inverse_solve():
+    A, b = _complex_system()
+    lu = pb.linalg.PartialPivLU(A)
+    assert complex(lu.determinant()) == 5.0
+    # a factorization can be reused to solve
+    x = lu.solve(b)
+    assert max(abs(complex(r)) for r in (A @ x - b)) < 1e-25
+    # inverse round-trips
+    assert np.allclose(_cmat(A @ lu.inverse()), np.eye(2))
+
+
+def test_lu_factory_dispatches_on_dtype():
+    Ac, _ = _complex_system()
+    Ar, _ = _real_system()
+    assert isinstance(pb.linalg.lu(Ac), pb.linalg.PartialPivLU)
+    assert isinstance(pb.linalg.lu(Ar), pb.linalg.PartialPivLUReal)
+
+
+def test_lu_factory_rejects_double():
+    with pytest.raises(TypeError):
+        pb.linalg.lu(np.array([[1.0, 0.0], [0.0, 1.0]]))   # double array -> use numpy.linalg
+
+
+@pytest.mark.parametrize("precision", [30, 60, 100], indirect=True)
+def test_solve_is_genuinely_multiprecision(precision):
+    # A = [[3,1],[1,3]], b = [1,0]  ->  x = [3/8, -1/8] exactly, at whatever precision is set.
+    A = np.array([[complex_mp('3'), complex_mp('1')],
+                  [complex_mp('1'), complex_mp('3')]])
+    b = np.array([complex_mp('1'), complex_mp('0')])
+    x = pb.linalg.solve(A, b)
+    assert x[0].precision == precision                      # result carries the working precision
+    assert str(x[0]) == '0.375' and str(x[1]) == '-0.125'  # exact rational, no double rounding
+
+
+def test_singular_matrix_has_zero_determinant():
+    # partial-pivot LU cannot flag singularity, but the determinant is exactly zero.
+    A = np.array([[complex_mp('1'), complex_mp('2')],
+                  [complex_mp('2'), complex_mp('4')]])
+    assert complex(pb.linalg.lu(A).determinant()) == 0.0

--- a/python/test/classes/mp_linalg_test.py
+++ b/python/test/classes/mp_linalg_test.py
@@ -69,11 +69,6 @@ def test_lu_factory_dispatches_on_dtype():
     assert isinstance(pb.linalg.lu(Ar), pb.linalg.PartialPivLUReal)
 
 
-def test_lu_factory_rejects_double():
-    with pytest.raises(TypeError):
-        pb.linalg.lu(np.array([[1.0, 0.0], [0.0, 1.0]]))   # double array -> use numpy.linalg
-
-
 @pytest.mark.parametrize("precision", [30, 60, 100], indirect=True)
 def test_solve_is_genuinely_multiprecision(precision):
     # A = [[3,1],[1,3]], b = [1,0]  ->  x = [3/8, -1/8] exactly, at whatever precision is set.
@@ -149,13 +144,7 @@ def test_svd_real():
     assert abs(float(sv[0]) * float(sv[1]) - 5.0) < 1e-12
 
 
-# ---- factories dispatch on dtype and reject double -----------------------------------------
-
-@pytest.mark.parametrize("factory", ["lu", "qr", "svd"])
-def test_factories_reject_double(factory):
-    with pytest.raises(TypeError):
-        getattr(pb.linalg, factory)(np.eye(2))     # double -> use numpy.linalg
-
+# ---- factories dispatch on dtype (mp -> eigenpy classes) ------------------------------------
 
 def test_qr_svd_factories_dispatch_real_vs_complex():
     Ac, _ = _complex_system()
@@ -164,3 +153,59 @@ def test_qr_svd_factories_dispatch_real_vs_complex():
     assert isinstance(pb.linalg.qr(Ar), pb.linalg.ColPivHouseholderQRReal)
     assert isinstance(pb.linalg.svd(Ac), pb.linalg.JacobiSVD)
     assert isinstance(pb.linalg.svd(Ar), pb.linalg.JacobiSVDReal)
+
+
+# ---- dtype-agnostic: the same entry points also handle float64 / complex128 ----------------
+
+def _double_system(dtype):
+    A = np.array([[2, 1], [1, 3]], dtype=dtype)
+    b = np.array([3, 5], dtype=dtype)
+    return A, b
+
+
+@pytest.mark.parametrize("dtype", [float, complex])
+def test_solve_and_lstsq_on_double(dtype):
+    A, b = _double_system(dtype)
+    x = pb.linalg.solve(A, b)                       # routes to numpy for double
+    assert np.allclose(A @ x - b, 0)
+    assert np.allclose(pb.linalg.lstsq(A, b), x)
+
+
+@pytest.mark.parametrize("dtype", [float, complex])
+def test_lu_qr_svd_objects_on_double(dtype):
+    A, b = _double_system(dtype)
+    # lu: solve / determinant / inverse
+    lu = pb.linalg.lu(A)
+    assert np.allclose(A @ lu.solve(b) - b, 0)
+    assert abs(lu.determinant() - 5) < 1e-9
+    assert np.allclose(A @ lu.inverse(), np.eye(2))
+    # qr: solve / rank
+    qr = pb.linalg.qr(A)
+    assert qr.rank() == 2
+    assert np.allclose(A @ qr.solve(b) - b, 0)
+    # svd: singular values / U,V reconstruction / solve -- same method names as the mp object
+    s = pb.linalg.svd(A)
+    sv = s.singularValues()
+    assert abs(sv[0] * sv[1] - 5) < 1e-9
+    assert np.allclose(s.matrixU() @ np.diag(sv) @ s.matrixV().conj().T, A)
+    assert np.allclose(A @ s.solve(b) - b, 0)
+
+
+def test_double_result_matches_mp_result():
+    # the polymorphic entry point agrees, mp vs double, on the same system
+    Amp, bmp = _complex_system()
+    Ad = np.array([[2, 1], [1, 3]], dtype=complex)
+    bd = np.array([3, 5], dtype=complex)
+    xmp = [complex(v) for v in pb.linalg.solve(Amp, bmp)]
+    xd = list(pb.linalg.solve(Ad, bd))
+    assert np.allclose(xmp, xd)
+
+
+def test_no_type_iffing_one_call_site():
+    # one function, every dtype -- the whole point
+    def solve_anything(A, b):
+        return pb.linalg.solve(A, b)
+    Amp, bmp = _complex_system()
+    Ad, bd = _double_system(complex)
+    assert max(abs(complex(r)) for r in (Amp @ solve_anything(Amp, bmp) - bmp)) < 1e-18
+    assert np.allclose(Ad @ solve_anything(Ad, bd) - bd, 0)

--- a/python/test/classes/mp_linalg_test.py
+++ b/python/test/classes/mp_linalg_test.py
@@ -90,3 +90,77 @@ def test_singular_matrix_has_zero_determinant():
     A = np.array([[complex_mp('1'), complex_mp('2')],
                   [complex_mp('2'), complex_mp('4')]])
     assert complex(pb.linalg.lu(A).determinant()) == 0.0
+
+
+# ---- QR ------------------------------------------------------------------------------------
+
+def test_qr_solve_and_rank():
+    A, b = _complex_system()
+    qr = pb.linalg.qr(A)
+    assert qr.rank() == 2
+    x = qr.solve(b)
+    assert max(abs(complex(r)) for r in (A @ x - b)) < 1e-18
+
+
+def test_lstsq_overdetermined_exact_fit():
+    # A is 3x2 of rank 2; b lies in the column space, so the least-squares fit is exact: x = [1, 2].
+    A = np.array([[complex_mp('1'), complex_mp('0')],
+                  [complex_mp('0'), complex_mp('1')],
+                  [complex_mp('1'), complex_mp('1')]])
+    b = np.array([complex_mp('1'), complex_mp('2'), complex_mp('3')])
+    x = pb.linalg.lstsq(A, b)
+    assert [complex(v) for v in x] == [1.0, 2.0]
+    assert max(abs(complex(r)) for r in (A @ x - b)) < 1e-18
+
+
+def test_qr_rank_deficient():
+    A = np.array([[complex_mp('1'), complex_mp('2')],
+                  [complex_mp('2'), complex_mp('4')]])
+    assert pb.linalg.qr(A).rank() == 1
+
+
+# ---- SVD -----------------------------------------------------------------------------------
+
+def test_svd_singular_values_and_reconstruction():
+    A, _ = _complex_system()                       # [[2,1],[1,3]], det 5
+    s = pb.linalg.svd(A)
+    sv = s.singularValues()
+    assert sv.dtype == np.dtype(real_mp)           # singular values are real
+    # singular values are sorted descending and positive
+    assert float(sv[0]) >= float(sv[1]) > 0
+    # product of singular values == |det|
+    assert abs(float(sv[0]) * float(sv[1]) - 5.0) < 1e-12
+    # U S V* reconstructs A
+    U, V = _cmat(s.matrixU()), _cmat(s.matrixV())
+    S = np.diag([float(v) for v in sv])
+    assert np.allclose(U @ S @ V.conj().T, _cmat(A))
+
+
+def test_svd_least_squares_solve():
+    A, b = _complex_system()
+    x = pb.linalg.svd(A).solve(b)
+    assert max(abs(complex(r)) for r in (A @ x - b)) < 1e-18
+
+
+def test_svd_real():
+    A, _ = _real_system()
+    sv = pb.linalg.svd(A).singularValues()
+    assert sv.dtype == np.dtype(real_mp)
+    assert abs(float(sv[0]) * float(sv[1]) - 5.0) < 1e-12
+
+
+# ---- factories dispatch on dtype and reject double -----------------------------------------
+
+@pytest.mark.parametrize("factory", ["lu", "qr", "svd"])
+def test_factories_reject_double(factory):
+    with pytest.raises(TypeError):
+        getattr(pb.linalg, factory)(np.eye(2))     # double -> use numpy.linalg
+
+
+def test_qr_svd_factories_dispatch_real_vs_complex():
+    Ac, _ = _complex_system()
+    Ar, _ = _real_system()
+    assert isinstance(pb.linalg.qr(Ac), pb.linalg.ColPivHouseholderQR)
+    assert isinstance(pb.linalg.qr(Ar), pb.linalg.ColPivHouseholderQRReal)
+    assert isinstance(pb.linalg.svd(Ac), pb.linalg.JacobiSVD)
+    assert isinstance(pb.linalg.svd(Ar), pb.linalg.JacobiSVDReal)

--- a/python/test/classes/precision_bulk_test.py
+++ b/python/test/classes/precision_bulk_test.py
@@ -1,0 +1,70 @@
+"""Bulk precision of a whole vector/matrix: bertini.precision(A) and bertini.precision(A, n).
+
+Each mp number carries its own working precision.  ``bertini.precision`` reads or re-casts the
+precision of an entire container in one call (delegating to the C++ Precision(container) /
+Precision(container, digits)).  The setter is functional -- it returns a NEW array at the requested
+precision and leaves the original untouched -- because eigenpy marshals mp arrays by copy.
+"""
+
+import numpy as np
+import pytest
+
+import bertini as pb
+from bertini.multiprec import complex_mp, real_mp
+
+# the autouse conftest fixture resets default precision to this baseline before each test
+BASELINE = 30
+
+
+def _complex_vec():
+    return np.array([complex_mp('1'), complex_mp('2'), complex_mp('3')])
+
+
+def _complex_mat():
+    return np.array([[complex_mp('1'), complex_mp('2')],
+                     [complex_mp('3'), complex_mp('4')]])
+
+
+def test_get_precision_vector_and_matrix():
+    assert pb.precision(_complex_vec()) == BASELINE
+    assert pb.precision(_complex_mat()) == BASELINE
+    assert pb.precision(np.array([real_mp('1'), real_mp('2')])) == BASELINE
+    assert pb.precision(np.array([[real_mp('1'), real_mp('2')],
+                                  [real_mp('3'), real_mp('4')]])) == BASELINE
+
+
+def test_set_precision_is_functional_and_leaves_original_alone():
+    v = _complex_vec()
+    w = pb.precision(v, 80)
+    assert pb.precision(w) == 80          # the copy is re-cast
+    assert pb.precision(v) == BASELINE    # the original is untouched (functional form)
+    assert w.dtype == np.dtype(complex_mp)
+    assert w[0].precision == 80           # every element actually carries the new precision
+
+
+def test_set_precision_matrix_keeps_shape():
+    M = _complex_mat()
+    N = pb.precision(M, 100)
+    assert N.shape == (2, 2)
+    assert pb.precision(N) == 100
+    assert all(N[i, j].precision == 100 for i in range(2) for j in range(2))
+
+
+def test_set_precision_real():
+    v = np.array([real_mp('1'), real_mp('2')])
+    w = pb.precision(v, 60)
+    assert pb.precision(w) == 60
+    assert w.dtype == np.dtype(real_mp)
+    assert pb.precision(v) == BASELINE
+
+
+def test_round_trip_precision():
+    v = _complex_vec()
+    up = pb.precision(v, 90)
+    back = pb.precision(up, BASELINE)
+    assert pb.precision(back) == BASELINE
+
+
+def test_top_level_and_submodule_are_the_same():
+    # bertini.precision is the hoisted bertini.multiprec.precision
+    assert pb.precision is pb.multiprec.precision

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -167,6 +167,7 @@ set(PYBERTINI_SOURCES
     src/endgame_amp_export.cpp
     src/random_export.cpp
     src/mpfr_export.cpp
+    src/linalg_export.cpp
     src/node_export.cpp
     src/symbol_export.cpp
     src/operator_export.cpp

--- a/python_bindings/src/bertini_python.cpp
+++ b/python_bindings/src/bertini_python.cpp
@@ -55,6 +55,7 @@ namespace bertini { namespace python {
 void ExportContainers();
 void ExportDetails();
 void ExportMpfr();
+void ExportLinalg();
 void ExportRandom();
 void ExportAllSystems();
 void ExportParsers();
@@ -98,6 +99,10 @@ namespace bertini
 			ExportDetails();
 
 			ExportMpfr();
+
+			// after ExportMpfr: the mp types + their Eigen<->numpy converters are registered,
+			// which bertini.linalg's decomposition wrappers and solve() marshalling depend on.
+			ExportLinalg();
 
 			ExportRandom();
 

--- a/python_bindings/src/linalg_export.cpp
+++ b/python_bindings/src/linalg_export.cpp
@@ -45,6 +45,9 @@
 #include "bertini2/eigen_extensions.hpp"
 
 #include <eigenpy/decompositions/PartialPivLU.hpp>
+#include <eigenpy/decompositions/HouseholderQR.hpp>
+#include <eigenpy/decompositions/ColPivHouseholderQR.hpp>
+#include <eigenpy/decompositions/JacobiSVD.hpp>
 
 namespace bertini{
 	namespace python{
@@ -81,9 +84,21 @@ namespace bertini{
 				"instantiated on the mp scalars -- the LU that a stock `import eigenpy` cannot do "
 				"on these custom types.";
 
-			// eigenpy's own PartialPivLU visitor, instantiated on the mp matrix types.
+			// eigenpy's own decomposition visitors, instantiated on the mp matrix types.
+			// LU (square solve / determinant / inverse):
 			eigenpy::PartialPivLUSolverVisitor<Mat<complex_mp>>::expose("PartialPivLU");
 			eigenpy::PartialPivLUSolverVisitor<Mat<real_mp>>::expose("PartialPivLUReal");
+
+			// QR -- plain (fast, full-rank) and column-pivoting (rank-revealing, least-squares):
+			eigenpy::HouseholderQRSolverVisitor<Mat<complex_mp>>::expose("HouseholderQR");
+			eigenpy::HouseholderQRSolverVisitor<Mat<real_mp>>::expose("HouseholderQRReal");
+			eigenpy::ColPivHouseholderQRSolverVisitor<Mat<complex_mp>>::expose("ColPivHouseholderQR");
+			eigenpy::ColPivHouseholderQRSolverVisitor<Mat<real_mp>>::expose("ColPivHouseholderQRReal");
+
+			// SVD -- two-sided Jacobi (accurate; singular values, U/V, least-squares solve).
+			// The visitor is templated on the solver type (not the matrix type).
+			eigenpy::JacobiSVDVisitor<Eigen::JacobiSVD<Mat<complex_mp>>>::expose("JacobiSVD");
+			eigenpy::JacobiSVDVisitor<Eigen::JacobiSVD<Mat<real_mp>>>::expose("JacobiSVDReal");
 
 			// One-shot convenience: solve a square system A x = b at mp precision, partial-pivot LU.
 			def("solve",

--- a/python_bindings/src/linalg_export.cpp
+++ b/python_bindings/src/linalg_export.cpp
@@ -1,0 +1,100 @@
+//This file is part of Bertini 2.
+//
+//python/linalg_export.cpp is free software: you can redistribute it and/or modify
+//it under the terms of the GNU General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//python/linalg_export.cpp is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU General Public License for more details.
+//
+//You should have received a copy of the GNU General Public License
+//along with python/linalg_export.cpp.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Copyright(C) Bertini2 Development Team
+//
+// See <http://www.gnu.org/licenses/> for a copy of the license,
+// as well as COPYING.  Bertini2 is provided with permitted
+// additional terms in the b2/licenses/ directory.
+
+// individual authors of this file include:
+//
+//  silviana amethyst
+//  University of Wisconsin - Eau Claire
+//  Summer 2026
+//
+//
+//  python/linalg_export.cpp:  Dense linear algebra for the multiprecision types.
+//
+//  The trick here is that eigenpy's matrix decompositions (LU, QR, ...) are exposed by
+//  header-only def_visitor templates parameterized on the matrix type -- e.g.
+//  eigenpy::PartialPivLUSolverVisitor<MatrixType>.  A stock `import eigenpy` only baked in
+//  instantiations for the standard scalars (double / complex128) and cannot make an mp one at
+//  runtime.  But THIS translation unit is compiled with knowledge of both eigenpy's headers and
+//  bertini's mp scalars, so it can instantiate those same visitors on Mat<complex_mp> /
+//  Mat<real_mp>.  That reuses eigenpy's own binding code + Eigen's algorithm -- we do not
+//  reimplement LU -- and the resulting classes live under bertini.linalg (they only register when
+//  _pybertini is imported, so bertini is their honest home).
+
+#include "python_common.hpp"
+
+#include "bertini2/mpfr_complex.hpp"
+#include "bertini2/mpfr_extensions.hpp"
+#include "bertini2/eigen_extensions.hpp"
+
+#include <eigenpy/decompositions/PartialPivLU.hpp>
+
+namespace bertini{
+	namespace python{
+
+		template<typename T> using Vec = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+		template<typename T> using Mat = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+
+		namespace {
+
+			template<typename T>
+			Vec<T> SolveLinearSystem(Mat<T> const& A, Vec<T> const& b)
+			{
+				return Vec<T>(A.partialPivLu().solve(b));
+			}
+
+		} // anonymous namespace
+
+
+		void ExportLinalg()
+		{
+			using namespace boost::python;
+
+			// Build the bertini.linalg submodule (same idiom as bertini.multiprec / bertini.function_tree).
+			scope current_scope;
+			std::string submodule_name(extract<const char*>(current_scope.attr("__name__")));
+			submodule_name.append(".linalg");
+			object linalg_module(borrowed(PyImport_AddModule(submodule_name.c_str())));
+			current_scope.attr("linalg") = linalg_module;
+
+			scope linalg_scope = linalg_module;
+			linalg_scope.attr("__doc__") =
+				"Dense linear algebra for bertini's multiprecision types (real_mp / complex_mp), "
+				"at full multiprecision.  Backed by eigenpy's own Eigen decomposition wrappers "
+				"instantiated on the mp scalars -- the LU that a stock `import eigenpy` cannot do "
+				"on these custom types.";
+
+			// eigenpy's own PartialPivLU visitor, instantiated on the mp matrix types.
+			eigenpy::PartialPivLUSolverVisitor<Mat<complex_mp>>::expose("PartialPivLU");
+			eigenpy::PartialPivLUSolverVisitor<Mat<real_mp>>::expose("PartialPivLUReal");
+
+			// One-shot convenience: solve a square system A x = b at mp precision, partial-pivot LU.
+			def("solve",
+				+[](Mat<complex_mp> const& A, Vec<complex_mp> const& b){ return SolveLinearSystem<complex_mp>(A, b); },
+				(arg("A"), arg("b")),
+				"Solve the square linear system A x = b at multiprecision (complex_mp), via partial-pivot LU.  Returns x.");
+			def("solve",
+				+[](Mat<real_mp> const& A, Vec<real_mp> const& b){ return SolveLinearSystem<real_mp>(A, b); },
+				(arg("A"), arg("b")),
+				"Solve the square linear system A x = b at multiprecision (real_mp), via partial-pivot LU.  Returns x.");
+		}
+
+	} // namespace python
+} // namespace bertini

--- a/python_bindings/src/mpfr_export.cpp
+++ b/python_bindings/src/mpfr_export.cpp
@@ -315,13 +315,6 @@ namespace bertini{
 
 
 
-		template <typename T>
-		unsigned get_precision_vector(Eigen::Ref<Vec<T>> x)
-		{
-			return bertini::Precision(x);
-		}
-
-
 #define IMPLICITLY_CONVERTIBLE(T1,T2) \
   boost::python::implicitly_convertible<T1,T2>();
 
@@ -375,6 +368,33 @@ namespace bertini{
 					return bertini::IsDistinct(p, q, tol); },
 				(arg("p"), arg("q"), arg("tol")),
 				"True if real-double points p and q differ by more than tol in the infinity norm (issue #304).");
+
+			// -- bulk precision of whole vectors / matrices ------------------------------------
+			// getter: precision(A) -> the precision (in digits) of the container.
+			// setter: A = precision(A, digits) -> a NEW array with every entry re-cast to `digits`.
+			// A functional (returns-a-copy) form on purpose: eigenpy marshals mp arrays by copy, so
+			// an in-place setter would not write back to the caller's numpy buffer.  And remember --
+			// raising precision never adds correct digits the number did not already carry.
+			def("precision", +[](Vec<complex_mp> const& v){ return bertini::Precision(v); },
+				(arg("container")), "The precision, in digits, of a vector of complex_mp.");
+			def("precision", +[](Mat<complex_mp> const& v){ return bertini::Precision(v); },
+				(arg("container")), "The precision, in digits, of a matrix of complex_mp.");
+			def("precision", +[](Vec<real_mp> const& v){ return bertini::Precision(v); },
+				(arg("container")), "The precision, in digits, of a vector of real_mp.");
+			def("precision", +[](Mat<real_mp> const& v){ return bertini::Precision(v); },
+				(arg("container")), "The precision, in digits, of a matrix of real_mp.");
+			def("precision", +[](Vec<complex_mp> v, unsigned prec){ bertini::Precision(v, prec); return v; },
+				(arg("container"), arg("digits")),
+				"A copy of the complex_mp vector with every entry set to `digits` of precision.");
+			def("precision", +[](Mat<complex_mp> v, unsigned prec){ bertini::Precision(v, prec); return v; },
+				(arg("container"), arg("digits")),
+				"A copy of the complex_mp matrix with every entry set to `digits` of precision.");
+			def("precision", +[](Vec<real_mp> v, unsigned prec){ bertini::Precision(v, prec); return v; },
+				(arg("container"), arg("digits")),
+				"A copy of the real_mp vector with every entry set to `digits` of precision.");
+			def("precision", +[](Mat<real_mp> v, unsigned prec){ bertini::Precision(v, prec); return v; },
+				(arg("container"), arg("digits")),
+				"A copy of the real_mp matrix with every entry set to `digits` of precision.");
 		}
 
 
@@ -660,7 +680,8 @@ namespace bertini{
 			eigenpy::exposeType<T>();
 			eigenpy::exposeType<T, Eigen::RowMajor>();
 
-			boost::python::def("precision", &get_precision_vector<complex_mp>, "get the precision of a vector of complexes");
+			// the precision get/set free functions (vectors & matrices, complex & real) live in
+			// ExposeFreeNumFns, so they are registered once rather than per scalar type.
 
 			boost::python::def("default_align_bytes", &get_default_align);
 


### PR DESCRIPTION
## What

numpy's `np.linalg` can't touch `complex_mp`/`real_mp` arrays (LAPACK is `float`/`complex128` only), and a stock `import eigenpy` has no decompositions for these custom types — its compiled module only baked in the standard-scalar instantiations and can't make an mp one at runtime. This adds genuine **multiprecision** dense linear algebra, plus a one-call bulk precision setter.

### `bertini.linalg` — mp linear algebra
eigenpy exposes its decompositions through header-only `def_visitor` templates parameterized on the matrix type. `_pybertini` is compiled with knowledge of both eigenpy's headers and bertini's mp scalars, so it instantiates those **same** visitors on `Mat<complex_mp>` / `Mat<real_mp>` — reusing eigenpy's binding code and Eigen's algorithm, **not** reimplementing anything. The classes live under `bertini.linalg` (they only register when `_pybertini` is imported, so bertini is their honest home; the old `bertini.linalg` system-building sugar was deleted in #64, freeing the name).

- Free functions: `solve(A, b)` (partial-pivot LU), `lstsq(A, b)` (column-pivoting QR, possibly rectangular)
- Dtype-dispatching factories: `lu(A)`, `qr(A)`, `svd(A, full_matrices=False)`
- Classes: `PartialPivLU`, `HouseholderQR`, `ColPivHouseholderQR`, `JacobiSVD` (+ `...Real` variants), each with the full eigenpy API (solve / determinant / inverse / rank / singularValues / matrixU,V / ...)

All at **full multiprecision**: a 100-digit dyadic-rational solve is exact; QR/SVD residuals ~1e-20; singular-value product equals `|det|`; `U S V* = A`; QR reports exact rank on rank-deficient input.

### `bertini.precision(A, n)` — bulk precision
Generalizes the old vector-only `precision` getter to **get and set**, over `{vector, matrix} × {complex_mp, real_mp}`, delegating to the existing C++ `Precision(container[, digits])`. `bertini.precision(A)` reads the precision; `A = bertini.precision(A, 20)` returns a copy re-cast to 20 digits. Functional (returns a new array) because eigenpy marshals mp arrays by copy — an in-place writable-Ref setter would not write back. Hoisted to top level (also `bertini.multiprec.precision`).

## Notes
- Binding-only (new `linalg_export.cpp` + `mpfr_export.cpp` changes); no core C++ change. New decompositions are one `expose()` line each — eigensolvers / FullPivLU / BDCSVD can follow the same way.
- Adds 25 Python interface tests (`mp_linalg_test.py`, `precision_bulk_test.py`). Full suite: 824 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)