### PR TITLE
fix(classic-io): three defects in the classic-input round trip (segfault, silent empty parse, inflated degree bound)

### DIFF
--- a/core/include/bertini2/io/parsing/qi_files.hpp
+++ b/core/include/bertini2/io/parsing/qi_files.hpp
@@ -57,6 +57,8 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <cctype>
+#include <cstring>
 #include <string>
 
 #include "bertini2/io/parsing/unicode_ident.hpp"
@@ -78,6 +80,64 @@ inline void StripUTF8BOM(std::string& s)
 	{
 		s.erase(0, 3);
 	}
+}
+
+/// \brief Unwrap a Bertini 1 classic input FILE down to the declarations the grammar reads.
+///
+/// `System::to_classic_input()` emits a complete Bertini 1 file --
+/// `CONFIG ... END;` then `INPUT ... END;` -- because its purpose is running the same
+/// problem in Bertini 1.  The grammar reads only the INPUT-section BODY.  The two therefore
+/// were not inverses, and the mismatch did not announce itself: the wrapped text matched
+/// nothing and the caller received an empty System.  See #396.
+///
+/// Comply rather than refuse: handing a system parser a classic input file means one thing.
+/// The CONFIG section holds tracking settings a System does not carry, so it is dropped.
+/// Text that is already a bare body is returned untouched, so this is a no-op for every
+/// caller that was working before.
+inline void StripClassicFileWrappers(std::string& s)
+{
+	auto skip_ws = [](std::string const& t, size_t i) {
+		while (i < t.size() && std::isspace(static_cast<unsigned char>(t[i]))) ++i;
+		return i;
+	};
+	// case-insensitive check for `word` at position i, followed by a non-identifier char
+	auto keyword_at = [](std::string const& t, size_t i, char const* word) {
+		size_t n = std::strlen(word);
+		if (i + n > t.size()) return false;
+		for (size_t k = 0; k < n; ++k)
+			if (std::toupper(static_cast<unsigned char>(t[i+k])) != word[k]) return false;
+		if (i + n < t.size())
+		{
+			unsigned char c = static_cast<unsigned char>(t[i+n]);
+			if (std::isalnum(c) || c=='_') return false;
+		}
+		return true;
+	};
+
+	size_t i = skip_ws(s, 0);
+
+	// a leading CONFIG section, if present, runs to its first END;
+	if (keyword_at(s, i, "CONFIG"))
+	{
+		size_t e = s.find("END;", i);
+		if (e == std::string::npos)
+			return;                       // malformed; let the grammar report it
+		i = skip_ws(s, e + 4);
+	}
+
+	// an INPUT section wrapper, if present: drop the keyword and the matching trailing END;
+	if (keyword_at(s, i, "INPUT"))
+	{
+		size_t body = skip_ws(s, i + 5);
+		size_t e = s.rfind("END;");
+		if (e == std::string::npos || e < body)
+			return;                       // malformed; let the grammar report it
+		s = s.substr(body, e - body);
+		return;
+	}
+
+	if (i != 0)
+		s = s.substr(i);
 }
 
 /// \brief Format a human-readable parse-error message (line, column, expected, and found text).

