### PR TITLE
fix(python): HomotopySolver accepts any faithful numeric start points; complex_mp constructs from python complex (#347, #348, #339)

### DIFF
--- a/python/bertini/nag_algorithm/__init__.py
+++ b/python/bertini/nag_algorithm/__init__.py
@@ -691,6 +691,70 @@ class _HomotopySolverHolder:
         return repr(object.__getattribute__(self, '_solver'))
 
 
+def _coerce_start_point_coordinate(entry, which_point, which_coordinate):
+    """One start-point coordinate, as a ``complex_mp`` the native layer accepts.
+
+    Start points are *transported values* (the tracker refines them), so anything that IS a
+    number is welcome: multiprecision scalars, Python/numpy numerics, and CONSTANT symbolic
+    nodes (evaluated).  An expression still containing variables is not a number, and gets a
+    math error saying so; anything else gets a TypeError naming the accepted kinds.
+    """
+    from bertini._pybertini.multiprec import complex_mp as _complex_mp, real_mp as _real_mp
+    from bertini._pybertini.function_tree import AbstractNode as _AbstractNode
+
+    if isinstance(entry, _complex_mp):
+        return entry
+    if isinstance(entry, _real_mp):
+        return _complex_mp(entry)
+    if isinstance(entry, _AbstractNode):
+        vars_inside = [str(v) for v in entry.variables()]
+        if vars_inside:
+            raise ValueError(
+                "start point {} coordinate {}: a start point must be a NUMBER, but this "
+                "coordinate is a symbolic expression still containing the variable(s) {} -- "
+                "evaluate or substitute it down to a constant first"
+                .format(which_point, which_coordinate, vars_inside))
+        return entry.eval()
+    if isinstance(entry, bool):
+        # bool is an int subclass; a True/False coordinate is a bug, not a number.
+        raise TypeError(
+            "start point {} coordinate {}: got a bool; start-point coordinates must be numbers"
+            .format(which_point, which_coordinate))
+    if isinstance(entry, int):
+        return _complex_mp(entry)
+    try:
+        z = complex(entry)  # Python float/complex and every numpy scalar kind land here
+    except (TypeError, ValueError):
+        raise TypeError(
+            "start point {} coordinate {}: cannot interpret a {} as a number.  Start-point "
+            "coordinates may be bertini multiprecision scalars (complex_mp / real_mp), Python "
+            "or numpy numbers, or constant symbolic nodes (e.g. bertini.symbolics.Complex)"
+            .format(which_point, which_coordinate, type(entry).__name__)) from None
+    return _complex_mp(z.real, z.imag)
+
+
+def _coerce_start_points(start_points):
+    """The user's start points, normalized to vectors of ``complex_mp``.
+
+    This is the tolerant seam between "whatever numbers the user has" and the native solver,
+    which needs multiprecision vectors: each point may be a list/tuple/numpy array (any
+    numeric dtype, including object arrays of mp values or constant symbolic nodes), and each
+    coordinate goes through :func:`_coerce_start_point_coordinate`.  Issue #347.
+    """
+    import numpy as np
+    pts = []
+    for k, pt in enumerate(start_points):
+        if isinstance(pt, (str, bytes)) or not hasattr(pt, '__iter__'):
+            raise TypeError(
+                "start point {}: each start point must be a vector of coordinates (a list, "
+                "tuple, or numpy array), got a {}".format(k, type(pt).__name__))
+        coerced = [_coerce_start_point_coordinate(e, k, j) for j, e in enumerate(pt)]
+        # no dtype= here: complex_mp registers its own numpy dtype, and inference finds it;
+        # an explicit dtype=object array is NOT accepted by the native converter.
+        pts.append(np.array(coerced))
+    return pts
+
+
 def HomotopySolver(homotopy, start_points, target, *, mptype='adaptive', precision=None, endgame='cauchy'):
     """Track a homotopy you constructed, from a list of start points you already have (e.g. the
     solutions of an earlier solve) -- the continuation primitive (parameter-homotopy workflow).
@@ -706,7 +770,11 @@ def HomotopySolver(homotopy, start_points, target, *, mptype='adaptive', precisi
         down to 0.  Its t=1 slice must vanish at the given ``start_points``.
     start_points : iterable of vectors
         The start points (at the start time).  An earlier solve's ``all_solutions()`` works directly
-        when the variable coordinates line up (e.g. an affine homotopy).
+        when the variable coordinates line up (e.g. an affine homotopy).  Each point may be a list,
+        tuple, or numpy array; coordinates may be multiprecision scalars (``complex_mp`` /
+        ``real_mp``), Python or numpy numbers, or constant symbolic nodes -- they are all coerced
+        to multiprecision for you.  (Start points are transported values, refined by the tracker,
+        so double-precision input is fine here.)
     target : System
         The system the solutions satisfy at t=0 -- used for dehomogenize / residual and for the
         solver's consistency check.  It must NOT have a path variable.
@@ -744,7 +812,7 @@ def HomotopySolver(homotopy, start_points, target, *, mptype='adaptive', precisi
             "    start_solver.solve()\n"
             "    nag_algorithm.HomotopySolver(homotopy, start_solver.all_solutions(), target)"
             .format(type(start_points).__name__))
-    user_start = _pybnalag.UserStartSystem(target, list(start_points))
+    user_start = _pybnalag.UserStartSystem(target, _coerce_start_points(start_points))
     solver = solver_cls(target, user_start, homotopy)
     return _HomotopySolverHolder(solver, homotopy, target, user_start)
 

--- a/python/test/classes/mpfr_test.py
+++ b/python/test/classes/mpfr_test.py
@@ -170,6 +170,21 @@ def test_construct():
     t = mp.complex_mp(mp.real_mp("4.32"), "6e2")
 
 
+def test_construct_from_python_complex():
+    # a python complex is exactly a pair of doubles, so it constructs like one (issue #348
+    # fallout: this raised a raw converter ArgumentError while complex_mp(0.5, 0.25) worked)
+    t = mp.complex_mp(0.5 + 0.25j)
+    assert complex(t) == 0.5 + 0.25j
+    assert complex(mp.complex_mp(1j)) == 1j
+
+
+def test_python_complex_still_not_implicitly_convertible():
+    # the constructor overload must NOT register an implicit conversion: a lossy python
+    # complex where a complex_mp is expected stays refused (doctrine note in mpfr_export.cpp)
+    with pytest.raises(TypeError):
+        mp.real_mp("2.0") + (0.5 + 0.25j)
+
+
 def test_arith_mp_float(cvals):
     x, y, z, p, tol = cvals
     a = mp.real_mp("3.12"); b = mp.real_mp("-5.92")

--- a/python/test/zero_dim/start_point_coercion_test.py
+++ b/python/test/zero_dim/start_point_coercion_test.py
@@ -1,0 +1,85 @@
+"""Start points arrive as whatever numbers the user has; the solver seam coerces them (issue #347).
+
+A HomotopySolver's start points are TRANSPORTED values -- the tracker refines them -- so any
+faithful numeric representation must be accepted: multiprecision scalars, Python/numpy numbers,
+and constant symbolic nodes.  Before the coercion seam, an ndarray of ``symbolics.Complex`` nodes
+(the natural thing to build when your coefficients are already exact nodes) crashed with a raw
+eigenpy converter TypeError naming a C++ Eigen type; a complex128 array died the same way.
+
+Non-numbers are refused with errors that say what to do: an expression still containing
+variables is a math error (it is not a number), anything else names the accepted kinds.
+"""
+
+import numpy as np
+import pytest
+
+import bertini as pb
+from bertini import nag_algorithm as na
+
+C = pb.multiprec.complex_mp
+GAMMA = pb.symbolics.Complex('0.6', '0.8')   # exact, off the real axis -> reproducible path
+
+
+def _quadratic_homotopy():
+    """H deforming x^2-4 (roots +-2) into x^2-1 (roots +-1); returns (homotopy, target)."""
+    x, t = pb.Variable('x'), pb.Variable('t')
+    target = pb.System()
+    target.add_variable_group(pb.VariableGroup([x]))
+    target.add_function(x * x - 1)
+    hom = pb.System()
+    hom.add_variable_group(pb.VariableGroup([x]))
+    one = pb.symbolics.Integer(1)
+    hom.add_function((one - t) * (x * x - 1) + GAMMA * t * (x * x - 4))
+    hom.add_path_variable(t)
+    return hom, target
+
+
+def _solved_roots(start_points):
+    hom, target = _quadratic_homotopy()
+    solver = na.HomotopySolver(hom, start_points, target)
+    solver.solve()
+    return sorted(round(complex(s[0]).real, 6) for s in solver.all_solutions())
+
+
+def test_start_points_as_mp_arrays():
+    # the previously-working spelling keeps working
+    assert _solved_roots([np.array([C('2')]), np.array([C('-2')])]) == [-1.0, 1.0]
+
+
+def test_start_points_as_constant_symbolic_nodes():
+    # issue #347: ndarrays of symbolics.Complex crashed with a raw eigenpy converter TypeError
+    sp = [np.array([pb.symbolics.Complex('2', '0')]),
+          np.array([pb.symbolics.Complex('-2', '0')])]
+    assert _solved_roots(sp) == [-1.0, 1.0]
+
+
+def test_start_points_as_complex128_arrays():
+    # doubles are a faithful transport format for start points; the tracker refines them
+    sp = [np.array([2.0 + 0.0j]), np.array([-2.0 + 0.0j])]
+    assert _solved_roots(sp) == [-1.0, 1.0]
+
+
+def test_start_points_as_plain_python_lists():
+    assert _solved_roots([[2.0], [-2]]) == [-1.0, 1.0]
+
+
+def test_start_points_of_mixed_kinds():
+    # one point per representation, and mixed coordinates within a point elsewhere: all one seam
+    sp = [np.array([pb.symbolics.Complex('2', '0')]), [C('-2')]]
+    assert _solved_roots(sp) == [-1.0, 1.0]
+
+
+def test_start_point_with_variables_is_a_math_error():
+    x = pb.Variable('x')
+    with pytest.raises(ValueError, match=r"symbolic expression.*variable.*x"):
+        _solved_roots([np.array([x + 2])])
+
+
+def test_start_point_junk_names_the_accepted_kinds():
+    with pytest.raises(TypeError, match=r"complex_mp.*numpy numbers.*constant symbolic"):
+        _solved_roots([["two"]])
+
+
+def test_start_point_must_be_a_vector():
+    with pytest.raises(TypeError, match=r"vector of coordinates"):
+        _solved_roots([2.0, -2.0])

--- a/python_bindings/src/mpfr_export.cpp
+++ b/python_bindings/src/mpfr_export.cpp
@@ -594,6 +594,10 @@ namespace bertini{
 			.def(init<std::string, real_mp>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a string and a variable-precision float"))
 			.def(init<real_mp, std::string>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a variable-precision float and a string"))
 			.def(init<std::string, std::string>((arg("self"),arg("real"),arg("imag")),"Construct variable-precision complex number from a pair of strings.  the best way to construct one and be sure you have padded with zeros to the end, in the current working precision"))
+			// a Python complex is exactly a pair of doubles, so accept it wherever a pair of
+			// doubles is accepted (issue #348 fallout: complex_mp(0.5+0.25j) raised a raw
+			// converter ArgumentError while complex_mp(0.5, 0.25) worked)
+			.def("__init__", boost::python::make_constructor(+[](std::complex<double> z) { return std::make_shared<T>(z.real(), z.imag()); }, boost::python::default_call_policies(), (arg("value"))), "Construct variable-precision complex number from a python complex.  do this with caution, as 0.1 is not what you think it is -- there's noise at the end.")
 
 			.def(init<T>((arg("self"),arg("value")),"Construct variable-precision complex number from another one"))
 


### PR DESCRIPTION
Fixes #347; addresses the reachable part of #348 (the crash itself is so far unreproducible on develop — details below); a down-payment on the #339 doctrine.

## What a novice hit (and should never hit)

A well-intentioned user built start points as numpy arrays of `symbolics.Complex` nodes — a perfectly natural thing when your coefficients are already exact nodes — and got a raw eigenpy converter `TypeError` naming a C++ Eigen type (#347). Switching to arrays of Python `complex` dies the same way, and `complex_mp(0.5+0.25j)` raised a Boost.Python `ArgumentError` listing twelve C++ signatures.

## The design position

Start points are **transported values** — the tracker refines them — so any faithful numeric representation should be welcome, and non-numbers should be refused with an error that says what to do. Two changes:

1. **`HomotopySolver` start-point coercion seam** (`python/bertini/nag_algorithm/__init__.py`): each coordinate may be a multiprecision scalar (`complex_mp`/`real_mp`), a Python or numpy number (plain `complex128` arrays now work), or a **constant symbolic node** (evaluated). An expression still containing variables is a *math* error naming the variables; anything else gets a TypeError naming the accepted kinds. The exact code from #347 now runs unmodified, in both its `symbolics.Complex` and `complex_mp` spellings, producing identical results.

2. **`complex_mp` constructs from a Python `complex`** (`python_bindings/src/mpfr_export.cpp`): a Python complex is exactly a pair of doubles, so it constructs the same way `complex_mp(re, im)` doubles do — same caution docstring. **Explicit construction only**: no `implicitly_convertible` is registered, so a lossy Python complex where a `complex_mp` is *expected* stays refused (the 2026.04.14 doctrine note in that file is untouched), and a test pins that refusal.

## On #348 specifically

The reported hard crash does not reproduce here: the verbatim code (SliceMover included) passes on develop, under a perturbed precision state, and under numpy 2.5.1; the duplicate `add_path_variable('t')` in the reporter's code is provably benign (variables are interned by name); the Concatenate structured-block fix is in every 3.3.x release. We need the reporter's platform + crash output to go further.

## Tests

- `python/test/zero_dim/start_point_coercion_test.py`: named regression tests per input kind (mp arrays, constant nodes, complex128, plain lists, mixed), plus the two refusal modes and the vector-shape error.
- `python/test/classes/mpfr_test.py`: `complex_mp(python complex)` round-trips; implicit conversion still refused.
- Full Python suite: 926 passed, 3 skipped. Both doclint gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
