### PR TITLE
fix(zero_dim): singularity classification uses the endpoint's spectral-norm condition number (B1 CondNumThreshold spec)

### DIFF
--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -55,6 +55,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdlib>
+#include <limits>
 #include <mutex>
 #include <iostream>
 #include <map>
@@ -192,7 +193,7 @@ struct SolutionMetaData
 
 
 	///// things computed in endgame only
-	NumErrorT condition_number; 				///< The latest estimate of the condition number.
+	NumErrorT condition_number; 				///< Spectral-norm condition number of the target system's Jacobian at the endpoint (the quantity `condition_number_threshold` is specified against).
 	NumErrorT newton_residual; 				///< The latest Newton residual.
 	ComplexT final_time_used;   			///< The final value of time tracked to.
 	NumErrorT accuracy_estimate; 			///< Accuracy estimate between extrapolations.
@@ -1981,7 +1982,7 @@ run the endgame, classify the endpoints, report.  See the forward-declare doc ab
 				}
 				smd.function_residual = static_cast<NumErrorT>(ctx.target_sys.Eval(solutions_post_endgame_[soln_ind]).template lpNorm<Eigen::Infinity>());
 				smd.final_time_used = ctx.endgame.LatestTime();
-				smd.condition_number = ctx.tracker.LatestConditionNumber();
+				smd.condition_number = EndpointSpectralConditionNumber(ctx.target_sys, solutions_post_endgame_[soln_ind]);
 				smd.newton_residual = ctx.tracker.LatestNormOfStep();
 
 				smd.accuracy_estimate = ctx.endgame.ApproximateError();
@@ -2130,8 +2131,10 @@ run the endgame, classify the endpoints, report.  See the forward-declare doc ab
 			\brief Classify each successful endpoint as singular or not.
 
 			Matching Bertini 1: an endpoint is singular if it is the endpoint of multiple paths
-			(multiplicity > 1), or if the approximation of its condition number (spectral norm, as
-			estimated by the tracker) exceeds `condition_number_threshold`.
+			(multiplicity > 1), or if the approximation of its condition number, in the spectral
+			norm, exceeds `condition_number_threshold`.  The condition number compared here is the
+			one computed at the endpoint by `EndpointSpectralConditionNumber` -- see that function
+			for why the tracker's running estimate must not be substituted.
 			*/
 			void ClassifySingular()
 			{
@@ -2143,6 +2146,42 @@ run the endgame, classify the endpoints, report.  See the forward-declare doc ab
 						continue;
 					smd.is_singular = (smd.multiplicity > 1) || (smd.condition_number > cond_threshold);
 				}
+			}
+
+			/**
+			\brief The spectral-norm condition number of the system's Jacobian at an endpoint.
+
+			This is the quantity Bertini 1's `CondNumThreshold` is specified against ("an
+			approximation of the condition number, in the spectral norm"): \f$\sigma_{max} /
+			\sigma_{min}\f$ of the homogenized, patched target system's Jacobian, evaluated AT the
+			endpoint, at the endpoint's own precision.
+
+			The tracker's running estimate (`LatestConditionNumber()`: `norm_J * norm_J_inverse`
+			from a random-RHS LU probe, refreshed only every `frequency_of_CN_estimation` steps,
+			on the homotopy mid-path) is NOT a substitute and must not be used for classification:
+			endpoints lying exactly on a positive-dimensional component -- whose Jacobian is
+			provably rank-deficient, spectral condition number effectively infinite -- have been
+			observed carrying tracker estimates as low as ~1e3, silently classifying as
+			nonsingular.  The tracker estimate remains available per-step via observers.
+
+			A singular-to-working-precision Jacobian (smallest singular value 0, or an empty
+			singular value list) yields +infinity, which compares correctly against any threshold.
+
+			\param sys The (homogenized, patched) system whose Jacobian to measure; its precision
+			           must already match the endpoint's.
+			\param endpoint The solution point, in the system's own (homogenized) coordinates.
+			\return The spectral condition number, as `NumErrorT`.
+			*/
+			static NumErrorT EndpointSpectralConditionNumber(SystemType const& sys, Vec<BaseComplexT> const& endpoint)
+			{
+				const auto J = sys.Jacobian(endpoint);
+				const auto singular_values = Eigen::JacobiSVD<Mat<BaseComplexT>>(J).singularValues();
+				if (singular_values.size() == 0)
+					return std::numeric_limits<NumErrorT>::infinity();
+				const auto& smallest = singular_values(singular_values.size()-1);
+				if (smallest <= 0)
+					return std::numeric_limits<NumErrorT>::infinity();
+				return static_cast<NumErrorT>(singular_values(0) / smallest);
 			}
 
 

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -1179,6 +1179,65 @@ BOOST_AUTO_TEST_CASE(condition_number_threshold_is_applied)
 }
 
 
