### PR TITLE
feat: solve/settings/symbolic ergonomics (SolveResult return, settings=, precision/mptype, random nodes)

### DIFF
--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -1321,6 +1321,22 @@ run the endgame, classify the endpoints, report.  See the forward-declare doc ab
 			}
 
 			/**
+			\brief The default point-match tolerance for MetadataForPoint / CoincidentMetadataForPoint.
+
+			The solver's OWN same-point tolerance -- ``final_tolerance * same_point_tolerance_multiplier``,
+			the very tolerance ComputeMultiplicities uses to cluster coincident endpoints.  Using it as the
+			match default means a point taken straight from this solver's own solution lists (solutions(),
+			real_solutions(), ...) matches itself back, and matches no OTHER cluster (the solver already
+			deemed distinct clusters at least this far apart).  Returned as \ref NumErrorT, the error/tolerance
+			type (currently an alias for double), matching \ref IsDistinct -- not a bare double.
+			*/
+			NumErrorT DefaultPointMatchTolerance() const
+			{
+				return this->template Get<Tolerances>().final_tolerance *
+				       this->template Get<PostProcessing>().same_point_tolerance_multiplier;
+			}
+
+			/**
 			\brief The metadata of the solution matching \p point -- the cluster REPRESENTATIVE (issue #302).
 
 			Matches \p point against the solutions (user coordinates by default) with the infinity-norm
@@ -1334,7 +1350,7 @@ run the endgame, classify the endpoints, report.  See the forward-declare doc ab
 			\param user_coords Whether \p point is in user coordinates (else the solver's internal coordinates).
 			\see CoincidentMetadataForPoint
 			*/
