### PR TITLE
fix(python): accept a Complex (constant) node as a coefficient (#326)

### DIFF
--- a/python/bertini/_coefficients.py
+++ b/python/bertini/_coefficients.py
@@ -118,8 +118,26 @@ def _exact_to_mpfr(value):
     """Convert a single exact value to a multiprec.complex_mp (refusing Python floats).
 
     Mirrors :func:`coefficient`'s exact-only rule, but produces a multiprecision *value*
-    (for a coefficient matrix) rather than a function-tree node.
+    (for a coefficient matrix) rather than a function-tree node.  Accepts the same exact
+    spellings as :func:`coefficient`, including a bertini constant *node* -- e.g. a
+    ``symbolics.Complex`` -- so a value good enough for :func:`coefficient` is good enough
+    here too (issue #326).
     """
+    # A function-tree constant node (as coefficient() / Complex() / Integer() / Rational()
+    # produce): accept it, the symmetric partner to the complex_mp case below.  A Complex node
+    # carries a full-precision complex_mp directly; any other constant node is evaluated (it
+    # holds no variables).  This closes the gap where a complex_mp was accepted but the Complex
+    # *node* wrapping the same value was not (issue #326).
+    if isinstance(value, _AbstractNode):
+        if isinstance(value, Complex):
+            return _mp.complex_mp(value.value())
+        try:
+            return _mp.complex_mp(value.eval())
+        except Exception as e:
+            raise TypeError(
+                "cannot use a non-constant node as a coefficient (it still contains "
+                f"variables): {value!r}"
+            ) from e
     if _MP_VALUE_TYPES and isinstance(value, _MP_VALUE_TYPES):
         return _mp.complex_mp(value)
     if isinstance(value, bool):

--- a/python/test/classes/linalg_test.py
+++ b/python/test/classes/linalg_test.py
@@ -121,6 +121,28 @@ def test_add_linear_forms_refuses_floats():
         sys.add_linear_forms([[2.5, 1, 0]])
 
 
+def test_add_linear_forms_accepts_complex_symbol_nodes():
+    # issue #326: a complex_mp value was accepted but the Complex *node* wrapping it was not.
+    # A constant node (Complex, and mixed with int / string / complex_mp) is now a valid coefficient.
+    from bertini.symbolics import Complex
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([x, y]))
+    # 2x + 3y + 1, spelled with a Complex node, an int, and a complex_mp -- at (1,1) -> 6
+    sys.add_linear_forms([[Complex('2'), 3, mp.complex_mp('1')]])
+    v = sys.eval(np.array([mp.complex_mp('1'), mp.complex_mp('1')], dtype=mp.complex_mp))
+    assert abs(complex(v[0]) - 6) < 1e-10
+
+
+def test_add_linear_forms_refuses_nonconstant_node():
+    # a node that still contains a variable is not a constant coefficient
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([x, y]))
+    with pytest.raises(TypeError):
+        sys.add_linear_forms([[x, 1, 0]])
+
+
 # --- add_linear: the auto-target (A @ x + b = 0 as a LinearFormsBlock) ---
 
 def test_add_linear_matches_scalar_expansion():


### PR DESCRIPTION
Fixes #326.

## Problem

Building a linear-forms / products-of-linears block (or a slice) from **`symbolics.Complex` node** coefficients threw:

```
TypeError: cannot use Complex as a coefficient
```

The coefficient-matrix coercion `_exact_to_mpfr` (in `python/bertini/_coefficients.py`, used by `System.add_linear_forms`, `add_products_of_linears`, and `Slice.from_coefficients`) accepted a `multiprec.complex_mp` *value* but had no case for a function-tree `Complex` **node** wrapping that same value — so it fell through to the catch-all `TypeError`. Its sibling `coefficient()` (the node-*producing* path) already accepted nodes, so the two were inconsistent.

## Fix

`_exact_to_mpfr` now accepts any bertini **constant node**, mirroring `coefficient()`:

- a `Complex` node contributes its full-precision value directly (`node.value()`);
- any other constant node is evaluated (`node.eval()`);
- a node that still contains a variable is refused with a clear message.

So a value good enough for `coefficient()` is good enough for the numeric-matrix path too. Mixed rows (node + `int` + `Fraction` + `complex_mp`) work; Python `float`/`complex` are still refused (precision guard unchanged).

## Testing

Two regression tests in `python/test/classes/linalg_test.py`:
- `test_add_linear_forms_accepts_complex_symbol_nodes` — a `Complex` node coefficient (mixed with `int` and `complex_mp`) builds and evaluates correctly;
- `test_add_linear_forms_refuses_nonconstant_node` — a node containing a variable is still refused.

Pure-Python change (no bindings/rebuild). Full `python/test/classes/` suite passes; Python doc-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
