### PR TITLE
fix(zero_dim): max_precision_used harvested on failed endgames

### DIFF
--- a/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
+++ b/core/include/bertini2/nag_algorithms/zero_dim_solve.hpp
@@ -1946,17 +1946,12 @@ run the endgame, classify the endpoints, report.  See the forward-declare doc ab
 
 				smd.endgame_success_code = eg_success;
 
-				// an unsuccessful endgame has no final approximation, so the final-point-dependent
-				// metadata cannot be computed.
-				if (eg_success != SuccessCode::Success)
-				{
-					if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
-					{
-						ctx.tracker.RemoveObserver(ctx.first_prec_rec);
-						ctx.tracker.RemoveObserver(ctx.min_max_prec);
-					}
-					return;
-				}
+				// Harvest the AMP observers REGARDLESS of the endgame outcome: the precision a
+				// path used is a fact about the tracking that happened, and it is exactly the
+				// FAILED paths -- e.g. slow divergers escalating in the mp lane -- whose
+				// precision honesty matters most for diagnostics.  (Previously the failure
+				// path returned before this harvest, so a path that escalated to 70 digits
+				// and then failed reported its pre-endgame precision, e.g. 16.)
 				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
 				{
 					if (!smd.precision_changed)
@@ -1973,6 +1968,11 @@ run the endgame, classify the endpoints, report.  See the forward-declare doc ab
 					smd.max_precision_used =
 						max(smd.max_precision_used, ctx.min_max_prec.MaxPrecision());
 				}
+
+				// an unsuccessful endgame has no final approximation, so the final-point-dependent
+				// metadata cannot be computed.
+				if (eg_success != SuccessCode::Success)
+					return;
 				if (tracking::TrackerTraits<TrackerType>::IsAdaptivePrec)
 				{
 					assert(Precision(solutions_post_endgame_[soln_ind])==Precision(ctx.endgame.template FinalApproximation<BaseComplexT>()));

--- a/core/test/nag_algorithms/zero_dim.cpp
+++ b/core/test/nag_algorithms/zero_dim.cpp
@@ -874,11 +874,50 @@ BOOST_AUTO_TEST_CASE(double_precision_rejects_a_different_precision)
 // |t|, working precision, and the tracker's condition-number estimate -- so we can SEE whether the
 // condition number (||J|| * ||J^{-1}||) spikes then RECOVERS along the actual seed-6 path, and at
 // what |t| (mid-path vs the t->0 endgame region).
+// REGRESSION: max_precision_used must be harvested even when the ENDGAME FAILS.
+// The failure path used to return before the observer harvest, so a path that escalated
+// precision during the endgame and then failed reported its pre-endgame precision (e.g.
+// 16 digits while the endgame ran far higher).  Force escalate-then-fail deterministically:
+// demand a final tolerance far beyond what a lowered AMP precision ceiling can deliver.
+BOOST_AUTO_TEST_CASE(max_precision_used_is_recorded_on_failed_endgames)
+{
+	using namespace bertini;
+	using namespace bertini::tracking;
+	SetGlobalSeed(2);
+
+	System sys;
+	auto x = Variable::Make("x");
+	sys.AddVariableGroup(bertini::VariableGroup{x});
+	sys.AddFunction(x*x - 1);
+
+	auto zd = algorithm::ZeroDimSolver<AMPTracker,
+	              bertini::endgame::EndgameSelector<AMPTracker>::Cauchy,
+	              decltype(sys)>(sys);
+	zd.DefaultSetup();
+
+	auto tols = zd.Get<algorithm::TolerancesConfig>();
+	tols.final_tolerance = 1e-60;                 // needs ~60+ digits of working precision...
+	zd.Set(tols);
+
+	auto amp = AMPConfigFrom(zd.TargetSystem());
+	amp.maximum_precision = 25;                   // ...which this ceiling forbids
+	zd.GetTracker().PrecisionSetup(amp);
+
+	zd.Solve();
+
+	unsigned failed_after_escalating = 0;
+	for (auto const& m : zd.SolutionMetadata())
+	{
+		if (m.endgame_success_code == SuccessCode::Success)
+			continue;
+		// the endgame escalated past double before failing; the metadata must say so
+		BOOST_CHECK_GE(m.max_precision_used, 20u);
+		++failed_after_escalating;
+	}
+	BOOST_CHECK_GE(failed_after_escalating, 1u);   // the scenario must actually occur
+}
+
 template <class TrackerT>
-
-
-
-
 
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

`ExecuteDuringEG` returned from its endgame-failure path **before** harvesting the AMP min/max-precision observer, so any path that escalated precision during the endgame and then failed reported only its pre-endgame precision. Found while profiling NID crawler paths: metadata claimed 16 digits while the profiler watched them run at 70.

## Change

Hoist the observer harvest (`max_precision_used`, `precision_changed`, `time_of_first_prec_increase`) above the failure early-return. Final-point-dependent metadata (residuals, accuracy estimates, cycle number) is still correctly skipped on failure — a failed endgame has no final approximation. Observer add/remove pairing now mirrors the success path exactly (the old failure path removed `first_prec_rec` unconditionally, even when it was never added).

## Test

`max_precision_used_is_recorded_on_failed_endgames`: deterministic escalate-then-fail (final tolerance 1e-60 under a 25-digit AMP ceiling); failed paths must report ≥ 20 digits. Red without the fix (2 assertion failures), green with; full `test_nag_algorithms` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)