-			SolutionMetaDataT MetadataForPoint(Vec<BaseComplexT> const& point, double tol, bool user_coords = true) const
+			SolutionMetaDataT MetadataForPoint(Vec<BaseComplexT> const& point, NumErrorT tol, bool user_coords = true) const
 			{
 				auto const& sols = user_coords ? SolutionsUserCoords() : SolutionsInternalCoords();
 				auto const& md   = SolutionMetadata();
@@ -1373,7 +1389,7 @@ run the endgame, classify the endpoints, report.  See the forward-declare doc ab
 			\param user_coords Whether \p point is in user coordinates.
 			\see MetadataForPoint
 			*/
-			std::vector<SolutionMetaDataT> CoincidentMetadataForPoint(Vec<BaseComplexT> const& point, double tol, bool user_coords = true) const
+			std::vector<SolutionMetaDataT> CoincidentMetadataForPoint(Vec<BaseComplexT> const& point, NumErrorT tol, bool user_coords = true) const
 			{
 				auto const& sols = user_coords ? SolutionsUserCoords() : SolutionsInternalCoords();
 				auto const& md   = SolutionMetadata();

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -754,6 +754,16 @@ BOOST_AUTO_TEST_CASE(merge_multiplicities_and_metadata_for_point)
 	// coincident=true: every copy in the cluster (all four coincident endpoints).
 	BOOST_CHECK_EQUAL(zd.CoincidentMetadataForPoint(pt, 1e-5).size(), 4u);
 
+	// DefaultPointMatchTolerance is exactly the solver's same-point tolerance (final_tolerance *
+	// same_point_tolerance_multiplier) -- the default the binding uses when a caller omits tol, so a
+	// solution taken from the solver's own lists matches itself back with no explicit tolerance.
+	auto const expected_tol =
+		zd.Get<algorithm::TolerancesConfig>().final_tolerance *
+		zd.Get<algorithm::PostProcessingConfig>().same_point_tolerance_multiplier;
+	BOOST_CHECK_EQUAL(zd.DefaultPointMatchTolerance(), expected_tol);
+	auto const rep_default = zd.MetadataForPoint(pt, zd.DefaultPointMatchTolerance());
+	BOOST_CHECK_EQUAL(rep_default.multiplicity, 4);
+
 	// a point matching nothing throws.
 	auto far = pt;
 	for (int i = 0; i < far.size(); ++i)

--- a/python/bertini/_system_ops.py
+++ b/python/bertini/_system_ops.py
@@ -40,6 +40,41 @@ from bertini._pybertini.function_tree import AbstractNode as _AbstractNode
 _native = {}
 
 
+def _as_function_node(e, index=None):
+    """Return ``e`` if it is a function-tree node, else raise a targeted ``TypeError``.
+
+    Special-cases a SymPy expression -- the common mistake -- by pointing at
+    :func:`bertini.sympy_bridge.from_sympy`, instead of letting the raw Boost.Python
+    ``add_function`` signature error (which mentions SymPy internals such as ``Add``) surface.
+    Detection is by module name, so SymPy need not be importable.
+    """
+    if isinstance(e, _AbstractNode):
+        return e
+    where = "the expression" if index is None else f"expression {index}"
+    if type(e).__module__.split('.', 1)[0] == 'sympy':
+        raise TypeError(
+            f"{where} is a SymPy {type(e).__name__}, not a bertini function-tree node.  "
+            "bertini does not accept SymPy objects directly (a SymPy float would silently cap the "
+            "precision of the arbitrary-precision function tree).  Convert it first with "
+            "bertini.sympy_bridge.from_sympy(expr) -- passing your bertini Variables -- and add the "
+            "result."
+        )
+    raise TypeError(
+        f"{where} is a {type(e).__name__}, not a function-tree node; "
+        "did a coefficient fail to combine with a variable (or a whole expression get built)?"
+    )
+
+
+def add_function(self, expression):
+    """Add a single expression as a function to the system.
+
+    A thin guard over the native ``add_function`` that turns the common mistakes into a clear
+    message -- most usefully, passing a SymPy expression instead of a bertini node (convert with
+    :func:`bertini.sympy_bridge.from_sympy` first).  Returns whatever the native call returns.
+    """
+    return _native['add_function'](self, _as_function_node(expression))
+
+
 def add_functions(self, expressions):
     """Add a vector/array of expressions as individual functions; returns the count added.
 
@@ -52,13 +87,7 @@ def add_functions(self, expressions):
         expressions = [expressions]
     flat = np.array(expressions, dtype=object).reshape(-1)
     for i in range(flat.size):
-        e = flat[i]
-        if not isinstance(e, _AbstractNode):
-            raise TypeError(
-                f"expression {i} is a {type(e).__name__}, not a function-tree node; "
-                "did a coefficient fail to combine with a variable?"
-            )
-        self.add_function(e)
+        _native['add_function'](self, _as_function_node(flat[i], i))
     return int(flat.size)
 
 
@@ -265,6 +294,8 @@ def install(System):
         return
     _native['randomize'] = System.randomize
     _native['add_variable_group'] = System.add_variable_group
+    _native['add_function'] = System.add_function
+    System.add_function = add_function
     System.add_functions = add_functions
     System.add_variable_group = add_variable_group
     System.clone = clone

--- a/python/bertini/config.py
+++ b/python/bertini/config.py
@@ -412,22 +412,36 @@ def update(self, **fields):
     return self
 
 
-def get_settings(self):
-    """This owner's whole configuration as a carryable dict ``{config_name: config}``.
+def get_settings(self, as_dict=False):
+    """This owner's whole configuration as a carryable dict.
 
-    Each value is a copy of one of the owner's configs (e.g. ``{'stepping': SteppingConfig(...),
-    'tolerances': TolerancesConfig(...)}``), keyed by the same short names config_names() lists.  The
-    configs are independent copies (and picklable), so the dict is a plain Python value you can stash,
-    tweak, and apply to other owners -- the way to carry one set of tracking settings across a series
-    of related solves::
+    By default (``as_dict=False``) the value is ``{config_name: config}`` -- each a copy of one of
+    the owner's configs (e.g. ``{'stepping': SteppingConfig(...), 'tolerances': TolerancesConfig(...)}``),
+    keyed by the short names config_names() lists.  The configs are independent copies (and picklable),
+    so the dict is a plain Python value you can stash, tweak, and apply to other owners -- the way to
+    carry one set of tracking settings across a series of related solves::
 
         settings = first_solver.get_settings()
         next_solver.set_settings(settings)
 
-    See set_settings() for applying one back.
+    Pass ``as_dict=True`` for the flat, human-readable view instead: one ``{field_name: value}`` dict
+    across ALL configs (field names are unique across an owner's configs, so there is no collision).
+    That form drops the struct layer nobody wants to poke at, and round-trips through ``set``::
+
+        flat = solver.get_settings(as_dict=True)   # {'final_tolerance': ..., 'max_step_size': ..., ...}
+        other.set(**flat)
+
+    (The config-keyed default is kept because ``set_settings`` consumes it; use whichever fits.)  See
+    set_settings() for applying the config-keyed form back.
     """
-    return {config_key(cls): self.get_config(cls)
-            for cls in self.config_types() if cls is not None}
+    configs = {config_key(cls): self.get_config(cls)
+               for cls in self.config_types() if cls is not None}
+    if not as_dict:
+        return configs
+    flat = {}
+    for cfg in configs.values():
+        flat.update(cfg.to_dict())
+    return flat
 
 
 def set_settings(self, settings, strict=False):

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -422,6 +422,48 @@ def _solver_result(self):
     return SolveResult.from_solver(self)
 
 
+def _describe_solver_class(cls_name):
+    """A friendly label from a bound solver class name, e.g.
+    'ZeroDimSolverCauchyAdaptivePrecision' -> 'ZeroDimSolver[cauchy, adaptive precision]'."""
+    for kind in ('ZeroDimSolver', 'HomotopySolver'):
+        if cls_name.startswith(kind):
+            rest = cls_name[len(kind):]
+            eg = ('cauchy' if 'Cauchy' in rest else
+                  'power-series' if 'PowerSeries' in rest else '?')
+            prec = ('double' if 'Double' in rest else
+                    'fixed-multiple' if 'FixedMultiple' in rest else
+                    'adaptive' if 'Adaptive' in rest else '?')
+            return '{}[{}, {} precision]'.format(kind, eg, prec)
+    return cls_name
+
+
+def _solver_repr(self):
+    """A readable one-line summary: the solver kind, and once solved its solution tally.
+
+    Replaces the useless default ``<...object at 0x...>``.  Before solving: the kind plus a nudge
+    to call ``.solve()``.  After: finite/real/singular counts out of the paths tracked, and the
+    records run id when the solve recorded.
+    """
+    label = _describe_solver_class(type(self).__name__)
+    try:
+        md = self.solution_metadata()
+    except Exception:
+        return '<{}>'.format(label)
+    if not len(md):
+        return '<{}: not yet solved -- call .solve()>'.format(label)
+    # count DISTINCT finite solutions (multiplicity representatives), matching the default
+    # merge_multiplicities view of finite_solutions(); len(md) is the raw path count.
+    reps = [m for m in md if m.is_finite and m.multiplicity_representative]
+    n_finite = len(reps)
+    n_real = sum(1 for m in reps if m.is_real)
+    n_sing = sum(1 for m in reps if m.is_singular)
+    run = self.records_run_id()
+    tail = ', run {}'.format(run) if run else ''
+    return ('<{}: {} finite solution{} ({} real, {} singular) of {} path{}{}>'
+            .format(label, n_finite, '' if n_finite == 1 else 's',
+                    n_real, n_sing, len(md), '' if len(md) == 1 else 's', tail))
+
+
 def _make_solve_returning_result(native_solve):
     def solve(self, *args, **kwargs):
         native_solve(self, *args, **kwargs)
@@ -445,6 +487,7 @@ def _attach_result_and_solve():
             continue
         cls.result = _solver_result
         cls.solve = _make_solve_returning_result(cls.solve)
+        cls.__repr__ = _solver_repr
         cls._b2_has_result = True
 
 
@@ -598,6 +641,10 @@ class _HomotopySolverHolder:
 
     def __getattr__(self, name):
         return getattr(object.__getattribute__(self, '_solver'), name)
+
+    def __repr__(self):
+        # special methods bypass __getattr__, so delegate the friendly repr explicitly
+        return repr(object.__getattribute__(self, '_solver'))
 
 
 def HomotopySolver(homotopy, start_points, target, *, precision='adaptive', endgame='cauchy'):

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -404,6 +404,53 @@ def _attach_group_kwarg():
 _attach_group_kwarg()
 
 
+# --- solve() returns a SolveResult; result() re-derives it -----------------------------------
+#
+# The solver records ITSELF (record_to / the ambient directory), so it can hand back the same
+# records-aware SolveResult that bertini.solve returns -- no dependence on the records-layer
+# orchestration.  This makes solver.solve() and bertini.solve() return the same type (removing the
+# "the bare solver returns nothing" inconsistency), and result() re-derives it if the caller
+# dropped the return value.
+def _solver_result(self):
+    """This solve's :class:`~bertini.records.SolveResult`: the finite solutions plus the records
+    ticket (run id, directory, recall count), read from the solver's own recorded state.
+
+    A bare ``solver.solve()`` already returns this; ``result()`` re-derives it (call it after
+    ``solve()``) if you did not keep the return value.
+    """
+    from bertini.records import SolveResult
+    return SolveResult.from_solver(self)
+
+
+def _make_solve_returning_result(native_solve):
+    def solve(self, *args, **kwargs):
+        native_solve(self, *args, **kwargs)
+        return self.result()
+    solve.__name__ = 'solve'
+    solve.__doc__ = ((getattr(native_solve, '__doc__', '') or '') +
+        "\n\nReturns a bertini.records.SolveResult -- the finite solutions plus this solve's records "
+        "ticket (run id, directory, recall count), read from the solver's own records (the solver "
+        "records itself, on by default).  Drop it freely: solver.result() re-derives it, and the "
+        "records hold the truth.")
+    return solve
+
+
+def _attach_result_and_solve():
+    """Make every solver's solve() return a SolveResult and give it result() (idempotent)."""
+    for name in dir(_pybnalag):
+        if not name.startswith(('ZeroDimSolver', 'HomotopySolver')):
+            continue
+        cls = getattr(_pybnalag, name)
+        if not isinstance(cls, type) or getattr(cls, '_b2_has_result', False):
+            continue
+        cls.result = _solver_result
+        cls.solve = _make_solve_returning_result(cls.solve)
+        cls._b2_has_result = True
+
+
+_attach_result_and_solve()
+
+
 # --- ZeroDimSolver: a friendly factory over the bound ZeroDimSolver<endgame x precision> classes ---
 
 # Each bound solver class is named ZeroDimSolver<Endgame><Precision> (the start system is NO

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -552,6 +552,30 @@ def _infer_start_system(system):
     return 'mhom'
 
 
+def _precision_model(mptype, precision):
+    """Resolve the precision *model* (mptype) and apply an integer *digit count* (precision).
+
+    ``precision`` is the integer number of digits; it is applied via ``bertini.default_precision``
+    at construction (the documented "set precision, then build" step, which the fixed-multiple and
+    adaptive trackers read at construction).  ``mptype`` is the precision MODEL
+    (``'double'`` / ``'multiple'`` / ``'adaptive'``).
+
+    A **string** ``precision`` is the old, confusing model-selector alias -- honored as ``mptype``
+    with a ``DeprecationWarning`` for one release.  Returns the mptype string to build with.
+    """
+    import warnings
+    if isinstance(precision, str):
+        warnings.warn(
+            "precision={0!r} as a precision-MODEL is deprecated and will be removed: pass "
+            "mptype={0!r} for the model, and reserve precision= for an integer number of digits."
+            .format(precision), DeprecationWarning, stacklevel=3)
+        return precision
+    if precision is not None:
+        import bertini
+        bertini.default_precision(int(precision))     # the "set precision, then build" step
+    return mptype
+
+
 def ZeroDimSolver(system, *, endgame='cauchy', mptype='adaptive', startsystem='infer',
                   precision=None, settings=None, **field_settings):
     """Construct a zero-dim solver by name, with friendly defaults.
@@ -571,8 +595,10 @@ def ZeroDimSolver(system, *, endgame='cauchy', mptype='adaptive', startsystem='i
     ----------
     system : the polynomial :class:`~bertini.System` to solve.
     endgame : ``'cauchy'`` (default) or ``'powerseries'``.
-    mptype : the precision -- ``'double'``, ``'multiple'``, or ``'adaptive'`` (``'amp'``, the default).
-    precision : an alias for ``mptype``; if given (not ``None``) it overrides ``mptype``.
+    mptype : the precision MODEL -- ``'double'``, ``'multiple'``, or ``'adaptive'`` (``'amp'``, the default).
+    precision : the number of DIGITS (an ``int``), applied via ``bertini.default_precision`` at
+        construction -- meaningful for ``'multiple'``/``'adaptive'`` (``'double'`` is always 16).  A
+        *string* here is the deprecated old spelling of ``mptype`` and warns.
     startsystem : ``'infer'`` (default -- choose from the variable-group structure, matching the
         C++ blackbox), or force it with ``'binomial'`` / ``'linearproduct'`` / ``'mhom'``.  To run from a homotopy you
         built yourself with given start points, use :class:`HomotopySolver` / :func:`blend_homotopy`
@@ -598,8 +624,7 @@ def ZeroDimSolver(system, *, endgame='cauchy', mptype='adaptive', startsystem='i
         >>> solver.solve()                             # doctest: +SKIP
         >>> solver.all_solutions()                         # doctest: +SKIP
     """
-    if precision is not None:
-        mptype = precision
+    mptype = _precision_model(mptype, precision)
     start_key = str(startsystem).strip().lower().replace('-', '_').replace('_', '')
     # user-homotopy can't be built from a system alone -- point at the right entry point.
     if start_key in ('user', 'userhomotopy'):
@@ -666,7 +691,7 @@ class _HomotopySolverHolder:
         return repr(object.__getattribute__(self, '_solver'))
 
 
-def HomotopySolver(homotopy, start_points, target, *, precision='adaptive', endgame='cauchy'):
+def HomotopySolver(homotopy, start_points, target, *, mptype='adaptive', precision=None, endgame='cauchy'):
     """Track a homotopy you constructed, from a list of start points you already have (e.g. the
     solutions of an earlier solve) -- the continuation primitive (parameter-homotopy workflow).
 
@@ -685,23 +710,27 @@ def HomotopySolver(homotopy, start_points, target, *, precision='adaptive', endg
     target : System
         The system the solutions satisfy at t=0 -- used for dehomogenize / residual and for the
         solver's consistency check.  It must NOT have a path variable.
-    precision : {'adaptive', 'double', 'multiple'}
-        'adaptive' (default) is the robust path.
+    mptype : {'adaptive', 'double', 'multiple'}
+        The precision MODEL; 'adaptive' (default) is the robust path.
+    precision : int, optional
+        The number of DIGITS, applied via ``bertini.default_precision`` at construction.  A string
+        here is the deprecated old spelling of ``mptype`` and warns.
     endgame : {'cauchy', 'powerseries'}
 
     Returns a solver: call ``.solve()`` then ``.all_solutions()`` as for any solver.
     """
+    mptype = _precision_model(mptype, precision)
     prec = {'double': 'double', 'multiple': 'multiple', 'fixed_multiple': 'multiple',
-            'adaptive': 'adaptive'}.get(precision, precision)
+            'adaptive': 'adaptive'}.get(mptype, mptype)
     eg = {'cauchy': 'cauchy', 'powerseries': 'powerseries',
           'power_series': 'powerseries'}.get(endgame, endgame)
     try:
         cls_name = _HOMOTOPY_SOLVER_CLASSES[(prec, eg)]
     except KeyError:
         raise ValueError(
-            "HomotopySolver: unknown (precision, endgame) = ({!r}, {!r}); "
-            "precision in {{'adaptive','double','multiple'}}, endgame in {{'cauchy','powerseries'}}"
-            .format(precision, endgame))
+            "HomotopySolver: unknown (mptype, endgame) = ({!r}, {!r}); "
+            "mptype in {{'adaptive','double','multiple'}}, endgame in {{'cauchy','powerseries'}}"
+            .format(mptype, endgame))
     solver_cls = getattr(_pybnalag, cls_name)
     # A frequent mix-up (issue #258): passing the start-point *solver* instead of its
     # start *points*.  A solver is not iterable, so list(start_points) below would
