### PR TITLE
fix(endgames): PSEG left previous_approximation_ a copy of final; bind the approximation accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,38 @@ _______________________________________________________________________________
 
 _______________________________________________________________________________
 
+## [3.5.0] - unreleased
+
+### Added
+
+- Python bindings for two endgame accessors that already existed in C++ but were unreachable:
+  `previous_approximation()` and `approximate_error()`, alongside the already-bound
+  `final_approximation()`.  Together they give the pair of successive root approximations the
+  endgame's own convergence test compares, plus the infinity norm between them -- a second
+  sample of the root at a known, coarser accuracy, which is what lets a caller judge how a
+  derived quantity (the singular values of a Jacobian, say) behaves as the approximation
+  improves, rather than thresholding it at one point.
+
+### Fixed
+
+- The power series endgame left `previous_approximation_` holding a COPY of
+  `final_approximation_` after every successful run.  It assigned the two at the bottom of its
+  convergence loop while testing the loop condition at the top, so the assignment ran one final
+  time on the way out.  The Cauchy endgame never had this -- it returns from its acceptance gate
+  before the corresponding assignment -- so the two endgames disagreed about their own post-run
+  state.  Power series now matches Cauchy.  Consequences: `PreviousApproximation()` is now a
+  genuine predecessor for both endgames, and `ZeroDimSolver`'s reported
+  `accuracy_estimate_user_coords` -- computed as the distance between the final approximation and
+  the previous one -- is no longer identically zero for power-series solves, which had it
+  reporting an exactly-perfect accuracy for every such path.
+- `EndgameBase::approximate_error_` was left uninitialized, so `ApproximateError()` read an
+  indeterminate value before any run.  Now initialized to infinity, which is the only safe
+  sentinel: the convergence gates compare it in both directions, and NaN -- which loses every
+  relational comparison -- would make the power series loop's `error > tolerance` test false and
+  skip the loop entirely, reporting instant success.
+
+_______________________________________________________________________________
+
 ## [3.4.0] - 2026-07-16
 
 A one-call way to build a linear slice that passes through a chosen point, an endgame-hardening

--- a/core/include/bertini2/endgames/base_endgame.hpp
+++ b/core/include/bertini2/endgames/base_endgame.hpp
@@ -38,6 +38,7 @@
 */
 
 #include <iostream>
+#include <limits>   // std::numeric_limits, for approximate_error_'s infinity sentinel
 #include <typeinfo>
 
 
@@ -131,7 +132,12 @@ protected:
 	mutable Vec<BCT> final_approximation_;       ///< The latest computed approximation of the endpoint.
 	mutable Vec<BCT> previous_approximation_;     ///< The previous approximation of the endpoint.
 	mutable unsigned int cycle_number_ = 0;       ///< The current estimate of the cycle number.
-	mutable NumErrorT approximate_error_;         ///< The error estimate between successive approximations.
+	/// The error estimate between successive approximations.  Initialized to infinity, not
+	/// left indeterminate: ApproximateError() is a public accessor, so a caller may read it
+	/// before any endgame has run.  Infinity is also the only safe sentinel here -- every
+	/// convergence gate in the flavors has the shape `approximate_error_ < FinalTolerance()`,
+	/// and an indeterminate value that happened to be small would be a false convergence.
+	mutable NumErrorT approximate_error_ = std::numeric_limits<NumErrorT>::infinity();
 
 	// The adaptive-numeric-type state (current_endgame_precision_, adaptive_numeric_type_active_) lives in
 	// the AMP precision policy, AMPEndgame -- the flavors reach it through this-> (it is a base via PrecT).

--- a/core/include/bertini2/endgames/powerseries.hpp
+++ b/core/include/bertini2/endgames/powerseries.hpp
@@ -805,6 +805,18 @@ public:
 	 		
 
 
