### PR TITLE
ci(windows): run the C++ test build through ccache

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -299,6 +299,16 @@ jobs:
           auto-activate: false
           channel-priority: strict
 
+      # Persist the compiler cache for the C++ test build (mirrors the Unix test jobs and the
+      # Windows wheel job).  Loose key -- always save fresh, restore newest; ccache self-invalidates.
+      - name: Cache ccache (Windows C++ tests)
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}\.ccache
+          key: ccache-win-cpp-${{ github.sha }}
+          restore-keys: |
+            ccache-win-cpp-
+
       - name: Configure and build C++ tests
         shell: pwsh
         run: |
@@ -319,15 +329,24 @@ jobs:
           $boostHeader = "$env:CONDA_PREFIX\Library\include\boost\archive\archive_exception.hpp"
           (Get-Content $boostHeader).Replace('public virtual std::exception', 'public std::exception') | Set-Content $boostHeader
 
+          # Run clang-cl through ccache (USE_CCACHE=ON default; ccache ships in environment-win.yml)
+          # and persist its dir (cached above).  The -DUSE_CCACHE=OFF "precaution" from 87bb4c61 is
+          # lifted: the Windows *wheel* job has built clang-cl through ccache for months without
+          # issue, so caching the C++ test build too can only warm it -- a cold cache is a normal
+          # build, never a break.
+          $env:CCACHE_DIR = "${{ github.workspace }}\.ccache"
+          $env:CCACHE_MAXSIZE = '400M'
+          ccache --zero-stats 2>$null
+
           cmake -B build `
             -DCMAKE_PREFIX_PATH="$env:CONDA_PREFIX\Library" `
             -DBUILD_PYTHON_BINDINGS=OFF `
             -DENABLE_UNIT_TESTING=ON `
-            -DUSE_CCACHE=OFF `
             -DINSTALL_DOCUMENTATION=OFF `
             -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON `
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build --parallel
+          ccache --show-stats
 
       # Run under both per-solve thread settings (see the unix C++ test job for the rationale).
       - name: Test (threaded + OMP_NUM_THREADS=1)


### PR DESCRIPTION
## Why

The Windows **C++ test** job set `-DUSE_CCACHE=OFF`, so it recompiled the whole library cold on every run. That flag was a *precaution* against ccache/clang-cl edge cases (commit 87bb4c61) — **not** part of the `/WHOLEARCHIVE` static-lib fix (they were bundled in one commit, but issue #274 records they're unrelated). It has proven unnecessary: the Windows **wheel** job has run clang-cl through ccache for months without issue.

## What

- Drop `-DUSE_CCACHE=OFF` on the C++ test job (CMake default is `ON`; ccache is in `environment-win.yml`, so it wraps clang-cl automatically).
- Persist its `CCACHE_DIR` with a loose key + restore-keys, mirroring the Unix test jobs and the Windows wheel job. `ccache --zero-stats` / `--show-stats` to measure the hit rate.

A cold cache is just a normal build, so this can only *warm* the Windows C++ test build — never break it. Independent of #287/#319 (ccache is a compiler cache; `/WHOLEARCHIVE` was a linker flag).

**Watch:** `ccache --show-stats` in the Windows C++ test job log on the first warm (post-merge, default-branch) run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