@@ -720,9 +749,9 @@ def HomotopySolver(homotopy, start_points, target, *, precision='adaptive', endg
     return _HomotopySolverHolder(solver, homotopy, target, user_start)
 
 
-def user_homotopy(homotopy, start_points, target, *, precision='adaptive', endgame='cauchy'):
+def user_homotopy(homotopy, start_points, target, *, mptype='adaptive', precision=None, endgame='cauchy'):
     """Thin forwarder to :func:`HomotopySolver`, kept for back-compatibility."""
-    return HomotopySolver(homotopy, start_points, target, precision=precision, endgame=endgame)
+    return HomotopySolver(homotopy, start_points, target, mptype=mptype, precision=precision, endgame=endgame)
 
 
 def coefficient_parameter_homotopy(target, generic, path_variable='t'):
@@ -892,7 +921,7 @@ def parameter_sweep(make_system, generic_parameters, target_parameters,
     for i in my_indices:
         target = make_system(targets[i])
         H = coefficient_parameter_homotopy(target, generic)
-        solver = HomotopySolver(H, start_points, target, precision=mptype, endgame=endgame)
+        solver = HomotopySolver(H, start_points, target, mptype=mptype, endgame=endgame)
         solver.solve()
         local.append((i, collect(solver) if collect is not None else solver))
 

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -465,12 +465,20 @@ def _solver_repr(self):
 
 
 def _make_solve_returning_result(native_solve):
-    def solve(self, *args, **kwargs):
-        native_solve(self, *args, **kwargs)
+    def solve(self, communicator=None, **settings):
+        # settings= : any config field by name (e.g. final_tolerance=1e-13), applied via set()
+        # before solving -- collapses the make/set/solve dance to one line.  communicator is
+        # reserved (MPI is a solve-time opt-in), never a setting.
+        if settings:
+            self.set(**settings)
+        native_solve(self, communicator)
         return self.result()
     solve.__name__ = 'solve'
     solve.__doc__ = ((getattr(native_solve, '__doc__', '') or '') +
-        "\n\nReturns a bertini.records.SolveResult -- the finite solutions plus this solve's records "
+        "\n\nSettings: pass any config field by name (e.g. solve(final_tolerance=1e-13)); each is "
+        "applied via set() before solving, so make/set/solve becomes a single call.  communicator= "
+        "is reserved for MPI (never a setting).\n\n"
+        "Returns a bertini.records.SolveResult -- the finite solutions plus this solve's records "
         "ticket (run id, directory, recall count), read from the solver's own records (the solver "
         "records itself, on by default).  Drop it freely: solver.result() re-derives it, and the "
         "records hold the truth.")
@@ -544,7 +552,7 @@ def _infer_start_system(system):
 
 
 def ZeroDimSolver(system, *, endgame='cauchy', mptype='adaptive', startsystem='infer',
-                  precision=None):
+                  precision=None, **settings):
     """Construct a zero-dim solver by name, with friendly defaults.
 
     ``ZeroDimSolver(system)`` is the Cauchy endgame in adaptive precision with the start system
@@ -553,6 +561,10 @@ def ZeroDimSolver(system, *, endgame='cauchy', mptype='adaptive', startsystem='i
     rather than an over-counting total-degree start.  Override any piece with a string::
 
         ZeroDimSolver(system, endgame='cauchy', mptype='amp', startsystem='mhom')
+
+    Any further keyword is treated as a **config setting** applied at construction (via ``set``), so
+    ``ZeroDimSolver(sys, final_tolerance=1e-13)`` needs no separate ``set()`` before solving; the same
+    settings may instead be passed to ``solve(...)``.
 
     Parameters
     ----------
@@ -607,7 +619,12 @@ def ZeroDimSolver(system, *, endgame='cauchy', mptype='adaptive', startsystem='i
     # Every start system is built through its explicit factory.  (Previously total_degree
     # short-circuited to the default constructor, which silently substituted the *default* start
     # system -- the facade quirk that made startsystem='totaldegree' secretly solve the default.)
-    return cls(system, _pybnalag.start_system_factory(start_enum))
+    solver = cls(system, _pybnalag.start_system_factory(start_enum))
+    # settings= : any config field by name (e.g. final_tolerance=1e-13), applied at construction so
+    # a one-line ZeroDimSolver(sys, final_tolerance=1e-13) needs no separate set() before solve().
+    if settings:
+        solver.set(**settings)
+    return solver
 
 
 # --- HomotopySolver: track a homotopy YOU built, from start points YOU have ----------------------

--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -465,19 +465,20 @@ def _solver_repr(self):
 
 
 def _make_solve_returning_result(native_solve):
-    def solve(self, communicator=None, **settings):
-        # settings= : any config field by name (e.g. final_tolerance=1e-13), applied via set()
-        # before solving -- collapses the make/set/solve dance to one line.  communicator is
-        # reserved (MPI is a solve-time opt-in), never a setting.
-        if settings:
-            self.set(**settings)
+    def solve(self, communicator=None, settings=None, **field_settings):
+        # settings= : a dict of config fields; **field_settings: the same by keyword.  Both are
+        # applied via set() before solving -- collapsing make/set/solve to one line.  communicator
+        # and settings are reserved names (MPI is a solve-time opt-in), never config fields.
+        combined = dict(settings or {}, **field_settings)
+        if combined:
+            self.set(**combined)
         native_solve(self, communicator)
         return self.result()
     solve.__name__ = 'solve'
     solve.__doc__ = ((getattr(native_solve, '__doc__', '') or '') +
-        "\n\nSettings: pass any config field by name (e.g. solve(final_tolerance=1e-13)); each is "
-        "applied via set() before solving, so make/set/solve becomes a single call.  communicator= "
-        "is reserved for MPI (never a setting).\n\n"
+        "\n\nSettings: pass config fields either as a dict (settings={'final_tolerance': 1e-13}) or by "
+        "keyword (solve(final_tolerance=1e-13)); each is applied via set() before solving, so "
+        "make/set/solve becomes a single call.  communicator= is reserved for MPI (never a setting).\n\n"
         "Returns a bertini.records.SolveResult -- the finite solutions plus this solve's records "
         "ticket (run id, directory, recall count), read from the solver's own records (the solver "
         "records itself, on by default).  Drop it freely: solver.result() re-derives it, and the "
@@ -552,7 +553,7 @@ def _infer_start_system(system):
 
 
 def ZeroDimSolver(system, *, endgame='cauchy', mptype='adaptive', startsystem='infer',
-                  precision=None, **settings):
+                  precision=None, settings=None, **field_settings):
     """Construct a zero-dim solver by name, with friendly defaults.
 
     ``ZeroDimSolver(system)`` is the Cauchy endgame in adaptive precision with the start system
@@ -562,9 +563,9 @@ def ZeroDimSolver(system, *, endgame='cauchy', mptype='adaptive', startsystem='i
 
         ZeroDimSolver(system, endgame='cauchy', mptype='amp', startsystem='mhom')
 
-    Any further keyword is treated as a **config setting** applied at construction (via ``set``), so
-    ``ZeroDimSolver(sys, final_tolerance=1e-13)`` needs no separate ``set()`` before solving; the same
-    settings may instead be passed to ``solve(...)``.
+    Config settings may be applied at construction (via ``set``) so no separate ``set()`` is needed
+    before solving -- either as a dict (``ZeroDimSolver(sys, settings={'final_tolerance': 1e-13})``)
+    or by keyword (``ZeroDimSolver(sys, final_tolerance=1e-13)``); the same go to ``solve(...)`` too.
 
     Parameters
     ----------
@@ -620,10 +621,11 @@ def ZeroDimSolver(system, *, endgame='cauchy', mptype='adaptive', startsystem='i
     # short-circuited to the default constructor, which silently substituted the *default* start
     # system -- the facade quirk that made startsystem='totaldegree' secretly solve the default.)
     solver = cls(system, _pybnalag.start_system_factory(start_enum))
-    # settings= : any config field by name (e.g. final_tolerance=1e-13), applied at construction so
-    # a one-line ZeroDimSolver(sys, final_tolerance=1e-13) needs no separate set() before solve().
-    if settings:
-        solver.set(**settings)
+    # config fields as a dict (settings={...}) and/or by keyword, applied at construction so a one-line
+    # ZeroDimSolver(sys, final_tolerance=1e-13) needs no separate set() before solve().
+    combined = dict(settings or {}, **field_settings)
+    if combined:
+        solver.set(**combined)
     return solver
 
 

--- a/python/bertini/random/__init__.py
+++ b/python/bertini/random/__init__.py
@@ -4,6 +4,91 @@ from bertini._pybertini import random as _pybrand
 from bertini._pybertini.random import *
 
 
+def random_real(symbolic=False):
+    """A random real number of bounded modulus, at the current default precision.
+
+    Box-uniform in ``[-1, 1]`` and pulled away from 0 -- the Bertini genericity draw.
+    Reproducible via :func:`set_random_seed`.
+
+    Parameters
+    ----------
+    symbolic : bool, default False
+        When False (default) return a numeric ``multiprec.real_mp`` value.  When True return a
+        constant function-tree *node* (a real :class:`~bertini.symbolics.Complex` leaf, imaginary
+        part 0) ready to drop straight into an expression -- the spelling to reach for when you
+        want a random coefficient rather than a random value.  ``bertini.symbolics.random_real``
+        is the always-symbolic shortcut.
+
+    Notes
+    -----
+    The node carries exactly the digits drawn, i.e. the current default precision -- set
+    ``bertini.default_precision(1000)`` first for a 1000-digit constant.  (A random float can be no
+    more precise than its draw; for a *precision-independent* exact random constant use
+    ``bertini.symbolics.Rational.rand_real`` instead.)
+    """
+    v = _pybrand.random_real()
+    if symbolic:
+        from bertini._coefficients import coefficient
+        return coefficient(v)
+    return v
+
+
+def random_complex(symbolic=False):
+    """A random complex number of bounded modulus, at the current default precision.
+
+    Modulus pulled toward 1 (away from 0 and infinity) -- the Bertini genericity draw.
+    Reproducible via :func:`set_random_seed`.
+
+    Parameters
+    ----------
+    symbolic : bool, default False
+        When False (default) return a numeric ``multiprec.complex_mp`` value.  When True return a
+        constant function-tree *node* (a :class:`~bertini.symbolics.Complex` leaf) ready to drop
+        straight into an expression.  ``bertini.symbolics.random_complex`` is the always-symbolic
+        shortcut.
+
+    Notes
+    -----
+    The node carries exactly the digits drawn, i.e. the current default precision -- set
+    ``bertini.default_precision(1000)`` first for a 1000-digit constant.  For a
+    *precision-independent* exact random constant use ``bertini.symbolics.Rational.rand`` instead.
+    """
+    v = _pybrand.random_complex()
+    if symbolic:
+        from bertini._coefficients import coefficient
+        return coefficient(v)
+    return v
+
+
+def random_vector(size, real=False, symbolic=False):
+    """A random length-``size`` vector of bounded-modulus numbers, at the current default precision.
+
+    The natural random projection / linear-functional coefficient vector (generic and
+    seed-reproducible, unlike the quantized orthonormal :func:`random_matrix`).
+
+    Parameters
+    ----------
+    size : int
+        The length of the vector.
+    real : bool, default False
+        When True the entries are real (``real_mp``); otherwise complex (``complex_mp``).
+    symbolic : bool, default False
+        When True return a numpy object array of constant coefficient *nodes* (via
+        :func:`bertini.coefficients`) rather than numeric multiprecision values -- each entry a
+        :class:`~bertini.symbolics.Complex` leaf.
+
+    Notes
+    -----
+    As for :func:`random_real`, a symbolic entry carries the current default precision's worth of
+    digits; set ``bertini.default_precision`` first if you need more.
+    """
+    v = _pybrand.random_vector(size, real)
+    if symbolic:
+        from bertini._coefficients import coefficients
+        return coefficients(v)
+    return v
+
+
 def random_matrix(rows, cols, real=False, units=False, orthonormal=True, symbolic=False):
     """A ``rows`` x ``cols`` random matrix, at the current default precision.
 

--- a/python/bertini/records.py
+++ b/python/bertini/records.py
@@ -203,6 +203,35 @@ class SolveResult:
         """The underlying solver object (all_solutions, solution_metadata, ...)."""
         return self._solver
 
+    @classmethod
+    def from_solver(cls, solver, directory=None):
+        """Build a :class:`SolveResult` from a solver that has already been ``solve()``d.
+
+        Reads the answer (finite solutions, each carrying its records provenance) and the
+        records ticket (run id, directory, recall count) straight off the solver.  The bare
+        solver records *itself* -- it attaches an output directory and writes every path as it
+        completes -- so this needs nothing from :func:`solve`; it is exactly how both a bare
+        ``solver.solve()`` and the :func:`solve` convenience produce the same result type.
+
+        Parameters
+        ----------
+        solver : object
+            A zero-dim / homotopy solver on which ``solve()`` has run.
+        directory : str, optional
+            The records directory to record on the result; defaults to the solver's own
+            attached records path (``records_path()``) when it recorded, else ``None``.
+        """
+        run_id = solver.records_run_id()
+        all_sols = solver.all_solutions()
+        solutions = [Solution(all_sols[int(m.path_index)],
+                              provenance=({'run': run_id, 'index': int(m.path_index)}
+                                          if run_id else None))
+                     for m in solver.solution_metadata() if m.is_finite]
+        if directory is None and run_id:
+            directory = solver.records_path()
+        return cls(solutions, run_id, directory if run_id else None,
+                   int(solver.num_paths_recalled()), solver)
+
 
 # --- chained solves -------------------------------------------------------------------
 
@@ -351,23 +380,13 @@ def solve(system, seed=None, directory=None, precision='adaptive', endgame='cauc
         zd = _nag.ZeroDimSolver(system, mptype=precision, endgame=endgame)
         if _recording_enabled:
             zd.record_to(where)
-    zd.solve()
-
-    run_id = zd.records_run_id()
-    # finite solutions, carrying their TRUE path indices as provenance ({run, index}
-    # is exactly how the records reference points); with recording off there is no
-    # run to reference, so provenance is honestly absent
-    all_sols = zd.all_solutions()
-    solutions = [Solution(all_sols[int(m.path_index)],
-                          provenance=({'run': run_id, 'index': int(m.path_index)}
-                                      if run_id else None))
-                 for m in zd.solution_metadata() if m.is_finite]
-
-    result = SolveResult(solutions, run_id, where if run_id else None,
-                         int(zd.num_paths_recalled()), zd)
-    if run_id:
+    # A bare solve() already returns a SolveResult built from the solver's own records state
+    # (the solver records itself); the free function differs only in the setup + recall
+    # orchestration above and the auto-declare below.  Same result type either way.
+    result = zd.solve()
+    if result.run_id:
         # top-level solves auto-declare their deliverable: "what were my solutions?"
-        save("solutions [run %s]" % run_id, result,
+        save("solutions [run %s]" % result.run_id, result,
              description="finite solutions, auto-declared by bertini.solve",
              directory=where)
     return result

--- a/python/bertini/records.py
+++ b/python/bertini/records.py
@@ -282,7 +282,7 @@ def _coerce_start_point(point, precision):
                       for v in arr.ravel()], dtype=mp_dtype)
 
 
-def _chained_solver(system, homotopy, start, where, *, precision, endgame):
+def _chained_solver(system, homotopy, start, where, *, mptype, endgame):
     """Build the HomotopySolver for a chained solve, plus the per-path provenance refs
     and the start-data identity that joins the ask."""
     import hashlib
@@ -305,14 +305,14 @@ def _chained_solver(system, homotopy, start, where, *, precision, endgame):
         _json.dumps(refs, sort_keys=True).encode()).hexdigest()
 
     solver = _nag.HomotopySolver(homotopy,
-                                 [_coerce_start_point(pt, precision) for pt in points],
-                                 system, precision=precision, endgame=endgame)
+                                 [_coerce_start_point(pt, mptype) for pt in points],
+                                 system, mptype=mptype, endgame=endgame)
     return solver, refs, identity
 
 
 # --- the three verbs ------------------------------------------------------------------
 
-def solve(system, seed=None, directory=None, precision='adaptive', endgame='cauchy',
+def solve(system, seed=None, directory=None, mptype='adaptive', precision=None, endgame='cauchy',
           homotopy=None, start=None):
     """Solve a polynomial system, recording and resuming automatically.
 
@@ -344,9 +344,14 @@ def solve(system, seed=None, directory=None, precision='adaptive', endgame='cauc
         with full provenance -- the records link every new endpoint back through the
         prior run, all the way to the beginning.  Raw points (arrays) are archived as a
         *given*: provenance bottoms out honestly at data you supplied.
-    precision, endgame : str
-        Passed through to :func:`bertini.nag_algorithm.ZeroDimSolver` (``mptype`` /
-        ``endgame``).
+    mptype : str
+        The precision MODEL (``'double'`` / ``'multiple'`` / ``'adaptive'``), passed to
+        :func:`bertini.nag_algorithm.ZeroDimSolver`.
+    precision : int, optional
+        The number of DIGITS, applied via ``bertini.default_precision``.  A *string* here is the
+        deprecated old spelling of ``mptype`` and warns.
+    endgame : str
+        Passed through to :func:`bertini.nag_algorithm.ZeroDimSolver`.
 
     Returns
     -------
@@ -369,15 +374,19 @@ def solve(system, seed=None, directory=None, precision='adaptive', endgame='cauc
         seed = _derive_seed()
     _set_seed(seed)
 
+    # precision= is an integer number of digits (applied via default_precision); mptype= is the
+    # precision model.  A string precision is the deprecated old model alias (warns).
+    mptype = _nag._precision_model(mptype, precision)
+
     where = str(directory if directory is not None else records_dir())
     if homotopy is not None:
         zd, refs, identity = _chained_solver(system, homotopy, start, where,
-                                             precision=precision, endgame=endgame)
+                                             mptype=mptype, endgame=endgame)
         if _recording_enabled:
             zd.record_to(where)
             zd.set_recorded_start_provenance(_json.dumps(refs), identity)
     else:
-        zd = _nag.ZeroDimSolver(system, mptype=precision, endgame=endgame)
+        zd = _nag.ZeroDimSolver(system, mptype=mptype, endgame=endgame)
         if _recording_enabled:
             zd.record_to(where)
     # A bare solve() already returns a SolveResult built from the solver's own records state

--- a/python/bertini/symbolics/__init__.py
+++ b/python/bertini/symbolics/__init__.py
@@ -63,6 +63,30 @@ def sqrt(x):
     return _Sqrt(x)
 
 
+def random_real():
+    """A random real number as a constant node (a real :class:`Complex` leaf, imaginary part 0).
+
+    The always-symbolic shortcut for ``bertini.random_real(symbolic=True)`` -- a random real
+    *coefficient* to drop straight into an expression, at the current default precision (set
+    ``bertini.default_precision`` first for more digits).  For a precision-independent *exact*
+    random constant use :meth:`Rational.rand_real` instead.
+    """
+    from bertini.random import random_real as _rr
+    return _rr(symbolic=True)
+
+
+def random_complex():
+    """A random complex number as a constant node (a :class:`Complex` leaf).
+
+    The always-symbolic shortcut for ``bertini.random_complex(symbolic=True)`` -- a random complex
+    *coefficient* to drop straight into an expression, at the current default precision (set
+    ``bertini.default_precision`` first for more digits).  For a precision-independent *exact*
+    random constant use :meth:`Rational.rand` instead.
+    """
+    from bertini.random import random_complex as _rc
+    return _rc(symbolic=True)
+
+
 VariableGroup.__str__ = lambda vg: '[{}]'.format(','.join([str(v) for v in vg]))
 
 
@@ -140,4 +164,4 @@ __all__ = list(dict.fromkeys(
     + [n for n in dir(_pybft.symbol) if n not in _HIDDEN]
     + [n for n in dir(_pybft.operator) if n not in _HIDDEN]
     + [n for n in dir(_pybft.root) if n not in _HIDDEN]
-    + ['VariableGroup', 'variables', 'sqrt']))
+    + ['VariableGroup', 'variables', 'sqrt', 'random_real', 'random_complex']))

--- a/python/test/classes/sympy_bridge_test.py
+++ b/python/test/classes/sympy_bridge_test.py
@@ -211,3 +211,46 @@ def test_sympy_matrix_and_det_over_node_array():
 def test_sympy_bridge_reachable_at_top_level():
     # bertini.sympy_bridge is exposed lazily (module __getattr__)
     assert pb.sympy_bridge.to_sympy is to_sympy
+
+
+# --- helpful error when a SymPy expr is passed where a node is expected ---
+
+def _system_with_xy():
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([x, y]))
+    return sys, x, y
+
+
+def test_add_function_rejects_sympy_with_pointer_to_from_sympy(sxy):
+    sx, sy = sxy
+    sys, x, y = _system_with_xy()
+    with pytest.raises(TypeError) as ei:
+        sys.add_function(sx**2 + sy)                  # a SymPy Add, not a bertini node
+    msg = str(ei.value)
+    assert 'SymPy' in msg
+    assert 'from_sympy' in msg                        # tells the user the exact fix
+
+
+def test_add_functions_rejects_sympy_with_index_and_pointer(sxy):
+    sx, sy = sxy
+    sys, x, y = _system_with_xy()
+    with pytest.raises(TypeError) as ei:
+        sys.add_functions([x**2 - 1, sx * sy])        # element 1 is SymPy
+    msg = str(ei.value)
+    assert 'expression 1' in msg                      # names which element
+    assert 'from_sympy' in msg
+
+
+def test_add_function_still_accepts_a_bertini_node(sxy):
+    # the guard must not get in the way of the normal path
+    sys, x, y = _system_with_xy()
+    sys.add_function(x * x - 1)
+    assert sys.num_functions() == 1
+
+
+def test_converted_sympy_node_is_accepted(sxy):
+    sx, sy = sxy
+    sys, x, y = _system_with_xy()
+    sys.add_function(from_sympy(sx**2 + sy, variables=[x, y]))   # the recommended path works
+    assert sys.num_functions() == 1

--- a/python/test/random/factories_test.py
+++ b/python/test/random/factories_test.py
@@ -9,7 +9,9 @@ orthonormal ``random_matrix``), and ``vg @ coeffs`` builds the single linear-com
 import numpy as np
 
 import bertini as pb