+			// CONVERGED.  Break BEFORE the assignment below so previous_approximation_ keeps
+			// holding the genuine PREDECESSOR of final_approximation_.  The Cauchy flavor
+			// already behaves this way -- it returns from its acceptance gate before the
+			// corresponding assignment -- and the two must agree, because the public
+			// accessors FinalApproximation()/PreviousApproximation()/ApproximateError() are
+			// only coherent as a triple: overwriting here made previous == final on every
+			// successful run, so the reported error described a pair the caller could not
+			// see.  The loop's own condition is left in place so a FinalTolerance() >= 1
+			// still refuses to enter at all, exactly as before.
+			if (approx_error <= this->FinalTolerance())
+				break;
+
 	 		Precision(prev_approx, Precision(latest_approx));
 	 		prev_approx = latest_approx;
 		} //end while	
@@ -894,6 +906,18 @@ public:
 				}
 				norm_prev = norm_latest;
 			}
+
+			// CONVERGED.  Break BEFORE the assignment below so previous_approximation_ keeps
+			// holding the genuine PREDECESSOR of final_approximation_.  The Cauchy flavor
+			// already behaves this way -- it returns from its acceptance gate before the
+			// corresponding assignment -- and the two must agree, because the public
+			// accessors FinalApproximation()/PreviousApproximation()/ApproximateError() are
+			// only coherent as a triple: overwriting here made previous == final on every
+			// successful run, so the reported error described a pair the caller could not
+			// see.  The loop's own condition is left in place so a FinalTolerance() >= 1
+			// still refuses to enter at all, exactly as before.
+			if (this->approximate_error_ <= this->FinalTolerance())
+				break;
 
 			this->previous_approximation_ = this->final_approximation_;
 		}

--- a/core/test/endgames/generic_cauchy_test.hpp
+++ b/core/test/endgames/generic_cauchy_test.hpp
@@ -2336,3 +2336,93 @@ BOOST_AUTO_TEST_CASE(singular_affine_user_homotopy_success_implies_at_the_root)
 		// any non-Success code is an honest failure: also acceptable
 	}
 }// end singular_affine_user_homotopy_success_implies_at_the_root
