### PR TITLE
fix(docs): malformed inline literal broke the docs deploy

### DIFF
--- a/python/bertini/records.py
+++ b/python/bertini/records.py
@@ -275,7 +275,7 @@ class SolveResult:
 
     @classmethod
     def from_solver(cls, solver, directory=None):
-        """Build a :class:`SolveResult` from a solver that has already been ``solve()``d.
+        """Build a :class:`SolveResult` from a solver on which ``solve()`` has already run.
 
         Snapshots the typed answer (a :class:`ZeroDimResult`, its finite solutions carrying records
         provenance) and reads the records ticket (run id, directory, recall count) straight off the


### PR DESCRIPTION
The 3.3.0 docs *deploy* failed on a reStructuredText warning (the release itself — PyPI + GitHub Release — succeeded).

`SolveResult.from_solver`'s docstring had `` ``solve()``d `` — an inline literal immediately followed by a letter, which docutils rejects (*"Inline literal start-string without end-string"*). The publish docs build runs `sphinx -b html -W` (warnings-as-errors), so it failed there. Reword to "a solver on which ``solve()`` has already run."

Verified: docutils no longer emits the inline-literal warning for that docstring.

**Follow-up (separate PR):** no PR workflow runs *any* Sphinx build — the doctest and `-b html -W` builds both live in `build_docs.yml`, which triggers only on `workflow_call` (deploy) and `workflow_dispatch`. That's why this slipped to deploy. I'll wire a build-only docs run into PR CI so reST warnings fail the PR, not the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