+from bertini import symbolics as sym
 from bertini.multiprec import real_mp, complex_mp
+from bertini.symbolics import AbstractNode, Complex
 
 
 def test_random_real_is_real_mp():
@@ -54,3 +56,83 @@ def test_variablegroup_matmul_is_the_linear_combination():
     got = complex(pi.eval(x=pt[0], y=pt[1], z=pt[2]))
     want = complex(coeffs[0]) * 2 + complex(coeffs[1]) * (-3) + complex(coeffs[2]) * 5
     assert abs(got - want) < 1e-9, (got, want)
+
+
+# --- symbolic (node) forms: random constants ready to drop into an expression ---
+
+def test_random_real_symbolic_is_a_real_node():
+    n = pb.random_real(symbolic=True)
+    assert isinstance(n, AbstractNode)
+    assert isinstance(n, Complex)                  # a real literal is a zero-imaginary Complex leaf
+    assert n.value().imag == 0                      # ... and its imaginary part really is 0
+
+
+def test_random_complex_symbolic_is_a_complex_node():
+    n = pb.random_complex(symbolic=True)
+    assert isinstance(n, AbstractNode)
+    assert isinstance(n, Complex)
+
+
+def test_symbolic_default_is_still_the_numeric_value():
+    # symbolic defaults False -- the pre-existing value-returning behavior is unchanged
+    assert isinstance(pb.random_real(), real_mp)
+    assert isinstance(pb.random_complex(), complex_mp)
+    assert isinstance(pb.random_real(symbolic=False), real_mp)
+
+
+def test_random_vector_symbolic_is_an_array_of_nodes():
+    v = pb.random_vector(4, symbolic=True)
+    assert len(v) == 4
+    assert all(isinstance(e, AbstractNode) for e in v)
+
+
+def test_symbolics_namespace_shortcuts_return_nodes():
+    # bertini.symbolics.random_real / random_complex are the always-symbolic spellings
+    assert isinstance(sym.random_real(), Complex)
+    assert isinstance(sym.random_complex(), Complex)
+    assert sym.random_real().value().imag == 0
+
+
+def test_symbolic_node_evaluates_to_the_value_it_wraps():
+    # the node is a genuine constant carrying the drawn value: it evaluates back to it
+    pb.random.set_random_seed(99)
+    n = pb.random_real(symbolic=True)
+    drawn = n.value()                               # the stored complex_mp
+    got = n.eval()                                  # a constant node needs no point
+    assert abs(complex(got) - complex(drawn)) < 1e-12
+
+
+def test_symbolic_node_drops_into_an_expression():
+    x = pb.Variable('x')
+    a = pb.random_real(symbolic=True)
+    expr = a * x                                    # a random real coefficient times a variable
+    # eval at x = 4 must equal (coefficient) * 4
+    got = complex(expr.eval(x=complex_mp(4)))
+    want = complex(a.value()) * 4
+    assert abs(got - want) < 1e-12, (got, want)
+
+
+def test_symbolic_precision_follows_default_precision():
+    # a random float node is only as precise as its draw: the current default precision
+    pb.default_precision(200)
+    assert pb.random_real(symbolic=True).value().precision == 200
+    assert pb.random_complex(symbolic=True).value().precision == 200
+    assert sym.random_real().value().precision == 200
+
+
+def test_symbolic_draws_are_seed_reproducible():
+    pb.random.set_random_seed(2024)
+    a = repr(pb.random_real(symbolic=True))
+    pb.random.set_random_seed(2024)
+    b = repr(pb.random_real(symbolic=True))
+    assert a == b                                   # same seed -> same node
+    pb.random.set_random_seed(2025)
+    c = repr(pb.random_real(symbolic=True))
+    assert a != c                                   # a different seed -> a different node
+
+
+def test_exact_rational_random_alternative_is_a_rational_node():
+    # the precision-independent alternative advertised in the docstrings: an exact random rational
+    from bertini.symbolics import Rational
+    assert isinstance(Rational.rand_real(), Rational)
+    assert isinstance(Rational.rand(), Rational)