+
+
+/**
+The three approximation accessors -- FinalApproximation(), PreviousApproximation() and
+ApproximateError() -- are only useful as a COHERENT TRIPLE: the error must be the infinity
+norm of the difference between the two vectors the caller can actually see.  A caller who
+wants a second, deliberately coarser sample of the root (to watch how a derived quantity --
+the singular values of a Jacobian, say -- moves as the approximation improves) gets nothing
+from a `previous` that is a copy of `final`.
+
+REGRESSION: the power series endgame used to assign previous_approximation_ =
+final_approximation_ at the BOTTOM of its convergence loop, while testing the loop condition
+at the top.  On every successful run the assignment therefore ran one last time and the two
+vectors came back EQUAL, while ApproximateError() still reported the last nonzero gap.  The
+Cauchy flavor never had the bug -- it returns from its acceptance gate before the
+corresponding assignment -- so the two endgames also disagreed about their own post-run
+state.  Asserted here for both, at every tracker precision.
+*/
+BOOST_AUTO_TEST_CASE(approximation_accessors_are_a_coherent_triple)
+{
+	DefaultPrecision(ambient_precision);
+
+	System sys;
+	Var x = Variable::Make("x");
+	Var t = Variable::Make("t");
+
+	sys.AddFunction((x-1)*(1-t) + (x+1)*t);
+
+	VariableGroup vars{x};
+	sys.AddVariableGroup(vars);
+	sys.AddPathVariable(t);
+
+	auto precision_config = PrecisionConfig(sys);
+	TrackerType tracker(sys);
+	bertini::tracking::SteppingConfig stepping_preferences;
+	bertini::tracking::NewtonConfig newton_preferences;
+	tracker.Setup(TestedPredictor, 1e-5, 1e5, stepping_preferences, newton_preferences);
+	tracker.PrecisionSetup(precision_config);
+
+	auto time = ComplexFromString(".1");
+	Vec<BCT> sample(1);
+	sample << ComplexFromString("7.999999999999999e-01", "2.168404344971009e-19");
+
+	TestedEGType my_endgame(tracker);
+	my_endgame.SetBoundaryTime(time);
+
+	// BEFORE any run there is no estimate.  Infinity, not an indeterminate value and not
+	// NaN: every convergence gate compares this against the final tolerance, and the
+	// power series loop's gate has the shape `error > tolerance` -- a NaN would make that
+	// false and skip the loop entirely, reporting instant success.
+	BOOST_CHECK_EQUAL(my_endgame.ApproximateError(),
+	                  std::numeric_limits<bertini::NumErrorT>::infinity());
+
+	auto code = my_endgame.Run(sample);
+	BOOST_REQUIRE(code == SuccessCode::Success);
+
+	auto const& fin  = my_endgame.template FinalApproximation<BCT>();
+	auto const& prev = my_endgame.template PreviousApproximation<BCT>();
+
+	BOOST_REQUIRE_EQUAL(fin.size(), sample.size());
+	BOOST_REQUIRE_EQUAL(prev.size(), sample.size());
+
+	// having converged, the reported error is what the endgame's own gate accepted
+	auto const err = my_endgame.ApproximateError();
+	BOOST_CHECK(err <= my_endgame.FinalTolerance());
+
+	// ... and it must DESCRIBE the pair the caller can actually see.  This is the check
+	// that catches a `previous` overwritten with a copy of `final`: the gap collapses to
+	// zero while the reported error keeps the last real value.
+	//
+	// Deliberately NOT asserting err > 0.  An endgame may legitimately converge with the
+	// error exactly zero when two successive approximations agree bitwise -- measured on
+	// fixed_multiple_cauchy at precision 16 against this very system, whose root is exactly
+	// 1.  Coherence is the invariant; a nonzero gap is not.
+	//
+	// Compared RELATIVE to the error itself, deliberately.  The converged error is smaller
+	// than any absolute tolerance one would think to write, so an ANCHORED comparison
+	// silently passes against the bug: the gap collapses to 0 while err stays ~1e-12, and
+	// `diff <= 1e-10 * max(1, err)` reduces to `1e-12 <= 1e-10`.  Measured -- an anchored
+	// form of this check passed against the unfixed endgame.  Relative, the bug is a ratio
+	// of exactly 1 and cannot hide.
+	auto const gap = static_cast<bertini::NumErrorT>(
+		(fin - prev).template lpNorm<Eigen::Infinity>());
+	auto const diff = gap > err ? gap - err : err - gap;
+	if (err == static_cast<bertini::NumErrorT>(0))
+		BOOST_CHECK_EQUAL(gap, static_cast<bertini::NumErrorT>(0));
+	else
+		BOOST_CHECK(diff <= static_cast<bertini::NumErrorT>(1e-6) * err);
+
+}// end approximation_accessors_are_a_coherent_triple

--- a/core/test/endgames/generic_pseg_test.hpp
+++ b/core/test/endgames/generic_pseg_test.hpp
@@ -1515,3 +1515,91 @@ BOOST_AUTO_TEST_CASE(pseg_full_run_nonzero_target_time)
 }// end cauchy_full_run_nonzero_target_time
 
 
