### PR TITLE
fix(precision): evaluation complies with its arguments instead of refusing them

### DIFF
--- a/core/include/bertini2/system/straight_line_program.hpp
+++ b/core/include/bertini2/system/straight_line_program.hpp
@@ -852,16 +852,29 @@ namespace bertini {
 		void SetVariableValues(Eigen::MatrixBase<Derived> const& variable_values) const{
 			using NumT = typename Derived::Scalar;
 
-#if !defined(BERTINI_DISABLE_PRECISION_CHECKS)
-// && _WIN32
+			// The Memory's precision is an ARTIFACT OF THE CURRENT EVALUATION, never an
+			// invariant to defend.  The compiled Program is a precision-independent tape of
+			// operations; only the Memory holding values carries digits.  So evaluating at
+			// whatever precision the caller brings is always meaningful, and the right
+			// response to a mismatch is to RE-TAG THE MEMORY, not to refuse.
+			//
+			// Refusing was a genuine trap, not merely unergonomic.  A Memory takes its
+			// precision from the ambient DefaultPrecision() when the program is lazily
+			// compiled, while the owning System keeps whatever it was told, so the two
+			// diverge the moment anything moves the ambient default -- which an AMP tracker
+			// or endgame does as a matter of course.  The System was then WEDGED with no way
+			// out: evaluating at its own reported precision raised here, and
+			// System::precision(n) could not repair it, because both setters short-circuit
+			// when the value they are handed already equals the one they hold.  See #377.
+			//
 			// An empty variable vector (a constant program with no variables) has no
-			// precision to read or check.
-			if (!std::is_same<NumT,complex_dbl>::value && variable_values.size() > 0 && Precision(variable_values)!=memory_.precision_){
-				std::stringstream err_msg;
-				err_msg << "variable_values and SLP must be of same precision.  respective precisions: " << Precision(variable_values) << " " << memory_.precision_ << std::endl;
-				throw std::runtime_error(err_msg.str());
+			// precision to read.  Re-tagging refills the constants from their exact recipes
+			// at the new precision, so accuracy is rebuilt rather than padded with zeros.
+			if constexpr (!std::is_same<NumT,complex_dbl>::value)
+			{
+				if (variable_values.size() > 0 && Precision(variable_values)!=memory_.precision_)
+					this->precision(Precision(variable_values));
 			}
-#endif
 
 			auto& memory = memory_.Get<NumT>(); // unpack for local reference
 
@@ -883,14 +896,15 @@ namespace bertini {
 		template<typename ComplexT>
 		void SetPathVariable(ComplexT const& time) const{
 
-#if !defined(BERTINI_DISABLE_PRECISION_CHECKS)
-// && _WIN32
-			if (Precision(time)!= DoublePrecision() && Precision(time)!=memory_.precision_){
-				std::stringstream err_msg;
-				err_msg << "time value and SLP must be of same precision.  respective precisions: " << Precision(time) << " " << memory_.precision_ << std::endl;
-				throw std::runtime_error(err_msg.str());
+			// Same doctrine as SetVariableValues, but this one only ever raises: the
+			// variables have already been written into memory by the time the path variable
+			// arrives, so re-tagging DOWNWARD here would truncate them.  Memory therefore
+			// ends an evaluation at the max of its arguments' precisions.
+			if constexpr (!std::is_same<ComplexT,complex_dbl>::value)
+			{
+				if (Precision(time) > memory_.precision_)
+					this->precision(Precision(time));
 			}
-#endif
 
 			if (!this->HavePathVariable())
 				throw std::runtime_error("calling Eval with path variable, but this StraightLineProgram doesn't have one.");
@@ -899,6 +913,10 @@ namespace bertini {
 			auto& memory = memory_.Get<ComplexT>(); // unpack for local reference
 
 			memory[program_->input_locations_.Time] = time;
+			// assigning an mp value adopts the SOURCE's precision, so a lower-precision time
+			// would otherwise leave one slot out of step with the rest of memory
+			if constexpr (!std::is_same<ComplexT,complex_dbl>::value)
+				Precision(memory[program_->input_locations_.Time], memory_.precision_);
 			memory_.is_evaluated_ = false;
 		}
 

--- a/core/include/bertini2/system/system.hpp
+++ b/core/include/bertini2/system/system.hpp
@@ -897,17 +897,29 @@ namespace bertini {
 				throw std::runtime_error("variable vector of different length from system-owned variables in SetVariables");
 			}
 
-			#ifndef BERTINI_DISABLE_PRECISION_CHECKS
-				// A system with no variables (a constant) has an empty point: there is no
-				// precision to read from it, so skip the check.
-				if (new_values.size() > 0)
-				{
-					if constexpr (!std::is_same<T,complex_dbl>::value) {
-						if (Precision(new_values) != this->precision())
-							throw std::runtime_error("precision of input point in SetVariables (" + std::to_string(Precision(new_values)) + ") must match the precision of the system (" + std::to_string(this->precision()) + ").");
-					}
-				}
-			#endif
+			// ALIGN to the incoming point rather than refusing it (#377).  A System's
+			// precision is not an invariant the caller must maintain by hand: the caller's
+			// intent is always just "evaluate f at x", and x carries the precision that
+			// evaluation should happen at.  Aligning here pushes the new precision down to
+			// every block (each block re-tags its SLP's memory and rebuilds its constants
+			// from their exact recipes), to the stored path value, and to the patch, so the
+			// whole System is consistent for the evaluation that follows.
+			//
+			// Refusing was not merely unergonomic, it was inescapable in one direction: a
+			// block's SLP takes its memory precision from the ambient DefaultPrecision() at
+			// lazy compile time while the System keeps whatever it was told, and once those
+			// diverge, System::precision(n) cannot repair it -- both it and
+			// StraightLineProgram::precision(n) short-circuit when handed the value they
+			// already hold.  See the SLP-side note in SetVariableValues.
+			//
+			// Deliberately NOT behind BERTINI_DISABLE_PRECISION_CHECKS: this is required
+			// behaviour, not a debug assertion.  A system with no variables (a constant) has
+			// an empty point and so carries no precision to read.
+			if constexpr (!std::is_same<T,complex_dbl>::value)
+			{
+				if (new_values.size() > 0 && Precision(new_values) != this->precision())
+					this->precision(Precision(new_values));
+			}
 
 			// Blocks are value-in: the polynomial block feeds this stored vector into its SLP, the
 			// structured blocks compute on it directly, and the patch reads it too (see

--- a/core/test/classes/precision_propagation_test.cpp
+++ b/core/test/classes/precision_propagation_test.cpp
@@ -205,4 +205,145 @@ BOOST_AUTO_TEST_CASE(stepping_config_max_step_size_no_stale_precision)
 
 
 // -----------------------------------------------------------------------
+
+
+// --- SLP precision follows its EVALUATION ARGUMENTS (#377) -------------
+//
+// The compiled Program is a precision-independent tape of operations; only the Memory
+// holding values carries digits.  So the Memory's precision is an artifact of the current
+// evaluation, never an invariant, and evaluation must re-tag rather than refuse.
+//
+// This used to throw, and -- worse -- there was no way out of it.  A Memory takes its
+// precision from the ambient DefaultPrecision() when the program is lazily compiled, while
+// the owning System keeps whatever it was told, so the two diverge the moment anything
+// moves the ambient default (an AMP tracker or endgame does, routinely).  Both
+// System::precision() and StraightLineProgram::precision() short-circuit when handed the
+// value they already hold, so neither could repair the divergence: the System was wedged.
+
+namespace {
+	/// f(x,y) = x^2 - y, whose Jacobian [2x, -1] is exact at any precision.
+	bertini::System TwoVarSystem()
+	{
+		using bertini::node::Variable;
+		auto x = Variable::Make("x"), y = Variable::Make("y");
+		bertini::System sys;
+		bertini::VariableGroup vars{x, y};
+		sys.AddVariableGroup(vars);
+		sys.AddFunction(pow(x, 2) - y);
+		return sys;
+	}
+
+	bertini::Vec<complex_mp> PointAt(unsigned prec, std::string const& re)
+	{
+		auto saved = DefaultPrecision();
+		DefaultPrecision(prec);
+		bertini::Vec<complex_mp> p(2);
+		p << complex_mp(real_mp(re), real_mp("0")), complex_mp(real_mp("1"), real_mp("0"));
+		Precision(p, prec);
+		DefaultPrecision(saved);
+		return p;
+	}
+}
+
+BOOST_AUTO_TEST_CASE(slp_evaluates_after_the_ambient_default_moved_underneath_it)
+{
+	DefaultPrecision(30);
+	auto sys = TwoVarSystem();
+	sys.precision(30);
+
+	// an AMP tracker or endgame leaves the ambient default somewhere else entirely
+	DefaultPrecision(16);
+
+	// evaluating at the system's OWN precision must work.  before the fix this threw
+	// "variable_values and SLP must be of same precision.  respective precisions: 30 16"
+	auto pt = PointAt(30, "3");
+	BOOST_CHECK_NO_THROW(sys.Eval(pt));
+	auto v = sys.Eval(pt);
+	BOOST_CHECK_EQUAL(v.size(), 1);
+	BOOST_CHECK(abs(v(0) - complex_mp(8)) < 1e-25);   // 3^2 - 1 = 8
+
+	BOOST_CHECK_NO_THROW(sys.Jacobian(pt));
+	auto J = sys.Jacobian(pt);
+	BOOST_CHECK(abs(J(0,0) - complex_mp(6)) < 1e-25); // d/dx = 2x = 6
+	BOOST_CHECK(abs(J(0,1) + complex_mp(1)) < 1e-25); // d/dy = -1
+}
+
+BOOST_AUTO_TEST_CASE(slp_retags_when_evaluated_at_a_sequence_of_precisions)
+{
+	DefaultPrecision(16);
+	auto sys = TwoVarSystem();
+
+	// the same system, evaluated up and down a ladder of precisions, in one lifetime
+	for (unsigned prec : {16u, 50u, 30u, 100u, 20u})
+	{
+		auto pt = PointAt(prec, "3");
+		BOOST_CHECK_NO_THROW(sys.Eval(pt));
+		auto v = sys.Eval(pt);
+		BOOST_CHECK(abs(v(0) - complex_mp(8)) < 1e-15);
+	}
+}
+
+BOOST_AUTO_TEST_CASE(slp_retag_rebuilds_constants_it_does_not_zero_pad_them)
+{
+	// The mean version.  A constant that is INEXACT in decimal -- 1/3 -- must come back at
+	// full accuracy after a re-tag upward, which is only true if re-tagging refills the
+	// constants from their exact recipes.  Padding a 16-digit 1/3 out to 100 digits would
+	// leave the tail zero and the residual ~1e-17, not ~1e-100.
+	using bertini::node::Variable;
+	using bertini::node::Rational;
+	auto x = Variable::Make("x");
+	bertini::System sys;
+	bertini::VariableGroup vars{x};
+	sys.AddVariableGroup(vars);
+	sys.AddFunction(x - Rational::Make(mpq_rational(1, 3)));
+
+	DefaultPrecision(16);
+	{	// force the lazy compile to happen at 16 digits
+		auto saved = DefaultPrecision();
+		bertini::Vec<complex_mp> p(1);
+		p << complex_mp(real_mp("1"), real_mp("0"));
+		Precision(p, 16);
+		BOOST_CHECK_NO_THROW(sys.Eval(p));
+		DefaultPrecision(saved);
+	}
+
+	// now evaluate AT 1/3 to 100 digits: the residual must be ~1e-100, not ~1e-17
+	DefaultPrecision(100);
+	bertini::Vec<complex_mp> third(1);
+	third << complex_mp(real_mp(mpq_rational(1, 3)), real_mp("0"));
+	Precision(third, 100);
+	auto v = sys.Eval(third);
+	BOOST_CHECK_MESSAGE(abs(v(0)) < 1e-90,
+		"constant was padded rather than rebuilt: residual " << abs(v(0)));
+}
+
+BOOST_AUTO_TEST_CASE(slp_memory_ends_at_the_max_of_its_arguments_precisions)
+{
+	// The path variable arrives AFTER the variables are already in memory, so re-tagging on
+	// it may only ever raise -- lowering would truncate the variables just written.
+	using bertini::node::Variable;
+	auto x = Variable::Make("x");
+	auto t = Variable::Make("t");
+	bertini::System sys;
+	bertini::VariableGroup vars{x};
+	sys.AddVariableGroup(vars);
+	sys.AddPathVariable(t);
+	sys.AddFunction(x * t);
+
+	DefaultPrecision(30);
+	sys.precision(30);
+	auto pt = PointAt(30, "2");
+	bertini::Vec<complex_mp> one(1);
+	one << pt(0);                      // x = 2 at 30 digits
+
+	DefaultPrecision(60);
+	complex_mp time(real_mp("3"), real_mp("0"));
+	Precision(time, 60);
+
+	BOOST_CHECK_NO_THROW(sys.Eval(one, time));
+	auto v = sys.Eval(one, time);
+	BOOST_CHECK(abs(v(0) - complex_mp(6)) < 1e-25);
+	BOOST_CHECK_GE(Precision(v(0)), 30u);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/python/test/classes/slp_precision_follows_args_test.py
+++ b/python/test/classes/slp_precision_follows_args_test.py
@@ -1,0 +1,130 @@
+"""A System must evaluate at whatever precision its arguments carry (bertini2 #377).
+
+The compiled SLP is a precision-independent tape of operations; only the Memory holding
+values carries digits.  So the Memory's precision is an artifact of the current evaluation,
+never an invariant, and evaluation re-tags rather than refuses.
+
+This used to throw, and there was no way out.  A Memory takes its precision from the
+ambient ``default_precision()`` when the program is lazily compiled, while the owning
+System keeps whatever it was told, so the two diverge the moment anything moves the ambient
+default -- which an AMP tracker or endgame does as a matter of course.  Both setters
+short-circuit when handed the value they already hold, so neither could repair it:
+
+    RuntimeError: variable_values and SLP must be of same precision.
+                  respective precisions: 30 16
+
+Mirrors the C++ suite in core/test/classes/precision_propagation_test.cpp.
+"""
+
+import numpy as np
+import pytest
+
+import bertini
+from bertini import System, VariableGroup
+from bertini.symbolics import Rational, Variable
+from bertini.multiprec import complex_mp, real_mp
+
+
+def two_var_system():
+    """f(x, y) = x^2 - y; Jacobian [2x, -1] is exact at any precision."""
+    x, y = Variable("x"), Variable("y")
+    s = System()
+    vg = VariableGroup()
+    vg.append(x)
+    vg.append(y)
+    s.add_variable_group(vg)
+    s.add_functions([x**2 - y])
+    return s
+
+
+def point_at(prec, re):
+    saved = bertini.default_precision()
+    bertini.default_precision(prec)
+    try:
+        p = np.array([complex_mp(str(re), '0'), complex_mp('1', '0')])
+    finally:
+        bertini.default_precision(saved)
+    return p
+
+
+def test_eval_after_the_ambient_default_moved_underneath_the_system():
+    """The wedge, reproduced: build at 30, let something move the default to 16, evaluate
+    at the system's OWN precision.  Before the fix this raised, and no setter could undo
+    it -- the System was unusable in both directions."""
+    bertini.default_precision(30)
+    s = two_var_system()
+    s.precision(30)
+
+    bertini.default_precision(16)          # what an AMP tracker/endgame leaves behind
+
+    v = np.atleast_1d(np.asarray(s.eval(point_at(30, 3))))
+    assert abs(complex(float(repr(v[0].real)), float(repr(v[0].imag))) - 8) < 1e-25
+
+
+def test_jacobian_after_the_ambient_default_moved_underneath_the_system():
+    bertini.default_precision(30)
+    s = two_var_system()
+    s.precision(30)
+    bertini.default_precision(16)
+
+    J = np.atleast_2d(np.asarray(s.eval_jacobian(point_at(30, 3))))
+    assert J.shape == (1, 2)
+    assert abs(float(repr(J[0, 0].real)) - 6.0) < 1e-25     # d/dx = 2x
+    assert abs(float(repr(J[0, 1].real)) + 1.0) < 1e-25     # d/dy = -1
+
+
+@pytest.mark.parametrize("ladder", [[16, 50, 30, 100, 20], [100, 16, 100]])
+def test_one_system_evaluated_up_and_down_a_precision_ladder(ladder):
+    """Precision is per-evaluation, so a single System serves any sequence of them."""
+    bertini.default_precision(16)
+    s = two_var_system()
+    for prec in ladder:
+        v = np.atleast_1d(np.asarray(s.eval(point_at(prec, 3))))
+        assert abs(float(repr(v[0].real)) - 8.0) < 1e-14
+
+
+def test_retag_rebuilds_constants_rather_than_zero_padding_them():
+    """The mean one.  A constant that is INEXACT in decimal -- 1/3 -- must come back at
+    full accuracy after the memory is re-tagged upward, which is only true if re-tagging
+    refills constants from their exact recipes.  Padding a 16-digit 1/3 out to 100 digits
+    leaves the tail zero, and the residual would be ~1e-17 instead of ~1e-100.
+    """
+    x = Variable("x")
+    s = System()
+    vg = VariableGroup()
+    vg.append(x)
+    s.add_variable_group(vg)
+    # NOTE Rational(a, b) is (real, imaginary), not numerator/denominator -- the
+    # single-argument spelling is the one that means one third
+    s.add_functions([x - Rational('1/3')])
+
+    bertini.default_precision(16)                 # force the lazy compile at 16 digits
+    s.eval(np.array([complex_mp('1', '0')]))
+
+    bertini.default_precision(100)
+    third = np.array([complex_mp(real_mp(1) / real_mp(3), real_mp(0))])
+    v = np.atleast_1d(np.asarray(s.eval(third)))
+    residual = abs(float(repr(v[0].real)))
+    assert residual < 1e-90, f"constant was padded, not rebuilt: residual {residual:g}"
+
+
+def test_path_variable_precision_only_ever_increases_memory_precision():
+    """The path variable arrives after the variables are already in memory, so re-tagging
+    on it may only raise -- lowering would truncate the variables just written."""
+    x, t = Variable("x"), Variable("t")
+    s = System()
+    vg = VariableGroup()
+    vg.append(x)
+    s.add_variable_group(vg)
+    s.add_path_variable(t)
+    s.add_functions([x * t])
+
+    bertini.default_precision(30)
+    s.precision(30)
+    pt = np.array([complex_mp('2', '0')])
+
+    bertini.default_precision(60)
+    time = complex_mp('3', '0')
+
+    v = np.atleast_1d(np.asarray(s.eval(pt, time)))
+    assert abs(float(repr(v[0].real)) - 6.0) < 1e-25


### PR DESCRIPTION
Fixes ask 1 of #377.

## A System doesn't just complain — it gets WEDGED

An SLP's `Memory` takes its precision from the ambient `DefaultPrecision()` when the
program is **lazily compiled**, while the owning `System` keeps whatever it was told. They
diverge the moment anything moves the ambient default — which an AMP tracker or endgame
does as a matter of course. Once they have, **both directions throw**:

```
built at 30, ambient default moved to 16 (what an AMP endgame leaves behind)
  eval@30  (the system's OWN precision)   FAIL  variable_values and SLP must be of same precision: 30 16
  eval@16  (the ambient precision)        FAIL  input point (16) must match the system (30)
  eval@30 after S.precision(16); S.precision(30)   FAIL  ...unchanged
```

That third line is the point. `System::precision(n)` **cannot repair it**: it and
`StraightLineProgram::precision(n)` both short-circuit when handed the value they already
hold, so the System — already believing it is at 30 — pushes nothing down to the SLP. The
only escape is setting the ambient global, which means `System::precision()` is a report of
something that may no longer be true.

## Comply, don't refuse

The doctrine: a Memory's precision is an **artifact of the current evaluation**, never an
invariant to defend. The compiled Program is a precision-independent tape of operations;
only the Memory holding values carries digits. Likewise a System's precision is the fan-out
point to its blocks' working coefficients and its patch — each of which already keeps an
exact master (`constant_recipes_`, `coefficients_highest_precision_`) beside its working
copy. Nothing irreplaceable lives in either.

- **`SetVariableValues`** re-tags the SLP's memory to the incoming precision, reusing
  `precision()`, which **refills constants from their exact recipes** rather than padding
  with zeros — accuracy is rebuilt, not faked.
- **`SetPathVariable`** only ever *raises*: the variables are already in memory by then, so
  re-tagging downward would truncate them. Memory ends an evaluation at the max of its
  arguments' precisions. The time slot is re-tagged after assignment, since assigning an mp
  value adopts the source's precision.
- **`System::SetVariables`** aligns the System to the incoming point, pushing precision down
  to every block and the patch. Deliberately **not** behind
  `BERTINI_DISABLE_PRECISION_CHECKS` — alignment is required behaviour, not an assertion.

## Threading

Unaffected. `ZeroDimSolver` already hands each worker a deep-cloned System, and the comment
there says why: *"a target-system copy (residual evaluation mutates System precision
state)"*. The codebase already accepts that evaluating mutates precision state and solves it
by ownership.

## Tests, both languages

`core/test/classes/precision_propagation_test.cpp` and
`python/test/classes/slp_precision_follows_args_test.py`: the wedge reproduction for `Eval`
and `Jacobian`, one system evaluated up and down a ladder of precisions, and the
max-of-arguments rule for the path variable.

The pointed one asserts that a constant **inexact in decimal** — `1/3` — compiled at 16
digits returns residual **exactly 0** when evaluated at 100 digits. That holds only if
re-tagging *rebuilds* constants from their recipes; padding a 16-digit `1/3` out to 100
would leave the tail zero and the residual at ~1e-17.

## Verification

- `ctest --test-dir build/core` — **10/10 suites pass**, including `test_tracking_basics`,
  `test_endgames` and `test_nag_algorithms`, the heaviest users of precision changes
- `pytest python/test/` — **933 passed, 1 skipped**
- **Numerically inert.** Four decomposition tests in a downstream consumer — witness-point
  counts, warning counts, Euler characteristic — fail **byte-identically** with and without
  this change: same face count, same midslice count, same warning count, same χ. The
  baseline binary was confirmed to be the baseline by checking that it still refuses, rather
  than by trusting build timing.

## Scope

This is ask 1 only. Asks 2 and 3 — removing `System::precision` as load-bearing
caller-managed state, and one documented ownership rule — are now *cheaper* rather than
harder: with evaluation aligning on its own, the fan-out `System::precision()` performs is
triggered by the arguments instead of by hand, so removal is a sweep over ~161 call sites
(69 `core/include`, 46 `core/test`, 37 `python`, 1 binding) plus an ADR, not new machinery.
Left for its own PR since it is an API break.

## ADR

None proposed. Both non-obvious choices are load-bearing but explained inline at their
sites: why `SetPathVariable` may only raise, and why re-tagging must rebuild constants
rather than pad. The regression tests fail loudly if either is undone. The ADR that *is*
warranted is the ownership rule from ask 3, which belongs with the removal PR.