--- a/core/include/bertini2/io/parsing/system_parsers.hpp
+++ b/core/include/bertini2/io/parsing/system_parsers.hpp
@@ -53,7 +53,7 @@ namespace bertini {
 				using boost::phoenix::ref;
 				
 				SystemParser<Iterator> S;
-				
+
 				System s{};
 				bool r = phrase_parse(first, last,
 									  S,
@@ -84,6 +84,9 @@ namespace bertini {
 		// stray leading character by the grammar.
 		std::string cleaned = input;
 		parsing::classic::StripUTF8BOM(cleaned);
+		// accept a full Bertini 1 classic file (CONFIG/INPUT wrappers), not just the bare
+		// INPUT-section body that the grammar reads -- see #396
+		parsing::classic::StripClassicFileWrappers(cleaned);
 
 		std::string::const_iterator iter = cleaned.begin();
 		std::string::const_iterator end = cleaned.end();

--- a/core/src/function_tree/operators/arithmetic.cpp
+++ b/core/src/function_tree/operators/arithmetic.cpp
@@ -1061,15 +1061,43 @@ int PowerOperator::Degree(std::shared_ptr<Variable> const& v) const
 
 int PowerOperator::Degree(VariableGroup const& vars) const
 {
-	auto multideg = MultiDegree(vars);
-	auto deg = 0;
-	std::for_each(multideg.begin(),multideg.end(),[&](int n){
-					if (n < 0)
-						deg = -1;
-					else
-						deg += n;
-					});
-	return deg;
+	// TOTAL degree with respect to the group -- NOT the sum of the per-variable degrees,
+	// which is what this used to compute.  Summing is valid only for a monomial: for
+	// (x+y)^2 the degree in x is 2 and the degree in y is 2, but the TOTAL degree is 2,
+	// not 4.  The error scales with the number of variables in the base -- measured
+	// (x^2+y^2+z^2+3)^2 reported 12 instead of 4 -- and it reaches AMP through
+	// System::DegreeBound(), which calls Degrees(Variables()).
+	//
+	// It stayed hidden because the two ways of building the same expression take different
+	// paths: an integer exponent written in C++ or Python builds an IntegerPowerOperator,
+	// whose Degree(VariableGroup) is base_deg*exponent and always was right, while the
+	// classic-input parser builds this generic PowerOperator.  So a system round-tripped
+	// through classic input tracked with a different degree bound than the original.
+	//
+	// Same shape as Degree(v) above, with the base's group degree in place of its degree in
+	// one variable.
+	auto base_deg = base_->Degree(vars);
+	auto exp_deg = exponent_->Degree(vars);
+
+	if (exp_deg!=0)
+		return -1;   // a variable exponent is not polynomial
+
+	complex_dbl exp_val = ConstantExponentValue(exponent_);
+	bool exp_is_int = false;
+	if (fabs(imag(exp_val)) < 10*std::numeric_limits<double>::epsilon())
+		if (fabs(real(exp_val) - std::round(real(exp_val))) < 10*std::numeric_limits<double>::epsilon())
+			exp_is_int = true;
+
+	if (!exp_is_int)
+		return base_deg==0 ? 0 : -1;
+
+	if (abs(exp_val-complex_dbl(0.0)) < 10*std::numeric_limits<double>::epsilon())
+		return 0;
+	if (real(exp_val)<0)
+		return -1;
+	if (base_deg<0)
+		return -1;
+	return base_deg*static_cast<int>(std::round(real(exp_val)));
 }
 
 

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -950,6 +950,16 @@ namespace bertini
 
 		RealT bound(0);
 
+		// A system with no functions -- or no variables -- has no coefficient bound; same
+		// convention as DegreeBound() below, which returns 0 for the same reason.  This is
+		// not merely tidiness: either way f_vals and dh_dx below are EMPTY (dh_dx is
+		// functions x variables), and Eigen's maxCoeff() on an empty array is UNDEFINED
+		// BEHAVIOUR -- it asserts in a debug build and reads out of bounds in a release one.
+		// `bertini.System().to_classic_input()` reached here (the CONFIG section emits
+		// `coefficientbound:`) and segfaulted the interpreter.  See #395.
+		if (NumTotalFunctions()==0 || NumVariables()==0)
+			return bound;
+
 		for (unsigned ii=0; ii < num_evaluations; ii++)
 		{	
 			Vec<ComplexT> randy = RandomOfUnits<ComplexT>(static_cast<unsigned>(NumVariables()));

--- a/core/test/classic/classic_parsing_test.cpp
+++ b/core/test/classic/classic_parsing_test.cpp
@@ -812,6 +812,105 @@ BOOST_AUTO_TEST_CASE(multipoint_emoji_variable_parses)
 }
 
 
+
+// ---- the classic-input round trip, and the three defects found in it -----------------
+//
+// SystemToClassicFile() emits a complete Bertini 1 file (CONFIG ... END; then
+// INPUT ... END;) because its purpose is running the same problem in Bertini 1.  The
+// grammar reads the INPUT-section body.  The two must round-trip, and where they cannot,
+// they must say so rather than yield an empty system.  See #395, #396, #397.
+
+namespace {
+	/// f = (x^2+y^2+z^2+3)^2 - 16(x^2+y^2) -- a torus.  TOTAL DEGREE 4.
+	bertini::System TorusSystem()
+	{
+		using bertini::node::Variable;
+		auto x = Variable::Make("x"), y = Variable::Make("y"), z = Variable::Make("z");
+		bertini::System sys;
+		bertini::VariableGroup vars{x, y, z};
+		sys.AddVariableGroup(vars);
+		sys.AddFunction(pow(pow(x,2)+pow(y,2)+pow(z,2)+3, 2) - 16*(pow(x,2)+pow(y,2)));
+		return sys;
+	}
+}
+
+BOOST_AUTO_TEST_CASE(classic_file_of_a_system_with_no_functions_does_not_crash)
+{
+	// REGRESSION (#395): this SEGFAULTED.  CoefficientBound ends in
+	//   max(f_vals.array().abs().maxCoeff(), dh_dx.array().abs().maxCoeff(), bound)
+	// and with no functions both arrays are EMPTY -- Eigen's maxCoeff() on an empty array
+	// is undefined behaviour.  SystemToClassicFile reaches it because the CONFIG section
+	// emits `coefficientbound:`.  DegreeBound(), in the same file, already guarded the
+	// identical case; CoefficientBound never did.
+	bertini::System empty;
+	BOOST_CHECK_NO_THROW(bertini::classic::SystemToClassicFile(empty));
+	BOOST_CHECK_EQUAL(empty.CoefficientBound<bertini::complex_dbl>(), 0.0);
+
+	using bertini::node::Variable;
+	bertini::System vars_only;
+	bertini::VariableGroup vg{Variable::Make("x")};
+	vars_only.AddVariableGroup(vg);          // variables, but still no functions
+	BOOST_CHECK_NO_THROW(bertini::classic::SystemToClassicFile(vars_only));
+}
+
+BOOST_AUTO_TEST_CASE(a_full_classic_file_parses_back_into_the_same_system)
+{
+	// REGRESSION (#396): the emitted file could not be read back -- it failed at line 2 on
+	// the CONFIG block, `expected "=" found "tracktype: 0;"`.
+	auto sys = TorusSystem();
+	auto text = bertini::classic::SystemToClassicFile(sys);
+
+	bertini::System back;
+	BOOST_REQUIRE_NO_THROW(back = bertini::System(text));
+	BOOST_CHECK_EQUAL(back.NumTotalFunctions(), 1);
+	BOOST_CHECK_EQUAL(back.NumVariables(), 3);
+
+	// The CONFIG section is deliberately NOT compared: `coefficientbound` is estimated by
+	// evaluating at RANDOM points, so two emissions of one system differ there.
+	auto body = [](std::string const& t){ return t.substr(t.find("INPUT")); };
+	BOOST_CHECK_EQUAL(body(text), body(bertini::classic::SystemToClassicFile(back)));
+}
+
+BOOST_AUTO_TEST_CASE(a_bare_input_section_body_still_parses)
+{
+	// the pre-existing calling convention: unwrapping must be a no-op for a bare body
+	bertini::System s("variable_group x, y, z;\nfunction f0;\nf0 = x^2+y^2+z^2-1;\n");
+	BOOST_CHECK_EQUAL(s.NumTotalFunctions(), 1);
+	BOOST_CHECK_EQUAL(s.NumVariables(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(power_of_a_sum_reports_its_total_degree_not_the_sum_of_per_variable_degrees)
+{
+	// REGRESSION (#397): PowerOperator::Degree(VariableGroup) summed the per-variable
+	// degrees, which is valid only for a MONOMIAL.  (x+y)^2 has degree 2 in x and 2 in y
+	// but TOTAL degree 2 -- it reported 4, and (x^2+y^2+z^2+3)^2 reported 12 instead of 4.
+	//
+	// Invisible from C++/Python integer powers, which build an IntegerPowerOperator whose
+	// group degree was always right; only the classic parser builds the generic
+	// PowerOperator.  And invisible in ungrouped Degrees() -- it showed only through
+	// Degrees(Variables()), which is what DegreeBound() calls, and DegreeBound feeds AMP.
+	struct Case { char const* expr; int total_degree; };
+	for (auto const& c : { Case{"x^4", 4}, Case{"(x+y)^2", 2},
+	                       Case{"(x^2+y^2)^2", 4}, Case{"(x^2+y^2+z^2+3)^2", 4} })
+	{
+		bertini::System s(std::string("variable_group x, y, z;\nfunction f0;\nf0 = ")
+		                  + c.expr + ";\n");
+		BOOST_CHECK_MESSAGE(s.DegreeBound() == c.total_degree,
+			"DegreeBound() for " << c.expr << " was " << s.DegreeBound()
+			<< ", expected " << c.total_degree);
+	}
+}
+
+BOOST_AUTO_TEST_CASE(degree_bound_agrees_between_a_built_and_a_parsed_system)
+{
+	// The consequence that matters: a system round-tripped through classic input must track
+	// under the SAME AMP degree bound as the one it was built from.
+	auto built = TorusSystem();
+	bertini::System parsed(bertini::classic::SystemToClassicFile(built));
+	BOOST_CHECK_EQUAL(built.DegreeBound(), 4);
+	BOOST_CHECK_EQUAL(parsed.DegreeBound(), built.DegreeBound());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 

--- a/python/test/classes/classic_input_roundtrip_test.py
+++ b/python/test/classes/classic_input_roundtrip_test.py
@@ -1,0 +1,140 @@
+"""The classic-input round trip, and the three defects found in it.
+
+``System.to_classic_input()`` emits a complete Bertini 1 file (``CONFIG ... END;`` then
+``INPUT ... END;``) because its purpose is running the same problem in Bertini 1.
+``bertini.parse.system()`` reads the INPUT-section body.  The two must round-trip, and when
+they cannot, they must say so rather than hand back an empty system.
+
+Covers bertiniteam/b2 #395, #396 and #397.
+"""
+
+import re
+
+import numpy as np
+import pytest
+
+import bertini
+from bertini import System, VariableGroup
+from bertini.symbolics import Variable
+
+
+def whitney_ish():
+    """f = (x^2+y^2+z^2+3)^2 - 16(x^2+y^2)  -- a torus.  TOTAL DEGREE 4."""
+    x, y, z = Variable('x'), Variable('y'), Variable('z')
+    s = System()
+    vg = VariableGroup()
+    for v in (x, y, z):
+        vg.append(v)
+    s.add_variable_group(vg)
+    s.add_functions([(x**2 + y**2 + z**2 + 3)**2 - 16 * (x**2 + y**2)])
+    return s, vg
+
+
+# --------------------------------------------------------------- #395
+
+def test_empty_system_emits_classic_input_without_crashing():
+    """REGRESSION (#395): this SEGFAULTED.
+
+    ``CoefficientBound`` ended in ``max(f_vals...maxCoeff(), dh_dx...maxCoeff(), bound)``,
+    and with no functions both are EMPTY -- Eigen's ``maxCoeff()`` on an empty array is
+    undefined behaviour.  ``to_classic_input()`` reaches it because the CONFIG section
+    emits ``coefficientbound:``.
+    """
+    text = System().to_classic_input()
+    assert 'coefficientbound:' in text
+
+
+def test_system_with_variables_but_no_functions_emits_classic_input():
+    """The same crash, with variables present: the trigger is zero FUNCTIONS."""
+    s = System()
+    vg = VariableGroup()
+    vg.append(Variable('x'))
+    s.add_variable_group(vg)
+    assert 'coefficientbound:' in s.to_classic_input()
+
+
+# --------------------------------------------------------------- #396
+
+def test_full_classic_file_round_trips():
+    """REGRESSION (#396): parse.system() could not read what to_classic_input() writes.
+
+    It failed at line 2 on the CONFIG block: ``expected "=" found "tracktype: 0;"``.
+    """
+    s, _ = whitney_ish()
+    back = bertini.parse.system(s.to_classic_input())
+    assert back.num_functions() == 1
+    assert back.num_variables() == 3
+
+
+def test_round_trip_preserves_the_input_section_verbatim():
+    """The CONFIG section is NOT compared: ``coefficientbound`` is estimated by evaluating
+    at random points, so it differs between two emissions of the very same system."""
+    s, _ = whitney_ish()
+    a = s.to_classic_input()
+    b = bertini.parse.system(a).to_classic_input()
+    body = lambda t: t.split('INPUT', 1)[1]
+    assert body(a) == body(b)
+
+
+def test_bare_input_section_body_still_parses():
+    """The pre-existing calling convention must keep working -- the unwrapping is a no-op
+    for text that is already a bare body."""
+    p = bertini.parse.system("variable_group x, y, z;\nfunction f0;\nf0 = x^2+y^2+z^2-1;\n")
+    assert p.num_functions() == 1
+    assert p.num_variables() == 3
+
+
+def test_input_wrapper_alone_is_accepted():
+    p = bertini.parse.system(
+        "INPUT\nvariable_group x, y, z;\nfunction f0;\nf0 = x^2+y^2+z^2-1;\nEND;\n")
+    assert p.num_functions() == 1
+    assert p.num_variables() == 3
+
+
+@pytest.mark.parametrize("bad", [
+    "this is not a system at all",
+    "",
+    "INPUT\nEND;\n",
+])
+def test_unparseable_input_raises_rather_than_returning_an_empty_system(bad):
+    """REGRESSION (#396), the dangerous half.
+
+    The binding discarded ``parse()``'s return value, and ``parse()`` leaves its result
+    untouched when it matches nothing -- so Python received a structurally valid, entirely
+    EMPTY System and no error.  A caller round-tripping through text carried on with zero
+    functions.  Silence is the bug; an exception is the fix.
+    """
+    with pytest.raises(RuntimeError):
+        bertini.parse.system(bad)
+
+
+# --------------------------------------------------------------- #397
+
+@pytest.mark.parametrize("expr,total_degree", [
+    ("x^4", 4),
+    ("(x+y)^2", 2),
+    ("(x^2+y^2)^2", 4),
+    ("(x^2+y^2+z^2+3)^2", 4),
+])
+def test_parsed_power_of_a_sum_reports_its_total_degree(expr, total_degree):
+    """REGRESSION (#397): PowerOperator::Degree(VariableGroup) SUMMED the per-variable
+    degrees, which is valid only for a monomial.  ``(x+y)^2`` has degree 2 in x and 2 in y
+    but TOTAL degree 2; it reported 4, and ``(x^2+y^2+z^2+3)^2`` reported 12 instead of 4.
+
+    Invisible from Python's ``**`` (which builds an IntegerPowerOperator, always correct)
+    and invisible in ungrouped ``degrees()`` -- it showed only through
+    ``Degrees(Variables())``, which is what ``DegreeBound()`` calls, and DegreeBound feeds
+    AMP.
+    """
+    p = bertini.parse.system(
+        "variable_group x, y, z;\nfunction f0;\nf0 = %s;\n" % expr)
+    assert int(re.search(r'degreebound: (\d+)', p.to_classic_input()).group(1)) == total_degree
+
+
+def test_degree_bound_agrees_between_a_built_and_a_parsed_system():
+    """The consequence that matters: a system round-tripped through classic input must
+    track under the SAME AMP degree bound as the one it was built from."""
+    s, _ = whitney_ish()
+    p = bertini.parse.system(s.to_classic_input())
+    db = lambda S: int(re.search(r'degreebound: (\d+)', S.to_classic_input()).group(1))
+    assert db(s) == db(p) == 4

--- a/python_bindings/include/parser_export.hpp
+++ b/python_bindings/include/parser_export.hpp
@@ -43,6 +43,8 @@
 #include <bertini2/io/parsing/system_parsers.hpp>
 
 
+#include <type_traits>
+
 #include "python_common.hpp"
 
 
@@ -61,8 +63,39 @@ namespace bertini{
 		{
 			// Treat input as UTF-8; drop a leading BOM so it is not parsed as a stray character.
 			bertini::parsing::classic::StripUTF8BOM(str);
+			// accept a full Bertini 1 classic file, which is exactly what
+			// System.to_classic_input() emits -- see #396
+			bertini::parsing::classic::StripClassicFileWrappers(str);
 			ResultT res;
-			bertini::parsing::classic::parse(str.begin(), str.end(), res);
+			// The return value is NOT optional to check.  parse() answers false when the
+			// grammar matched nothing or did not consume the whole input, and it leaves the
+			// result untouched -- so ignoring it handed Python a structurally valid, entirely
+			// EMPTY System and reported nothing.  A caller round-tripping through text then
+			// carried on with a system of zero functions.  See #396.
+			if (!bertini::parsing::classic::parse(str.begin(), str.end(), res))
+			{
+				std::string shown = str.size() > 80 ? str.substr(0, 80) + "..." : str;
+				throw std::runtime_error(
+					"[SystemParser] could not parse a system from the input.  Expected classic "
+					"declarations (variable_group / function / definitions), optionally wrapped "
+					"in a Bertini 1 `INPUT ... END;` section with an optional leading "
+					"`CONFIG ... END;` section.  Input began: \"" + shown + "\"");
+			}
+			// parse() also answers TRUE for input that declares NOTHING -- an empty string, or
+			// an `INPUT ... END;` section with an empty body -- because matching zero
+			// declarations is a successful match of the grammar.  The caller still ends up
+			// holding an empty System they did not ask for, which is the whole complaint in
+			// #396, so refuse that too.  A system with variables but no functions is left
+			// alone: that is a real, if unusual, declaration.
+			if constexpr (std::is_same<ResultT, System>::value)
+			{
+				if (res.NumVariables()==0 && res.NumTotalFunctions()==0)
+					throw std::runtime_error(
+						"[SystemParser] the input declared no variables and no functions, so "
+						"there is no system to return.  Expected classic declarations "
+						"(variable_group / function / definitions), optionally wrapped in a "
+						"Bertini 1 `INPUT ... END;` section.");
+			}
 			return res;
 		};
 		


### PR DESCRIPTION
Fixes #395, #396 and #397.

Pulling on "a records layer cannot reload the systems it wrote" turned up three
independent bugs, each of which hid the next.

## #395 — segfault

`System::CoefficientBound` ends in

```cpp
max(f_vals.array().abs().maxCoeff(), dh_dx.array().abs().maxCoeff(), bound)
```

and with no functions both arrays are **empty**, where Eigen's `maxCoeff()` is undefined
behaviour. `bertini.System().to_classic_input()` reached it — the CONFIG section emits
`coefficientbound:` — and crashed the interpreter.

`DegreeBound()`, four lines below in the same file, already guarded exactly this case and
returns 0. `CoefficientBound` never did. Now guarded on **both** dimensions, since `dh_dx`
is functions × variables and so is empty when either is zero.

## #396 — the round trip failed, and failed silently

`to_classic_input()` emits a complete Bertini 1 file (`CONFIG ... END;` then
`INPUT ... END;`) because its purpose is running the same problem in Bertini 1; the grammar
reads the INPUT-section **body**. They were never inverses.

Worse, the Python binding **discarded the parse result**:

```cpp
bertini::parsing::classic::parse(str.begin(), str.end(), res);
return res;              // parse() said false and never touched res
```

`parse()` answers `false` when the grammar matched nothing or did not consume the input, and
leaves the result untouched — so Python received a structurally valid, entirely **empty**
System and no error. A caller round-tripping through text carried on with zero functions.

Two fixes. `StripClassicFileWrappers()` (in `qi_files.hpp`) lets both `System::System(string)`
and the binding accept a full classic file — a **no-op** for text that is already a bare
body, so nothing that worked before changes. And the binding now raises, including when the
input "successfully" declares nothing at all (an empty string, or an `INPUT` section with an
empty body): matching zero declarations is a successful parse of the grammar, but it still
leaves the caller holding a System they did not ask for.

## #397 — and the one that actually bites

`PowerOperator::Degree(VariableGroup)` computed the total degree by **summing the
per-variable degrees**, which is valid only for a monomial. `(x+y)^2` has degree 2 in `x`
and 2 in `y` but **total degree 2**, and it reported 4. The overcount scales with the number
of variables in the base:

| expression | true degree | reported |
|---|---|---|
| `x^4` | 4 | 4 |
| `(x+y)^2` | 2 | **4** |
| `(x^2+y^2)^2` | 4 | **8** |
| `(x^2+y^2+z^2+3)^2` | 4 | **12** |

It stayed invisible because the same expression takes two paths: an integer exponent written
in C++ or Python builds an `IntegerPowerOperator`, whose group degree is `base_deg*exponent`
and always was right, while the classic parser builds this generic `PowerOperator`. Both
print identically, and both give the correct **ungrouped** `Degrees()`. Only
`Degrees(Variables())` differed — which is precisely what `System::DegreeBound()` calls, and
**DegreeBound feeds AMP**.

So a system round-tripped through classic input tracked under a *different
adaptive-precision regime* than the one it was built from, silently. Any records/replay
layer storing systems as classic text was replaying them under different precision decisions
than the original run.

Now the same shape as `PowerOperator::Degree(v)` directly above it, with the base's group
degree in place of its degree in one variable.

## Tests

Both languages, each case naming its issue: the empty-system crash; the full-file round
trip; the bare-body convention still parsing; unparseable and empty input raising instead of
yielding an empty system; the total degree of a power of a sum; and `DegreeBound()` agreeing
between a built and a parsed system.

One deliberate asymmetry worth flagging to a reviewer: the round-trip test compares the
**INPUT sections only**. `coefficientbound` is estimated by evaluating at *random* points, so
two emissions of the very same system legitimately differ there — `to_classic_input()` is not
byte-deterministic, and asserting that it is would be wrong.

Verified: `ctest` 10/10 suites, `pytest` 942 passed / 1 skipped.

## ADR

None proposed. Each fix restores documented or obvious intent rather than making a new
tradeoff, and all three are carried by regression tests that fail loudly if undone.
