### PR TITLE
fix(publish): download only wheel artifacts (docs-cpp leaked into v3.2.0 release)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,12 @@ jobs:
       - name: Download all the dists
         uses: actions/download-artifact@v5
         with:
+          # ONLY the wheel artifacts. build_docs.yml's cpp_docs job also uploads a
+          # `docs-cpp` artifact (the whole Doxygen tree); without this pattern,
+          # merge-multiple would pull it into dist/ and it would be published /
+          # attached to the release (it polluted the v3.2.0 GitHub release with 509
+          # Doxygen files before dying mid-upload).
+          pattern: wheels-*
           merge-multiple: true
           path: dist/
       - name: Publish distribution 📦 to TestPyPI
@@ -111,6 +117,12 @@ jobs:
       - name: Download all the dists
         uses: actions/download-artifact@v5
         with:
+          # ONLY the wheel artifacts. build_docs.yml's cpp_docs job also uploads a
+          # `docs-cpp` artifact (the whole Doxygen tree); without this pattern,
+          # merge-multiple would pull it into dist/ and it would be published /
+          # attached to the release (it polluted the v3.2.0 GitHub release with 509
+          # Doxygen files before dying mid-upload).
+          pattern: wheels-*
           merge-multiple: true
           path: dist/
       - name: Publish distribution 📦 to PyPI
@@ -140,6 +152,12 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v5
         with:
+          # ONLY the wheel artifacts. build_docs.yml's cpp_docs job also uploads a
+          # `docs-cpp` artifact (the whole Doxygen tree); without this pattern,
+          # merge-multiple would pull it into dist/ and it would be published /
+          # attached to the release (it polluted the v3.2.0 GitHub release with 509
+          # Doxygen files before dying mid-upload).
+          pattern: wheels-*
           merge-multiple: true
           path: dist/
 


### PR DESCRIPTION
## Why

The v3.2.0 GitHub Release came out with **509 Doxygen files** attached and the job failed mid-upload. Root cause: `publish.yml`'s three `download-artifact` steps (TestPyPI, PyPI, github-release) used `merge-multiple: true` with **no pattern**. Since #316 added the `cpp_docs` job — which uploads the whole Doxygen tree as the `docs-cpp` artifact — those steps started pulling it into `dist/`, and `files: dist/*.*` attached it all. (PyPI escaped only because it downloads *before* `cpp_docs` finishes — a race, not safety.)

## Fix

Pin all three download steps to `pattern: wheels-*` so only the wheel artifacts reach `dist/`.

v3.2.0 is already live on PyPI (15 files) and its docs deployed; the release assets were cleaned up manually. This prevents the recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)