+/**
+The three approximation accessors -- FinalApproximation(), PreviousApproximation() and
+ApproximateError() -- are only useful as a COHERENT TRIPLE: the error must be the infinity
+norm of the difference between the two vectors the caller can actually see.  A caller who
+wants a second, deliberately coarser sample of the root (to watch how a derived quantity --
+the singular values of a Jacobian, say -- moves as the approximation improves) gets nothing
+from a `previous` that is a copy of `final`.
+
+REGRESSION: the power series endgame used to assign previous_approximation_ =
+final_approximation_ at the BOTTOM of its convergence loop, while testing the loop condition
+at the top.  On every successful run the assignment therefore ran one last time and the two
+vectors came back EQUAL, while ApproximateError() still reported the last nonzero gap.  The
+Cauchy flavor never had the bug -- it returns from its acceptance gate before the
+corresponding assignment -- so the two endgames also disagreed about their own post-run
+state.  Asserted here for both, at every tracker precision.
+*/
+BOOST_AUTO_TEST_CASE(approximation_accessors_are_a_coherent_triple)
+{
+	DefaultPrecision(ambient_precision);
+
+	System sys;
+	Var x = Variable::Make("x");
+	Var t = Variable::Make("t");
+
+	sys.AddFunction((x-1)*(1-t) + (x+1)*t);
+
+	VariableGroup vars{x};
+	sys.AddVariableGroup(vars);
+	sys.AddPathVariable(t);
+
+	auto precision_config = PrecisionConfig(sys);
+	TrackerType tracker(sys);
+	bertini::tracking::SteppingConfig stepping_preferences;
+	bertini::tracking::NewtonConfig newton_preferences;
+	tracker.Setup(TestedPredictor, 1e-5, 1e5, stepping_preferences, newton_preferences);
+	tracker.PrecisionSetup(precision_config);
+
+	auto time = ComplexFromString(".1");
+	Vec<BCT> sample(1);
+	sample << ComplexFromString("7.999999999999999e-01", "2.168404344971009e-19");
+
+	TestedEGType my_endgame(tracker);
+	my_endgame.SetBoundaryTime(time);
+
+	// BEFORE any run there is no estimate.  Infinity, not an indeterminate value and not
+	// NaN: every convergence gate compares this against the final tolerance, and the
+	// power series loop's gate has the shape `error > tolerance` -- a NaN would make that
+	// false and skip the loop entirely, reporting instant success.
+	BOOST_CHECK_EQUAL(my_endgame.ApproximateError(),
+	                  std::numeric_limits<bertini::NumErrorT>::infinity());
+
+	auto code = my_endgame.Run(sample);
+	BOOST_REQUIRE(code == SuccessCode::Success);
+
+	auto const& fin  = my_endgame.template FinalApproximation<BCT>();
+	auto const& prev = my_endgame.template PreviousApproximation<BCT>();
+
+	BOOST_REQUIRE_EQUAL(fin.size(), sample.size());
+	BOOST_REQUIRE_EQUAL(prev.size(), sample.size());
+
+	// having converged, the reported error is what the endgame's own gate accepted
+	auto const err = my_endgame.ApproximateError();
+	BOOST_CHECK(err <= my_endgame.FinalTolerance());
+
+	// ... and it must DESCRIBE the pair the caller can actually see.  This is the check
+	// that catches a `previous` overwritten with a copy of `final`: the gap collapses to
+	// zero while the reported error keeps the last real value.
+	//
+	// Deliberately NOT asserting err > 0.  An endgame may legitimately converge with the
+	// error exactly zero when two successive approximations agree bitwise -- measured on
+	// fixed_multiple_cauchy at precision 16 against this very system, whose root is exactly
+	// 1.  Coherence is the invariant; a nonzero gap is not.
+	//
+	// Compared RELATIVE to the error itself, deliberately.  The converged error is smaller
+	// than any absolute tolerance one would think to write, so an ANCHORED comparison
+	// silently passes against the bug: the gap collapses to 0 while err stays ~1e-12, and
+	// `diff <= 1e-10 * max(1, err)` reduces to `1e-12 <= 1e-10`.  Measured -- an anchored
+	// form of this check passed against the unfixed endgame.  Relative, the bug is a ratio
+	// of exactly 1 and cannot hide.
+	auto const gap = static_cast<bertini::NumErrorT>(
+		(fin - prev).template lpNorm<Eigen::Infinity>());
+	auto const diff = gap > err ? gap - err : err - gap;
+	if (err == static_cast<bertini::NumErrorT>(0))
+		BOOST_CHECK_EQUAL(gap, static_cast<bertini::NumErrorT>(0));
+	else
+		BOOST_CHECK(diff <= static_cast<bertini::NumErrorT>(1e-6) * err);
+
+}// end approximation_accessors_are_a_coherent_triple