--- a/python/test/records/records_test.py
+++ b/python/test/records/records_test.py
@@ -48,6 +48,51 @@ def test_solve_records_and_rerun_recalls(tmp_path):
         assert all(abs(complex(u) - complex(v)) < 1e-12 for u, v in zip(a, b))
 
 
+def test_bare_solver_solve_returns_a_solveresult(tmp_path):
+    # the bare solver records ITSELF, so solve() hands back the same records-aware SolveResult
+    # bertini.solve returns -- no dependence on the records-layer convenience.
+    from bertini.records import SolveResult
+    d = str(tmp_path / 'records')
+    solver = pb.ZeroDimSolver(circle_line())
+    solver.record_to(d)
+    result = solver.solve()
+    assert isinstance(result, SolveResult)
+    assert len(result) == 2
+    assert result.run_id                         # it recorded on its own
+    assert result.directory == d
+    assert result.num_recalled == 0
+    assert result.solver is solver
+
+
+def test_solver_result_re_derives_the_solveresult(tmp_path):
+    # result() re-derives the SolveResult if the caller dropped solve()'s return
+    from bertini.records import SolveResult
+    d = str(tmp_path / 'records')
+    solver = pb.ZeroDimSolver(circle_line())
+    solver.record_to(d)
+    solver.solve()                               # return value discarded
+    again = solver.result()
+    assert isinstance(again, SolveResult)
+    assert again.run_id and len(again) == 2
+
+
+def test_bare_solver_result_recalls_like_bertini_solve(tmp_path):
+    # the bare solver's own recall shows up in its SolveResult.num_recalled
+    d = str(tmp_path / 'records')
+    pb.random.set_random_seed(7)
+    first = pb.ZeroDimSolver(circle_line())
+    first.record_to(d)
+    r1 = first.solve()
+    assert r1.num_recalled == 0
+
+    pb.random.set_random_seed(7)
+    second = pb.ZeroDimSolver(circle_line())
+    second.record_to(d)
+    r2 = second.solve()
+    assert r2.run_id == r1.run_id                # same ask -> same run, recalled
+    assert r2.num_recalled == 2
+
+
 def test_solutions_are_points_that_remember(tmp_path):
     r = pb.solve(circle_line(), seed=42, directory=str(tmp_path / 'records'))
     s = r[0]

