### PR TITLE
perf(start): binomial start points computed at working precision (3.2x on small solves)

### DIFF
--- a/core/src/system/start/total_degree_binomial.cpp
+++ b/core/src/system/start/total_degree_binomial.cpp
@@ -117,7 +117,17 @@ namespace bertini {
 			for (size_t ii = 0; ii< NumNaturalVariables(); ++ii)
 			{
 				complex_mp a = exp( (two_i_pi * indices[ii]) / degrees_[ii]);
-				complex_mp b = pow(RandomValue<complex_mp>(ii), one / degrees_[ii]);
+
+				// Round the random value DOWN to working precision BEFORE taking the root.
+				// The Complex node stores its value at its (max) creation precision, and the
+				// variable-precision backend computes pow at the OPERAND's precision -- hundreds
+				// of digits of transcendental arithmetic whose extra digits the Precision call
+				// below then discarded.  Profiled at 93% of start-point generation time (~300x
+				// the working-precision cost); the master value stays exact, so regenerating at
+				// a higher ThreadPrecision still refines toward the same point.
+				complex_mp root_base = RandomValue<complex_mp>(ii);
+				Precision(root_base, ThreadPrecision());
+				complex_mp b = pow(root_base, one / degrees_[ii]);
 
 				Precision(a,ThreadPrecision());
 				Precision(b,ThreadPrecision());


### PR DESCRIPTION
## What

`TotalDegreeBinomial::GenerateStartPoint(complex_mp)` computed `pow(RandomValue<complex_mp>(ii), 1/d)` directly on the stored random value. The `Complex` node holds that value at its (max) creation precision, and boost's variable-precision mpc backend computes `pow` at the **operand's** precision — so every start point paid for hundreds of digits of complex `pow` (py-spy native profile: GMP Toom-class multiplication in the stacks, 93% of start-point generation self-time) whose extra digits the very next `Precision(b, ThreadPrecision())` call rounded away.

## Change

Round the root's base to `ThreadPrecision()` **before** the `pow`. One new local + comment. The master random value stays exact at full precision, so regenerating the same index at a higher thread precision still refines toward the same point — the same convergence semantics as before (previously: compute at max, round result; now: round base, compute; both agree to working precision and converge to the same master-derived point as precision grows).

## Measured

10 small witness-slice solves (eistute ∩ sphere, codim 2, 12 paths each): **0.51s → 0.16s** end-to-end.

## Notes

- `test_nag_algorithms`, `test_tracking_basics`, `test_generating` all green; doclint green.
- Related, not fixed here: `TotalDegreeLinearProduct`'s start points similarly do their linear-solve arithmetic at `MaxPrecisionAllowed()` masters' precision before truncating (see the existing 'leak' comment there) — same pattern, deserves its own measurement.
- This is the profiling follow-up from the AMP audit; found because start-point generation, not tracking, dominated small-solve wall time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)