--- a/python/test/tracking/cauchy_endgame_test.py
+++ b/python/test/tracking/cauchy_endgame_test.py
@@ -35,6 +35,8 @@ Three homotopies are used:
   cubic:     f(x,t) = (x-1)^3*(1-t) + (x^3+1)*t   cycle_num=3 at x=1
 """
 
+import math
+
 import numpy as np
 import pytest
 
@@ -270,3 +272,41 @@ def test_amp_cauchy_cycle_num_2(quadratic_homotopy, precision):
     assert code == SuccessCode.Success
     assert mp.abs(fa[0] - mpfr_complex(1)) < 1e-5
     assert eg.cycle_number() == 2
+
+
+def test_cauchy_approximation_accessors_are_a_coherent_triple(cubic_homotopy):
+    """final_approximation / previous_approximation / approximate_error are one triple.
+
+    Cauchy returns from its acceptance gate before overwriting the previous approximation,
+    so it always had this property; asserted here so the two endgames stay in agreement.
+    Note the error may legitimately be exactly zero when two successive approximations
+    agree bitwise -- coherence is the invariant, a nonzero gap is not.
+    """
+    s, x, t = cubic_homotopy
+
+    tracker = DoublePrecisionTracker(s)
+    tracker.setup(Predictor.HeunEuler, 1e-5, 1e5, SteppingConfig(), NewtonConfig())
+
+    eg = FixedDoubleCauchyEndgame(tracker, complex(0.1, 0))
+
+    assert math.isinf(eg.approximate_error())
+
+    current_space = np.array([complex(5.000000000000001e-01, 9.084258952712920e-17)])
+    code = eg.run(current_space)
+    assert code == SuccessCode.Success
+
+    fa = np.atleast_1d(np.asarray(eg.final_approximation()))
+    pa = np.atleast_1d(np.asarray(eg.previous_approximation()))
+    assert fa.shape == pa.shape == current_space.shape
+
+    err = eg.approximate_error()
+    assert err <= eg.get_endgame_settings().final_tolerance
+
+    # relative to err, not anchored: the converged error is below any absolute tolerance
+    # one would think to write, so an anchored check passes even when previous is a copy
+    # of final (gap 0 vs err ~1e-12).  Relative, that bug is a ratio of exactly 1.
+    gap = max(abs(complex(a) - complex(b)) for a, b in zip(fa, pa))
+    if err == 0.0:
+        assert gap == 0.0
+    else:
+        assert abs(gap - err) <= 1e-6 * err

--- a/python/test/tracking/powerseries_endgame_test.py
+++ b/python/test/tracking/powerseries_endgame_test.py
@@ -34,6 +34,8 @@ At t=1: x^3+1=0 (three simple roots).
 At t=0: (x-1)^3=0 (triple root x=1, cycle number = 3).
 """
 
+import math
+
 import numpy as np
 import pytest
 
@@ -244,3 +246,47 @@ def test_amp_pseg_full_run(cubic_homotopy, precision):
     fa = eg.final_approximation()
     assert code == SuccessCode.Success
     assert mp.abs(fa[0] - mpfr_complex(1)) < 1e-11
+
+
+def test_pseg_approximation_accessors_are_a_coherent_triple(cubic_homotopy):
+    """final_approximation / previous_approximation / approximate_error are one triple.
+
+    The error the endgame reports must be the infinity norm of the difference between the
+    two vectors it hands back -- otherwise a caller asking for a second, coarser sample of
+    the root (to watch how a derived quantity moves as the approximation improves) gets a
+    number that describes a pair they cannot see.
+
+    REGRESSION: the power series endgame used to overwrite previous_approximation with a
+    copy of final_approximation on its way out of the convergence loop, so the two came
+    back equal on every successful run.  Cauchy never did.
+    """
+    s, x, t = cubic_homotopy
+
+    tracker = DoublePrecisionTracker(s)
+    tracker.setup(Predictor.HeunEuler, 1e-6, 1e5, SteppingConfig(), NewtonConfig())
+
+    eg = FixedDoublePowerSeriesEndgame(tracker, complex(0.1, 0))
+
+    # no approximation computed yet -> no estimate.  infinity, not nan: the convergence
+    # gates compare this in both directions, and nan loses every comparison.
+    assert math.isinf(eg.approximate_error())
+
+    current_space = np.array([complex(5.000000000000001e-01, 9.084258952712920e-17)])
+    code = eg.run(current_space)
+    assert code == SuccessCode.Success
+
+    fa = np.atleast_1d(np.asarray(eg.final_approximation()))
+    pa = np.atleast_1d(np.asarray(eg.previous_approximation()))
+    assert fa.shape == pa.shape == current_space.shape
+
+    err = eg.approximate_error()
+    assert err <= eg.get_endgame_settings().final_tolerance
+
+    # relative to err, not anchored: the converged error is below any absolute tolerance
+    # one would think to write, so an anchored check passes even when previous is a copy
+    # of final (gap 0 vs err ~1e-12).  Relative, that bug is a ratio of exactly 1.
+    gap = max(abs(complex(a) - complex(b)) for a, b in zip(fa, pa))
+    if err == 0.0:
+        assert gap == 0.0
+    else:
+        assert abs(gap - err) <= 1e-6 * err