--- a/python/test/tracking/config_test.py
+++ b/python/test/tracking/config_test.py
@@ -300,6 +300,26 @@ def test_get_settings_is_a_named_dict_of_configs():
     assert isinstance(settings['tolerances'], TolerancesConfig)
 
 
+def test_get_settings_as_dict_is_a_flat_field_dict():
+    a = ZeroDimSolver(_square(), endgame='cauchy', mptype='adaptive', startsystem='binomial')
+    a.update(final_tolerance="1e-12")
+    flat = a.get_settings(as_dict=True)
+    # flat {field: value}, no struct layer (fields from all the solver-owned configs)
+    assert 'final_tolerance' in flat and 'condition_number_threshold' in flat
+    assert all(not hasattr(v, 'to_dict') for v in flat.values())
+    assert float(flat['final_tolerance']) == 1e-12
+    # the config-keyed default is unchanged (still what set_settings consumes)
+    assert set(a.get_settings()) == set(a.config_names())
+
+
+def test_get_settings_as_dict_round_trips_through_set():
+    a = ZeroDimSolver(_square(), mptype='adaptive')
+    a.update(final_tolerance="1e-10")
+    b = ZeroDimSolver(_square(), mptype='adaptive')
+    b.set(**a.get_settings(as_dict=True))       # flat dict applies straight through set()
+    assert b.get_config(TolerancesConfig).final_tolerance == 1e-10
+
+
 def test_settings_round_trip_onto_another_solver():
     from bertini.nag_algorithm import ZeroDimConfig
     a = ZeroDimSolver(_square(), endgame='cauchy', mptype='adaptive', startsystem='binomial')

--- a/python/test/zero_dim/basics_test.py
+++ b/python/test/zero_dim/basics_test.py
@@ -80,6 +80,37 @@ def test_repr_counts_distinct_solutions_for_a_multiple_root():
     assert len(solver.finite_solutions()) == 1       # matches the merged accessor
 
 
