### PR TITLE
chore(cli): remove the stale primary-authors block from the splash

### DIFF
--- a/core/include/bertini2/io/splash.hpp
+++ b/core/include/bertini2/io/splash.hpp
@@ -127,16 +127,7 @@ std::string Owners()
 	return ss.str();
 }
 
-/// \brief Get the names of the Bertini2 code authors.
-inline
-std::string Authors()
-{
-	std::stringstream ss;
-	ss << "S. Amethyst, J. Collins, T. Hodges";
-	return ss.str();
-}
-
-/// \brief Get the multi-line splash screen text (trademark, authors, URLs, version, license).
+/// \brief Get the multi-line splash screen text (trademark, URLs, version, license).
 inline
 std::string SplashScreen()
 {
@@ -144,7 +135,6 @@ std::string SplashScreen()
 
 	ss << "    Bertini(TM) 2\n\n";
 	ss << "  The Bertini Trademark is owned by\n" << Owners() << "\n\n";
-	ss << "  The code is primarily authored by\n" << Authors() << "\n\n";
 	ss << "  Source available online at\n" << SourceURL() << "\n\n";
 	ss << "  Wiki online at\n" << WikiURL() << "\n\n";
 	ss << "  This is version\n" << Version() << "\n";


### PR DESCRIPTION
The CLI splash listed a stale "primary authors" block:

    The code is primarily authored by
    S. Amethyst, J. Collins, T. Hodges

It's out of date and awkward to keep current, so drop it entirely (and the now-unused `Authors()` helper).  The Bertini **trademark-owners** block stays -- it's a trademark statement, not a coder credit.

The splash now reads: name → trademark owners → source/wiki URLs → version → license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