--- a/python_bindings/include/endgame_export.hpp
+++ b/python_bindings/include/endgame_export.hpp
@@ -78,6 +78,26 @@ namespace bertini{
 				return self.template FinalApproximation<T>();
 			}
 
+			// Returned BY VALUE, like the final approximation above: the endgame owns its
+			// approximation vectors and overwrites them on the next run, so handing Python a
+			// reference into that storage would alias live endgame state (ADR-0051's
+			// owned-copy doctrine for eigenpy-backed vectors).
+			template <typename T>
+			static
+			Vec<T> return_previous_approximation(EndgameT const& self)
+			{
+				return self.template PreviousApproximation<T>();
+			}
+
+			// Free function rather than a member pointer, for the same reason CycleNumber
+			// needs GetCycleNumberFn(): the accessor lives on the CRTP base, and naming it
+			// through the derived endgame type keeps overload resolution unambiguous.
+			static
+			NumErrorT return_approximate_error(EndgameT const& self)
+			{
+				return self.ApproximateError();
+			}
+
 		};// EndgameVisitor class
 
 
@@ -151,6 +171,17 @@ namespace bertini{
 			.def("get_system",  &EndgameT::GetSystem,  return_internal_reference<>(),arg("self"),"Get the tracked system.  This is a reference to the internal system.")
 
 			.def("final_approximation", &return_final_approximation<BCT>,arg("self"),"Get the current approximation of the root, in the ambient numeric type for the tracker being used")
+
+			.def("previous_approximation", &return_previous_approximation<BCT>,arg("self"),
+				"Get the second-most-recent approximation of the root, in the ambient numeric type for the tracker being used.  "
+				"Together with final_approximation() this is the pair the endgame's own convergence test compares, so the two "
+				"give you a second sample of the root at a KNOWN, coarser accuracy -- useful for judging how a quantity computed "
+				"at the root (a Jacobian's singular values, say) behaves as the approximation improves.  Empty before a run.")
+
+			.def("approximate_error", &return_approximate_error,arg("self"),
+				"Get the endgame's most recent accuracy estimate: the infinity norm of the difference between "
+				"final_approximation() and previous_approximation().  This is the quantity the endgame compares against the "
+				"final tolerance to decide it has converged.  Returns infinity when no approximation has been computed yet.")
 
 			.def("run", &EndgameBaseVisitor::WrapRun,
 				 (arg("self"), "start_point"),


### PR DESCRIPTION
## Why

Deflation needs to decide the rank of a Jacobian at an *approximate* root, and a single
spectrum at a single point cannot do it — a tiny singular value is indistinguishable from a
perturbation artifact. What separates them is watching how the value **moves** as the
approximation improves. The endgame already computes a second, deliberately coarser sample of
the root and the distance to it, and then throws both away: `PreviousApproximation()` and
`ApproximateError()` exist in C++ but have never been reachable from Python.

Binding them turned up a bug that made one of them useless anyway.

## The bug

The power series endgame assigned `previous_approximation_ = final_approximation_` at the
**bottom** of its convergence loop while testing the loop condition at the **top**, so the
assignment ran one last time on the way out. After every successful PSEG run the two vectors
were **equal**. Cauchy never had this — it returns from its acceptance gate before the
corresponding assignment — so the two endgames disagreed about their own post-run state.

Fixed in both PSEG drivers (fixed-precision `RunImpl` and adaptive `RunImplAMP`) by breaking
before the assignment, matching Cauchy's shape. The loop's own entry condition is deliberately
kept so a `FinalTolerance() >= 1` still refuses to enter at all, exactly as before.

**This reached further than the accessor.** `ZeroDimSolver` computes
`accuracy_estimate_user_coords` as the distance between the final approximation and the
previous one:

```cpp
smd.accuracy_estimate_user_coords =
    (DehomogenizePoint(solutions_post_endgame_[i]) -
     DehomogenizePoint(ctx.endgame.PreviousApproximation<BaseComplexT>())).lpNorm<Infinity>();
```

For power-series solves that was **identically zero** — an exactly-perfect accuracy reported
for every such path. The value flows into the records archive
(`records/solver_recording.hpp`) and MPI `path_result`. It is not part of any digest, so the
persistent-identity contract is untouched.

## Also fixed

`EndgameBase::approximate_error_` was never initialized, so `ApproximateError()` read an
indeterminate value before any run — not acceptable for a member now exposed to Python.

It is initialized to **infinity, deliberately not NaN**. NaN is the more honest "no estimate",
but it loses *every* relational comparison, and the gates read it in both directions:
`cauchy.hpp` has `approximate_error_ < FinalTolerance()` (NaN → false → not converged, fine),
but `powerseries.hpp` has `while (approximate_error_ > FinalTolerance())` — NaN there is false,
the loop never runs, and the endgame reports instant success on whatever happened to be in
`final_approximation_`. Infinity fails the `<` gate and passes the `>` gate, and is not a false
claim: with no approximation computed, the honest error bound is unbounded.

## What is bound

`previous_approximation()` and `approximate_error()` on every endgame flavor.
`final_approximation()` was already bound. Returned by value like the existing accessor, since
the endgame overwrites its approximation vectors on the next run (ADR-0051's owned-copy
doctrine for eigenpy-backed vectors).

Working end to end:

```
PSEG    pre-run error = inf
        final    = 1.000000000000804
        previous = 1.000000000004163      <- a genuine predecessor, not a copy
        approximate_error = 3.359091e-12   ||final-previous|| = 3.359091e-12
CAUCHY  final = 1,  previous = 1+1.54e-18j
        approximate_error = 2.220500e-16   ||final-previous|| = 2.220500e-16
```

## Tests

`approximation_accessors_are_a_coherent_triple`, added to both generic endgame test headers so
it runs for every tracker flavor at every ambient precision, plus Python interface tests.

Two things the tests deliberately do **not** assert, both learned by measurement:

- **Not** `ApproximateError() > 0`. `fixed_multiple_cauchy` at precision 16 converges with two
  successive approximations agreeing *bitwise* on this system, whose root is exactly 1.
  Coherence is the invariant; a nonzero gap is not.
- **Not** an anchored comparison. `diff <= 1e-10 * max(1, err)` **passes against the unfixed
  endgame** — with the bug `gap = 0` and `err ~ 1e-12`, so it reduces to `1e-12 <= 1e-10`. The
  converged error is below any absolute tolerance one would think to write, so the check is
  relative to the error itself, where the bug is a ratio of exactly 1.

Verified the regression test actually bites: reverting only the PSEG change and rebuilding
gives **8 targeted failures** across every PSEG flavor and precision.

## Verification

- `ctest --test-dir build/core` — **10/10 suites pass** (428 endgame cases)
- `pytest python/test/` — **926 passed, 1 skipped**
- `python tools/py_doclint.py` — clean, at baseline
- C++ doc-lint not run locally (no doxygen on this machine); the diff adds no new public entity
  under `core/include`, so the zero-undocumented ratchet is unaffected.

## ADR

Assessed, and I do not think one is warranted. The one thing a reader might "helpfully" undo is
the loop now carrying both a `while (error > tolerance)` condition and an
`if (error <= tolerance) break;`, which looks redundant — but that is a bug fix carried by a
regression test that fails loudly across 8 suites, which the ADR bar explicitly exempts. The
reasoning for both the break and the infinity sentinel is written inline at each site. Happy to
add one if you would rather have the guardrail.
