### PR TITLE
ci: build docs (doctest + sphinx -W) on every PR — close the deploy-only gap

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -740,3 +740,52 @@ jobs:
           & $py -m pip install --no-index --find-links dist/ bertini2
           & $py -m pip install pytest pytest-timeout numpy sympy pandas networkx matplotlib
           & $py -m pytest python/test/ -v
+
+  # Build the documentation on every PR/push -- the SAME sphinx doctest + `-b html -W`
+  # (warnings-as-errors) build publish.yml runs at deploy time.  This closes the gap where a
+  # reStructuredText mistake in a docstring or tutorial (e.g. a malformed inline literal) only
+  # surfaced at the release deploy, never on the PR.  It reuses the ubuntu wheel this workflow
+  # already built (no extra compile), and needs no Doxygen (the Sphinx site is self-contained; the
+  # C++ reference is assembled separately only at deploy).  Skipped for the minimal reusable call
+  # (build_docs.yml builds the docs itself at deploy time).
+  docs_gate:
+    name: Docs build (doctest + html -W)
+    if: ${{ inputs.minimal != true }}
+    needs: [build_macos_ubuntu_wheels]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0   # gitpython in conf.py derives the version from the git history
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python deps for Sphinx
+        run: |
+          python -m pip install --upgrade pip
+          pip install sphinx furo sphinxcontrib-bibtex gitpython \
+            scikit-build-core build numpy matplotlib pandas sympy networkx
+
+      - name: Download built wheel
+        uses: actions/download-artifact@v5
+        with:
+          name: wheels-ubuntu-latest-3.11
+          path: dist/
+
+      - name: Install bertini from built wheel
+        run: pip install --no-index --find-links dist/ bertini2
+
+      - name: Tutorial doctests (Sphinx)
+        # Execute the docs' `.. testcode::` / `>>>` blocks against the wheel -- verified code, not
+        # just prose.  (These likewise did not run on PRs before.)
+        working-directory: python/docs
+        run: sphinx-build -b doctest --keep-going source ../../build/docs/doctest
+
+      - name: Build Python docs (Sphinx, warnings as errors)
+        # -W turns reST warnings into errors -- the same gate the deploy uses -- so a docstring or
+        # tutorial reST mistake fails the PR here, not the release.
+        working-directory: python/docs
+        run: sphinx-build -b html -W --keep-going -d ../../build/docs/py-doctrees source ../../build/docs/html

--- a/tools/build_docs_check.sh
+++ b/tools/build_docs_check.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Local docs gate -- the SAME sphinx doctest + `-b html -W` (warnings-as-errors) build that CI
+# (build_and_test's docs_gate job) and the release deploy (publish.yml) run.  Run it before pushing
+# docstring / tutorial changes, so a reStructuredText mistake (e.g. a malformed inline literal) fails
+# here rather than at the release deploy.
+#
+# Requires bertini importable in the current interpreter (`pip install -e .`, or a built wheel) --
+# sphinx autodoc imports the package to render its docstrings.  The sphinx deps are installed below.
+#
+# Usage:  tools/build_docs_check.sh          # uses `python` on PATH
+#         PYTHON=/path/to/python tools/build_docs_check.sh
+set -euo pipefail
+
+PY="${PYTHON:-python}"
+cd "$(dirname "$0")/../python/docs"
+
+echo "== installing sphinx deps =="
+"$PY" -m pip install -q sphinx furo sphinxcontrib-bibtex gitpython matplotlib pandas sympy networkx
+
+echo "== tutorial doctests (sphinx -b doctest) =="
+"$PY" -m sphinx -b doctest --keep-going source ../../build/docs/doctest
+
+echo "== html build, warnings as errors (sphinx -b html -W) =="
+"$PY" -m sphinx -b html -W --keep-going -d ../../build/docs/py-doctrees source ../../build/docs/html
+
+echo "OK: docs build clean -- doctests pass and no reST warnings."


### PR DESCRIPTION
**Why the 3.3.0 docs deploy broke and no PR caught it:** the doctest build *and* the `-b html -W` (warnings-as-errors) build both live in `build_docs.yml`, which triggers only on `workflow_call` (the deploy, via publish.yml) and `workflow_dispatch`. No PR workflow runs *any* Sphinx build — so docstrings/tutorials were first *built* at release time. A malformed inline literal (`` ``solve()``d ``) sailed through PR CI and failed the deploy.

**Fix:** a `docs_gate` job in `build_and_test` that runs the **same** `sphinx -b doctest` + `sphinx -b html -W` build on every PR/push. It:
- reuses the `wheels-ubuntu-latest-3.11` artifact this workflow already builds — **no extra compile**;
- needs **no Doxygen** — the Sphinx site is self-contained (the C++ reference is assembled separately, only at deploy). Verified locally: `sphinx -b html -W` builds clean on current `develop`.
- is **skipped** for the minimal reusable call, so the deploy path (which builds docs itself) isn't duplicated.

Bonus: the tutorial **doctests** now actually run on PRs too (they didn't before).

`tools/build_docs_check.sh` runs the identical gate locally — the pre-push check.

This PR **self-tests**: the new `docs_gate` job runs on it.

Note: to make it *block* merges, it needs adding to the branch ruleset's required checks (a repo-settings change — your call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