+// REGRESSION: endpoints landing ON a positive-dimensional component must classify singular.
+// Their Jacobian is provably rank-deficient (spectral condition number effectively infinite),
+// but the tracker's RUNNING condition estimate -- which used to be what ClassifySingular
+// compared against the threshold -- can report such endpoints as well-conditioned (~1e3),
+// silently classifying them nonsingular.  The metadata condition number is now the
+// spectral-norm value of the target Jacobian AT the endpoint.
+//
+// V(s*y, s*z, x+2y+3z-5) with s = x^2+y^2+z^2-1: V(F) = the line {y=z=0} union the sphere
+// {s=0}; cut by the plane, the square system has ONE isolated nonsingular solution (5,0,0)
+// plus a whole conic (sphere ∩ plane) of non-isolated solutions that paths land on.
+BOOST_AUTO_TEST_CASE(endpoint_on_positive_dimensional_component_is_singular)
+{
+	using namespace bertini;
+	System sys;
+	auto x = Variable::Make("x"), y = Variable::Make("y"), z = Variable::Make("z");
+	sys.AddVariableGroup(VariableGroup{x, y, z});
+	auto s = x*x + y*y + z*z - 1;
+	sys.AddFunction(s*y);
+	sys.AddFunction(s*z);
+	sys.AddFunction(x + 2*y + 3*z - 5);          // misses the sphere ∩ line points
+
+	auto zd = algorithm::ZeroDimSolver<TrackerT, endgame::EndgameSelector<TrackerT>::Cauchy, decltype(sys)>(sys);
+	zd.DefaultSetup();
+	zd.Solve();
+
+	auto const& md  = zd.SolutionMetadata();
+	auto const& pts = zd.SolutionsUserCoords();
+
+	unsigned on_sphere = 0, isolated = 0;
+	for (size_t ii = 0; ii < md.size(); ++ii)
+	{
+		if (md[ii].endgame_success_code != SuccessCode::Success || !md[ii].is_finite)
+			continue;
+		const auto& p = pts[ii];
+		const double sphere_residual =
+			abs(p(0)*p(0) + p(1)*p(1) + p(2)*p(2) - 1.0);
+
+		if (sphere_residual < 1e-5)
+		{
+			// on the sphere: a non-isolated endpoint.  It must be singular, and singular BY
+			// CONDITION NUMBER (not merely by path multiplicity) -- the spectral condition
+			// number of a rank-deficient Jacobian exceeds any sane threshold.
+			++on_sphere;
+			BOOST_CHECK(md[ii].is_singular);
+			BOOST_CHECK_GT(md[ii].condition_number, 1e8);
+		}
+		else if (abs(p(0) - 5.0) < 1e-6 && abs(p(1)) < 1e-6 && abs(p(2)) < 1e-6)
+		{
+			// the line ∩ plane point: genuinely isolated and well-conditioned.
+			++isolated;
+			BOOST_CHECK(!md[ii].is_singular);
+			BOOST_CHECK_LT(md[ii].condition_number, 1e8);
+		}
+	}
+	BOOST_CHECK_GE(on_sphere, 1u);               // the junk paths must actually be exercised
+	BOOST_CHECK_EQUAL(isolated, 1u);
+}
+
+
 // the PostProcessing config round-trips through Get/Set.
 BOOST_AUTO_TEST_CASE(postprocessing_config_roundtrip)
 {


### PR DESCRIPTION
## What

`ClassifySingular()` implements the Bertini 1 `CondNumThreshold` spec:

> An endpoint is considered a singular point if it is either the endpoint of multiple paths or if an approximation of the condition number, **in the spectral norm**, is larger than this value.

Both clauses were present, but the condition number fed into the comparison was not the spec's quantity: it was `tracker.LatestConditionNumber()` — a running estimate (`norm_J * norm_J_inverse` from a random-RHS LU probe) refreshed only every `frequency_of_CN_estimation` steps, measured on the **homotopy mid-path**, not on the target system at the endpoint.

This PR computes `SolutionMetaData::condition_number` as the **spectral-norm condition number of the (homogenized, patched) target system's Jacobian at the endpoint**, at the endpoint's own precision: `σ_max/σ_min` via `Eigen::JacobiSVD` (the same construction the Cauchy endgame already uses for its rank checks). A singular-to-precision Jacobian yields `+infinity`, which compares correctly against any threshold.

## Why it matters

Endpoints landing **on a positive-dimensional component** have a provably rank-deficient Jacobian — spectral condition number effectively infinite — yet were observed carrying tracker estimates as low as ~1e3–1e7, silently classifying as **nonsingular** with the default 1e8 threshold. Concretely (found while prototyping NID): for `F = (s·y, s·z)` with `s` the sphere, every endpoint of a sliced solve that lands on the sphere sits on the conic `sphere ∩ plane`; those endpoints came back nonsingular. Downstream, anything that trusts `is_singular` (junk filtering, witness classification, bertini_real-style consumers) then treats junk as witness points — a failure mode hit repeatedly in bertini_real.

## Changes

- `core/include/bertini2/nag_algorithms/zero_dim_solve.hpp`
  - new `EndpointSpectralConditionNumber(sys, endpoint)` (static, engine-level), with a doc-comment guardrail explaining why the tracker's running estimate must not be substituted back;
  - `ExecuteDuringEG` stores that value in `smd.condition_number` (precision already matched at that point in the AMP path);
  - field + `ClassifySingular` doc comments updated to say what is actually computed.
- `core/test/nag_algorithms/zero_dim.cpp`
  - named regression test `endpoint_on_positive_dimensional_component_is_singular`: `V(s·y, s·z, x+2y+3z−5)` — endpoints on the sphere must classify singular **by condition number** (`> 1e8` asserted directly, not just `is_singular`), while the isolated line∩plane solution `(5,0,0)` stays nonsingular.

## Not changed

- **No config fields added or changed** — `PostProcessingConfig` and its canonical encoding are untouched, so **no digest/encoding version bump** is involved.
- The tracker's running estimate is still available per-step via observers / `latest_condition_number()` (the path-data tutorials use it); only the endpoint metadata semantics changed.
- One SVD per successful path; cost is noise next to tracking.

## Semantics note for reviewers

`SolutionMetaData::condition_number` values change for every solve (they now measure the endpoint, not the last tracker step). No tutorial doctest pins these values; the solver report's `max condition num` line will read differently (and can now print `inf` when junk endpoints are present, which is honest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