+def test_settings_accepted_in_constructor(circle_intersection_solver):
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([x, y]))
+    sys.add_function(x ** 2 + y ** 2 - 1)
+    sys.add_function(x + y)
+    solver = ZeroDimSolver(sys, final_tolerance=1e-13)     # one-line make+set
+    assert float(solver.get_config(TolerancesConfig).final_tolerance) == 1e-13
+    solver.solve()
+    assert len(solver.all_solutions()) == 2                # still solves correctly
+
+
+def test_settings_accepted_in_solve(circle_intersection_solver):
+    solver = circle_intersection_solver
+    result = solver.solve(final_tolerance=1e-12)           # set-then-solve in one call
+    assert float(solver.get_config(TolerancesConfig).final_tolerance) == 1e-12
+    from bertini.records import SolveResult
+    assert isinstance(result, SolveResult)
+
+
+def test_bad_setting_name_is_a_clear_error(circle_intersection_solver):
+    x, y = pb.Variable('x'), pb.Variable('y')
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([x, y]))
+    sys.add_function(x ** 2 + y ** 2 - 1)
+    sys.add_function(x + y)
+    with pytest.raises(Exception) as ei:
+        ZeroDimSolver(sys, not_a_real_setting=5)
+    assert 'not_a_real_setting' in str(ei.value)           # names the offending field
+
+
 def test_custom_tolerances(circle_intersection_solver):
     """Changing tolerances before solving should still yield correct solutions.
 

--- a/python/test/zero_dim/basics_test.py
+++ b/python/test/zero_dim/basics_test.py
@@ -45,6 +45,41 @@ def test_solution_count(circle_intersection_solver):
     assert len(solns) == 2
 
 
+def test_solve_returns_a_result_and_repr_is_informative(circle_intersection_solver):
+    from bertini.records import SolveResult
+    solver = circle_intersection_solver
+
+    # before solving: repr says so, not the useless default object line
+    r = repr(solver)
+    assert 'object at 0x' not in r
+    assert 'not yet solved' in r
+    assert 'ZeroDimSolver' in r and 'cauchy' in r and 'adaptive' in r   # kind is spelled out
+
+    # solve() returns a SolveResult; repr now carries the tally
+    result = solver.solve()
+    assert isinstance(result, SolveResult)
+    r = repr(solver)
+    assert 'object at 0x' not in r
+    assert '2 finite solutions' in r
+    assert 'of 2 paths' in r
+
+
+def test_repr_counts_distinct_solutions_for_a_multiple_root():
+    # {u^2, v^2}: one solution (0,0) of multiplicity 4 -- repr shows 1 finite (singular), 4 paths
+    u, v = pb.Variable('u'), pb.Variable('v')
+    sys = pb.System()
+    sys.add_variable_group(pb.VariableGroup([u, v]))
+    sys.add_function(u * u)
+    sys.add_function(v * v)
+    solver = ZeroDimSolver(sys)
+    solver.solve()
+    r = repr(solver)
+    assert '1 finite solution ' in r                 # distinct, singular pluralization
+    assert '1 singular' in r
+    assert 'of 4 paths' in r
+    assert len(solver.finite_solutions()) == 1       # matches the merged accessor
+
+
 def test_custom_tolerances(circle_intersection_solver):
     """Changing tolerances before solving should still yield correct solutions.
 

--- a/python/test/zero_dim/basics_test.py
+++ b/python/test/zero_dim/basics_test.py
@@ -100,6 +100,26 @@ def test_settings_accepted_in_solve(circle_intersection_solver):
     assert isinstance(result, SolveResult)
 
 
+def test_settings_dict_accepted_in_constructor_and_solve(circle_intersection_solver):
+    x, y = pb.Variable('x'), pb.Variable('y')
+
+    def sq():
+        s = pb.System()
+        s.add_variable_group(pb.VariableGroup([x, y]))
+        s.add_function(x ** 2 + y ** 2 - 1)
+        s.add_function(x + y)
+        return s
+
+    # settings= dict in the constructor
+    solver = ZeroDimSolver(sq(), settings={'final_tolerance': 1e-13})
+    assert float(solver.get_config(TolerancesConfig).final_tolerance) == 1e-13
+
+    # settings= dict in solve(), merged with keyword form
+    s2 = ZeroDimSolver(sq())
+    s2.solve(settings={'final_tolerance': 1e-12}, newton_before_endgame=1e-4)
+    assert float(s2.get_config(TolerancesConfig).final_tolerance) == 1e-12
+
+
 def test_bad_setting_name_is_a_clear_error(circle_intersection_solver):
     x, y = pb.Variable('x'), pb.Variable('y')
     sys = pb.System()

--- a/python/test/zero_dim/crossed_paths_test.py
+++ b/python/test/zero_dim/crossed_paths_test.py
@@ -78,7 +78,7 @@ def cubic_crossing_homotopy():
 def _solve(resolve_attempts, predictor=pb.Predictor.Euler, step=COARSE_STEP, tol=LOOSE_TOL):
     """Track the planted cubic and return (report, sorted distinct real roots)."""
     H, target, start_points = cubic_crossing_homotopy()
-    solver = pb.nag_algorithm.user_homotopy(H, start_points, target, precision='double')
+    solver = pb.nag_algorithm.user_homotopy(H, start_points, target, mptype='double')
 
     solver.get_tracker().predictor(predictor)
     solver.get_tracker().get_stepping().update(initial_step_size=step, max_step_size=step)

--- a/python/test/zero_dim/parameter_homotopy_test.py
+++ b/python/test/zero_dim/parameter_homotopy_test.py
@@ -45,13 +45,13 @@ def test_solve_once_then_sweep_a_parameter():
         assert _roots_real(solver.all_solutions()) == expected
 
 
-def test_user_homotopy_rejects_bad_precision():
+def test_user_homotopy_rejects_bad_mptype():
     x, t = pb.Variable('x'), pb.Variable('t')
     H = pb.System(); H.add_variable_group(pb.VariableGroup([x])); H.add_function(x * x - (4 - 3 * t)); H.add_path_variable(t)
     target = pb.System(); target.add_variable_group(pb.VariableGroup([x])); target.add_function(x * x - 1)
     import pytest
     with pytest.raises(ValueError):
-        pb.nag_algorithm.user_homotopy(H, [], target, precision='quadruple')
+        pb.nag_algorithm.user_homotopy(H, [], target, mptype='quadruple')
 
 
 def test_user_homotopy_rejects_solver_as_start_points():

--- a/python/test/zero_dim/solutions_ui_test.py
+++ b/python/test/zero_dim/solutions_ui_test.py
@@ -77,6 +77,48 @@ def test_metadata_for_missing_point_raises(double_root):
         solver.metadata_for(far, tol=1e-5)
 
 
+def test_metadata_for_defaults_tol_to_solver_same_point_tolerance(four_simple_roots):
+    # omitting tol uses the solver's own same-point tolerance, so metadata_for(pt) Just Works
+    # on a point taken straight from the solver's solution lists (the motivating loop).
+    _, solver = four_simple_roots
+    got = 0
+    for r in solver.real_solutions():
+        md = solver.metadata_for(r)                                    # no tol -> default
+        assert md.multiplicity == 1
+        got += 1
+    assert got == 4
+
+
+def test_default_point_match_tolerance_is_exposed_and_positive(four_simple_roots):
+    _, solver = four_simple_roots
+    tol = solver.default_point_match_tolerance()
+    assert isinstance(tol, float)                                      # NumErrorT -> Python float
+    assert tol > 0
+    # omitting tol matches passing exactly this value
+    r = solver.real_solutions()[0]
+    a = solver.metadata_for(r)
+    b = solver.metadata_for(r, tol=tol)
+    assert a.multiplicity == b.multiplicity
+
+
+def test_metadata_for_nonpositive_tol_is_treated_as_default(four_simple_roots):
+    # the sentinel contract: tol <= 0 means "use the solver default", not "match nothing"
+    _, solver = four_simple_roots
+    r = solver.real_solutions()[0]
+    md = solver.metadata_for(r, tol=0.0)
+    assert md.multiplicity == 1
+    md = solver.metadata_for(r, tol=-1.0)
+    assert md.multiplicity == 1
+
+
+def test_metadata_for_default_tol_coincident_list(double_root):
+    # default tol works for the coincident (list) form too -- (0,0) has multiplicity 4
+    _, solver = double_root
+    all_md = solver.metadata_for(solver.finite_solutions()[0], coincident=True)
+    assert isinstance(all_md, list)
+    assert len(all_md) == 4
+
+
 # --- #304: is_distinct_up_to on solution points ----------------------------------------------
 
 def test_is_distinct_up_to_tells_solutions_apart(four_simple_roots):

