### PR TITLE
fix(trackers): a terminal step failure ends the path instead of looping forever

### DIFF
--- a/core/include/bertini2/trackers/base_tracker.hpp
+++ b/core/include/bertini2/trackers/base_tracker.hpp
@@ -50,6 +50,32 @@ namespace bertini{
 	namespace tracking{
 
 		/**
+		\brief Whether a failed step leaves the tracker with no corrective action taken.
+
+		The stepping loop answers an ordinary failed step by adjusting precision and/or
+		stepsize and trying again, so the retry differs from the attempt that failed.  A
+		few outcomes admit no such adjustment: the tracker's state is left exactly as it
+		was, and retrying would repeat the identical step forever.  Those outcomes are
+		terminal -- the path must fail with that code instead of being retried.
+
+		Currently the sole member is \c FailedToSelectPrecisionAndStepsize, which the AMP
+		adjusters report when MinimizeTrackingCost finds no valid (precision, stepsize)
+		pair anywhere in the allowed window.  It assigns neither, so \c current_precision_
+		and \c current_stepsize_ survive the failure unchanged.
+
+		\param c The code returned by a tracker iteration.
+		\return True if the tracking loop must stop rather than retry.
+
+		\see Tracker::TrackPath
+		*/
+		inline
+		bool StepFailureIsTerminal(SuccessCode c)
+		{
+			return c == SuccessCode::FailedToSelectPrecisionAndStepsize;
+		}
+
+
+		/**
 		\class Tracker
 
 		\brief Base tracker class for trackers offered in Bertini2.
@@ -296,7 +322,17 @@ namespace bertini{
 					else if (step_success_code_==SuccessCode::Success)
 						OnStepSuccess();
 					else
+					{
 						OnStepFail();
+						// A terminal failure adjusted nothing, so the next iteration would be
+						// bit-identical to the one that just failed -- an infinite loop that
+						// burns a core forever instead of failing the path.
+						if (StepFailureIsTerminal(step_success_code_))
+						{
+							PostTrackCleanup();
+							return step_success_code_;
+						}
+					}
 
 				}// re: while
 

--- a/core/test/tracking_basics/amp_tracker_test.cpp
+++ b/core/test/tracking_basics/amp_tracker_test.cpp
@@ -1049,6 +1049,82 @@ BOOST_AUTO_TEST_CASE(minimize_tracking_cost_throws_when_no_precision_satisfies_m
 	);
 }
 
+// Regression test for the AMP stepping deadlock (b2 #410).
+//
+// MinimizeTrackingCost throws when no (precision, stepsize) pair anywhere in the
+// allowed window satisfies criterion B.  Both AMP adjusters catch that throw and
+// report FailedToSelectPrecisionAndStepsize -- but the throw happens BEFORE either
+// value is assigned, so current_precision_ and current_stepsize_ survive the failed
+// step untouched.  The stepping loop used to treat that code like any other failed
+// step and simply try again; with nothing changed, the retry was bit-identical, and
+// TrackPath never returned.  Observed in the wild: 750k failed steps at a frozen
+// precision of 20 and a frozen stepsize, one core pegged, no progress, forever.
+//
+// Here the window is emptied on purpose -- a tracking tolerance demanding ~40 digits
+// against maximum_precision = 20 -- so no valid pair exists.  TrackPath must RETURN.
+// The timeout is the regression guard: without the fix this case hangs rather than
+// fails, which would wedge CI instead of reporting.
+BOOST_AUTO_TEST_CASE(amp_tracker_terminates_when_no_precision_stepsize_pair_exists,
+                     * boost::unit_test::timeout(60))
+{
+	DefaultPrecision(16);
+	using namespace bertini::tracking;
+
+	Var x = Variable::Make("x");
+	Var y = Variable::Make("y");
+	Var t = Variable::Make("t");
+
+	System sys;
+	VariableGroup v{x, y};
+	sys.AddVariableGroup(v);
+	sys.AddPathVariable(t);
+	sys.AddFunction(t * (pow(x, 2) - 1) + (1 - t) * (pow(x, 2) + pow(y, 2) - 4));
+	sys.AddFunction(t * (y - 1) + (1 - t) * (2 * x + 5 * y));
+
+	auto AMP = bertini::tracking::AMPConfigFrom(sys);
+	AMP.maximum_precision = 20;   // ceiling BELOW the digits the tolerance demands
+
+	bertini::tracking::AMPTracker tracker(sys);
+	SteppingConfig stepping_preferences;
+	NewtonConfig newton_preferences;
+
+	tracker.Setup(Predictor::Euler,
+	              1e-40,          // ~40 digits required; the ceiling is 20
+	              1e5,
+	              stepping_preferences,
+	              newton_preferences);
+	tracker.PrecisionSetup(AMP);
+
+	mpfr t_start(1);
+	mpfr t_end(0);
+
+	Vec<mpfr> start_point(2);
+	start_point << mpfr(1), mpfr(1);
+
+	Vec<mpfr> end_point;
+	auto tracking_success = tracker.TrackPath(end_point, t_start, t_end, start_point);
+
+	// The point of the test: it comes back at all, and it comes back a failure.
+	BOOST_CHECK(tracking_success != bertini::SuccessCode::Success);
+	BOOST_CHECK(tracking_success == bertini::SuccessCode::FailedToSelectPrecisionAndStepsize);
+}
+
+// The predicate the stepping loop consults.  A terminal code is one for which the
+// tracker took no corrective action, so retrying repeats the identical step.
+BOOST_AUTO_TEST_CASE(terminal_step_codes_are_exactly_the_ones_that_adjust_nothing)
+{
+	using namespace bertini::tracking;
+
+	BOOST_CHECK(StepFailureIsTerminal(bertini::SuccessCode::FailedToSelectPrecisionAndStepsize));
+
+	// every one of these leaves the tracker adjusted, so the loop may retry
+	BOOST_CHECK(!StepFailureIsTerminal(bertini::SuccessCode::Success));
+	BOOST_CHECK(!StepFailureIsTerminal(bertini::SuccessCode::HigherPrecisionNecessary));
+	BOOST_CHECK(!StepFailureIsTerminal(bertini::SuccessCode::FailedToConverge));
+	BOOST_CHECK(!StepFailureIsTerminal(bertini::SuccessCode::MatrixSolveFailure));
+	BOOST_CHECK(!StepFailureIsTerminal(bertini::SuccessCode::MatrixSolveFailureFirstPartOfPrediction));
+}
+
 BOOST_AUTO_TEST_CASE(set_start_precision_overrides_to_higher_precision)
 {
 	DefaultPrecision(16);


### PR DESCRIPTION
Fixes the non-terminating tracking loop reported in #410.

## The bug

`MinimizeTrackingCost` throws when no `(precision, stepsize)` pair anywhere in
`[min_precision, max_precision]` satisfies criterion B.  Both AMP adjusters catch
that throw and report `SuccessCode::FailedToSelectPrecisionAndStepsize`:

* `AMPCriterionError()` — on a failed step
* `AdjustAMPStepSuccess()` — on a successful one

The throw happens **before either output is assigned**, so `current_precision_`
and `current_stepsize_` survive the failed step exactly as they were.

The stepping loop had no notion of a fatal step code — it saw a non-`Success`
return, called `OnStepFail()`, and went around again.  With nothing adjusted the
retry is **bit-identical**: `PreIterationCheck` sees the same precision and the
same stepsize, passes, and the identical step runs again.  Forever.

Observed on a real run (a cellular decomposition of the Whitney umbrella, one
fiber track during interslice): a single `Solve()` that never returned, **750k
failed steps in 135 seconds** at a frozen precision of 20 and a frozen stepsize
of `1.862645e-12`, successes frozen at 343, one core pegged.  Every printed digit
identical across the whole sampling window.  Killed at 90 minutes; three separate
runs behaved identically.

The contract was already documented — in `AdjustAMPStepSuccess`:

> The throw inside MinimizeTrackingCost remains semantically correct: it fires
> only when no valid pair exists anywhere in [p_min, p_max], indicating that the
> path has entered a region that cannot be tracked at any supported precision.
> **That is a genuine path failure, and is reported via
> `SuccessCode::FailedToSelectPrecisionAndStepsize`.**

It is reported.  The loop simply never listened.

## The fix

A `StepFailureIsTerminal()` predicate, and a loop that honors it: a terminal code
ends the path with that code instead of retrying.  Terminal means *the tracker
took no corrective action*, so the retry cannot differ from the attempt that just
failed.  Currently the sole member is `FailedToSelectPrecisionAndStepsize`; the
predicate exists so the set can grow with one line and a reason.

`base_tracker.hpp` only — no config change, no behavior change on any path that
was making progress.

## Tests

* `amp_tracker_terminates_when_no_precision_stepsize_pair_exists` — empties the
  scan window on purpose (a tolerance demanding ~40 digits against
  `maximum_precision = 20`) and requires `TrackPath` to **return** the failure.
  It carries `* boost::unit_test::timeout(60)` so a regression reports as a test
  failure rather than wedging CI, which is what this bug does to a build.

  That it exercises the new path is provable rather than assumed:
  `FailedToSelectPrecisionAndStepsize` is produced only inside
  `TrackerIteration` (`amp_tracker.hpp:912` and `:1037`), never by
  `TrackerLoopInitialization` or `PreIterationCheck`, so the only way `TrackPath`
  can *return* it is through the new early return.

* `terminal_step_codes_are_exactly_the_ones_that_adjust_nothing` — pins the
  predicate's membership, so widening it later is a deliberate edit.

All 104 cases in `test_tracking_basics` pass.

## Not in this PR

The other half of #410 stands on its own and is untouched here: **`max_num_steps`
counts only successful steps**, so a failing path is un-budgeted.  With this fix
the observed path fails cleanly instead of spinning, but a path that fails
millions of steps for some *other* reason still has nothing to stop it.  That
wants a budget decision (and probably a config field), so it belongs in its own
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6T44NHtv1m8p62qQp8Zeo