--- a/python/test/zero_dim/zero_dim_factory_test.py
+++ b/python/test/zero_dim/zero_dim_factory_test.py
@@ -72,12 +72,23 @@ def test_factory_returns_a_real_solver():
     assert len(solver.all_solutions()) == 2
 
 
-def test_precision_is_an_alias_for_mptype():
-    assert isinstance(ZeroDimSolver(_system(), precision='amp'),
-                      _n.ZeroDimSolverCauchyAdaptivePrecision)
-    # precision overrides mptype when both are given
-    assert isinstance(ZeroDimSolver(_system(), mptype='double', precision='adaptive'),
-                      _n.ZeroDimSolverCauchyAdaptivePrecision)
+def test_precision_is_an_integer_number_of_digits():
+    import bertini as b
+    # precision= is now a DIGIT COUNT, applied via default_precision -- not the model selector
+    b.default_precision(16)
+    solver = ZeroDimSolver(_system(), mptype='multiple', precision=80)
+    assert b.default_precision() == 80                     # the digit count took effect
+    assert isinstance(solver, _n.ZeroDimSolverCauchyFixedMultiplePrecision)   # mptype picked the class
+
+
+def test_precision_as_a_string_is_the_deprecated_model_alias():
+    import warnings
+    # a STRING precision is the old model-selector alias: honored, but warns
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        solver = ZeroDimSolver(_system(), precision='amp')
+    assert isinstance(solver, _n.ZeroDimSolverCauchyAdaptivePrecision)
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
 
 
 def test_user_startsystem_points_at_homotopy_solver():

--- a/python_bindings/include/zero_dim_export.hpp
+++ b/python_bindings/include/zero_dim_export.hpp
@@ -379,10 +379,14 @@ void ZDVisitor<AlgoT>::visit(PyClass& cl) const
 	.def("solution_metadata", &AlgoT::SolutionMetadata, return_internal_reference<>(), "get the metadata for the solutions at the target time")
 	.def("metadata_for",
 		// point taken BY VALUE (a copy from numpy) -- no writable Eigen::Ref, so the ADR-0001
-		// adjacent-scalar hazard does not apply.
+		// adjacent-scalar hazard does not apply.  tol defaults to a sentinel (<= 0): when the caller
+		// omits it, use the solver's own same-point tolerance so metadata_for(pt) Just Works on a point
+		// taken from the solver's own solution lists (the common case, issue's motivation).
 		+[](AlgoT const& self,
 		    Vec<typename AlgoT::BaseComplexT> point,
-		    double tol, bool coincident, bool user_coords) -> boost::python::object {
+		    NumErrorT tol, bool coincident, bool user_coords) -> boost::python::object {
+			if (tol <= 0.0)
+				tol = self.DefaultPointMatchTolerance();
 			if (coincident) {
 				boost::python::list out;
 				for (auto const& m : self.CoincidentMetadataForPoint(point, tol, user_coords)) out.append(m);
@@ -390,15 +394,23 @@ void ZDVisitor<AlgoT>::visit(PyClass& cl) const
 			}
 			return boost::python::object(self.MetadataForPoint(point, tol, user_coords));
 		},
-		(boost::python::arg("self"), boost::python::arg("point"), boost::python::arg("tol"),
+		(boost::python::arg("self"), boost::python::arg("point"), boost::python::arg("tol") = -1.0,
 		 boost::python::arg("coincident") = false, boost::python::arg("user_coords") = true),
 		"the SolutionMetaData for the solution matching `point` (issue #302).  Matches by the infinity-norm "
-		"tolerance `tol` (see is_distinct_up_to).  The return type NEVER depends on the point's multiplicity: "
-		"by default returns exactly ONE record -- the multiplicity-cluster representative (it carries "
-		".multiplicity, so you still learn m).  coincident=True instead ALWAYS returns a LIST of every "
+		"tolerance `tol` (see is_distinct_up_to).  tol is OPTIONAL: omit it (or pass a non-positive value) "
+		"to use the solver's own same-point tolerance (final_tolerance * same_point_tolerance_multiplier, via "
+		"default_point_match_tolerance()), so `solver.metadata_for(pt)` Just Works for a `pt` taken straight "
+		"from solutions() / real_solutions() / etc.  The return type NEVER depends on the point's "
+		"multiplicity: by default returns exactly ONE record -- the multiplicity-cluster representative (it "
+		"carries .multiplicity, so you still learn m).  coincident=True instead ALWAYS returns a LIST of every "
 		"coincident copy's record (their per-path condition number / residual / precision), length 1 for a "
 		"simple root.  Raises if no solution matches, or if the point matches more than one distinct cluster "
-		"(reduce tol).  `point` is in user coordinates unless user_coords=False.")
+		"(reduce tol).  `point` is in user coordinates unless user_coords=False.  Accepts any numpy array of "
+		"the solver's complex type -- which is exactly what the solution lists return.")
+	.def("default_point_match_tolerance", &AlgoT::DefaultPointMatchTolerance,
+		"the default infinity-norm tolerance metadata_for() uses when you omit `tol`: the solver's own "
+		"same-point tolerance (final_tolerance * same_point_tolerance_multiplier), the same one that clusters "
+		"coincident endpoints into multiplicities.")
 	.def("endgame_boundary_solutions", &AlgoT::EndgameBoundarySolutions, return_internal_reference<>(), "get the solutions (per-path point data) at the endgame boundary, where regular tracking switches to the endgame")
 	.def("endgame_boundary_metadata", &AlgoT::EndgameBoundaryMetadata, return_internal_reference<>(), "get the MidpathCheckReport from the path-crossing check at the endgame boundary: how many crossings were detected, which paths, how many re-track attempts were made, and whether the check ultimately passed")
 	.def("report", &AlgoT::Report, "a concise end-of-solve diagnostic summary (a SolveReport): how every path ended up -- finite solutions, diverged, or FAILED (by named reason) -- plus singular/real counts, max condition number, the path-crossing outcome, and all_paths_resolved.  print(solver.report()) for a human-readable summary; a count alone can hide a path the tracker silently lost.")


### PR DESCRIPTION
A batch of solve / settings / symbolic ergonomics.  Orthogonal to #329 (disjoint files; mergeable either order).

## Solving & results
- **`solver.solve()` returns a `SolveResult`** (was `None`), and `solver.result()` re-derives it. The bare `ZeroDimSolver`/`HomotopySolver` already record themselves, so they hand back the same records-aware `SolveResult` `bertini.solve` returns — removing the "the solver returns nothing" inconsistency. (`SolveResult.from_solver`, factored out of `bertini.solve`.)
- **`metadata_for(pt)` defaults `tol`** to the solver's own same-point tolerance (new `DefaultPointMatchTolerance()`, returns `NumErrorT`), so `for r in solver.real_solutions(): solver.metadata_for(r)` just works instead of raising a misleading Boost.Python signature error.
- **informative `repr(solver)`** instead of `<...object at 0x...>`: kind + solve tally (distinct finite / real / singular of N paths, run id when recorded).

## Settings
- **`solve(**settings)` / `ZeroDimSolver(..., **settings)`** — apply config fields at solve/construction, as keywords or a `settings={...}` dict, so make/set/solve collapses to one line. `communicator=` stays reserved.
- **`get_settings(as_dict=True)`** — flat `{field: value}` view across all configs (round-trips through `set(**flat)`); the config-keyed default is unchanged so the `set_settings` carry still works.

## `precision` / `mptype` (breaking, with a deprecation shim)
- **`precision=` is now an integer number of DIGITS** (applied via `default_precision` at construction, matching the tracker's own `precision` field); **`mptype=` is the precision MODEL** (`'double'`/`'multiple'`/`'adaptive'`) everywhere, including `solve` / `HomotopySolver` / `user_homotopy`. A **string** `precision=` is honored as the old model alias with a `DeprecationWarning` for one release. Tutorials already used `mptype=`, so churn is confined to the entry points + tests.

## Symbolic conveniences
- **`random_real(symbolic=True)` / `random_complex(symbolic=True)` / `random_vector(..., symbolic=True)`** and `symbolics.random_real()` / `random_complex()` — random constant *nodes* (a real one is a zero-imaginary `Complex` leaf), at the current default precision.
- **clear error when a SymPy expr hits `add_function(s)`** — points to `bertini.sympy_bridge.from_sympy` instead of a raw `Add` signature error (does not auto-accept: a SymPy float would cap precision).

Full Python suite (877 passed, 5 skipped) + C++ `test_nag_algorithms` + doc-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
