### PR TITLE
fix(system): MakeMovingHomotopy decides row identity on the canonical encoding, not a 6-digit rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,24 @@ _______________________________________________________________________________
 
 _______________________________________________________________________________
 
+## [3.5.0] - unreleased
+
+A correctness fix to the `MakeMovingHomotopy` guards: they decided function identity on a
+*presentation* rendering, which silently refused valid homotopies.
+
+### Fixed
+
+- `MakeMovingHomotopy` no longer rejects a valid deformation whose two moving endpoints merely
+  *print* the same.  Both of its guards (a fixed function duplicated in the moving rows, and a
+  moving row identical at both endpoints) compared functions via `operator<<`, whose default
+  stream precision is **6 significant digits** -- so two genuinely different rows agreeing to 6
+  digits compared equal and the homotopy was refused with a message asserting the endpoints were
+  the same row.  The collision is ~1e-6 *relative*, so it bit at every coordinate scale.  Identity
+  is now decided on `node::CanonicalEncoding` -- the exact-value encoding the content digests are
+  built on (ADR-0042) -- while `operator<<` is still used for the human-readable message text.
+  Found by a surface cell decomposition whose slice values were 1.9e-5 apart at a magnitude of
+  2409, and reproduced at order one (0.162749 vs 0.1627491).  (bertiniteam/b2#391)
+
 ## [3.4.0] - 2026-07-16
 
 A one-call way to build a linear slice that passes through a chosen point, an endgame-hardening

--- a/core/src/system/system.cpp
+++ b/core/src/system/system.cpp
@@ -29,6 +29,7 @@
 #include "bertini2/system/system.hpp"
 #include "bertini2/system/slice.hpp"   // for System::Slices() (needs the full Slice type)
 #include "bertini2/function_tree/find.hpp"
+#include "bertini2/function_tree/canonical_encoding.hpp"  // exact-value identity (issue #391)
 
 #include <algorithm>
 #include <sstream>
@@ -1829,41 +1830,53 @@ namespace bertini
 			throw std::runtime_error("MakeMovingHomotopy: the fixed and moving systems must not already have a path variable.");
 
 		// Catch the equations being placed in the wrong block.  Compare top-level functions
-		// structurally (their serialized form, the same one the classic writer emits), expanding any
-		// structured block via NaturalFunctionsAsNodes so polynomial and slice/products rows alike are
-		// covered.  Two failure modes:
+		// structurally, expanding any structured block via NaturalFunctionsAsNodes so polynomial
+		// and slice/products rows alike are covered.  Two failure modes:
 		//   * a fixed equation also living in the moving rows -- the rows that move must be ONLY the
 		//     moving rows, so a fixed function appearing there is a duplicate (the typical cause:
 		//     concatenating the fixed system into start_moving/end_moving; see issue #258); and
 		//   * a moving row identical at both endpoints -- it does not actually move and belongs in
 		//     `fixed`.  The blend pairs the moving rows by position, so this check is positional.
-		auto function_strings = [](System const& s) {
+		//
+		// IDENTITY IS DECIDED ON THE CANONICAL ENCODING, NEVER ON operator<<.  The stream render is
+		// PRESENTATION: the default ostream precision is 6 significant digits, so two genuinely
+		// different rows that agree to 6 digits render identically and were falsely refused --
+		// a valid homotopy rejected with a message asserting the two endpoints were the same
+		// (issue #391; measured refusals at rows 1e-3 apart on a constant of 2409, and 1.6e-7 apart
+		// on a constant of 0.163, so it is a ~1e-6 RELATIVE collision at every scale).  The
+		// canonical encoding is the exact-value form the content digests are built on (ADR-0042),
+		// which is precisely the preimage-not-presentation distinction that rule exists to enforce.
+		// operator<< is still used for the human-readable message text, which is what it is for.
+		auto function_keys = [](System const& s) {
 			std::vector<std::string> out;
 			for (auto const& f : s.NaturalFunctionsAsNodes())
-			{
-				std::ostringstream ss;
-				ss << f;
-				out.push_back(ss.str());
-			}
+				out.push_back(node::CanonicalEncoding(f));
 			return out;
 		};
-		auto const fixed_funcs = function_strings(fixed);
-		auto const start_funcs = function_strings(start_moving);
-		auto const end_funcs   = function_strings(end_moving);
+		auto readable = [](auto const& f) {   // generic: whatever NaturalFunctionsAsNodes yields
+			std::ostringstream ss;
+			ss << f;
+			return ss.str();
+		};
+		auto const fixed_nodes = fixed.NaturalFunctionsAsNodes();
+		auto const start_nodes = start_moving.NaturalFunctionsAsNodes();
+		auto const fixed_funcs = function_keys(fixed);
+		auto const start_funcs = function_keys(start_moving);
+		auto const end_funcs   = function_keys(end_moving);
 
-		for (auto const& f : fixed_funcs)
-			if (std::find(start_funcs.begin(), start_funcs.end(), f) != start_funcs.end()
-			 || std::find(end_funcs.begin(),   end_funcs.end(),   f) != end_funcs.end())
+		for (size_t i = 0; i < fixed_funcs.size(); ++i)
+			if (std::find(start_funcs.begin(), start_funcs.end(), fixed_funcs[i]) != start_funcs.end()
+			 || std::find(end_funcs.begin(),   end_funcs.end(),   fixed_funcs[i]) != end_funcs.end())
 				throw std::runtime_error(
-					"MakeMovingHomotopy: the function `" + f + "` appears in both the fixed system and "
-					"the moving rows.  start_moving/end_moving must contain ONLY the rows that move "
-					"(e.g. the sliding slice), not the fixed system as well -- did you concatenate the "
-					"fixed system into them?");
+					"MakeMovingHomotopy: the function `" + readable(fixed_nodes[i]) + "` appears in both "
+					"the fixed system and the moving rows.  start_moving/end_moving must contain ONLY "
+					"the rows that move (e.g. the sliding slice), not the fixed system as well -- did "
+					"you concatenate the fixed system into them?");
 
 		for (size_t i = 0; i < start_funcs.size(); ++i)   // start/end agree in count (checked above)
 			if (start_funcs[i] == end_funcs[i])
 				throw std::runtime_error(
-					"MakeMovingHomotopy: moving row " + std::to_string(i) + " (`" + start_funcs[i]
+					"MakeMovingHomotopy: moving row " + std::to_string(i) + " (`" + readable(start_nodes[i])
 					+ "`) is identical in start_moving and end_moving, so it does not move; put "
 					"non-moving equations in `fixed` instead.");
 

--- a/core/test/classes/moving_homotopy_test.cpp
+++ b/core/test/classes/moving_homotopy_test.cpp
@@ -267,6 +267,38 @@ BOOST_AUTO_TEST_CASE(rejects_non_moving_row_in_moving_block)
 	BOOST_CHECK_THROW(MakeMovingHomotopy(fixed, sm, em, "t", Gamma()), std::runtime_error);
 }
 
+// REGRESSION (issue #391): the identity of the moving rows is decided on the CANONICAL ENCODING
+// (exact values), never on operator<<.  The stream render carries only 6 significant digits, so two
+// genuinely DIFFERENT rows that agree to 6 digits used to render identically and the deformation was
+// refused -- a valid homotopy rejected with a message asserting its two endpoints were the same row.
+// The collision is ~1e-6 RELATIVE, so it bites at every scale, not only at large coordinates: both a
+// large constant (2408.97 vs 2408.971, the surface-decomposition failure that found this) and an
+// order-one one (0.162749 vs 0.1627491) collided before the fix.
+BOOST_AUTO_TEST_CASE(accepts_moving_rows_differing_below_stream_render_precision)
+{
+	DefaultPrecision(30);
+	auto x = Variable::Make("x"), y = Variable::Make("y");
+	System fixed; fixed.AddVariableGroup(VariableGroup{x, y});
+	fixed.AddFunction(x*x + y*y - node::Integer::Make(1));
+
+	auto row = [&](std::string const& c) {
+		System s; s.AddVariableGroup(VariableGroup{x, y});
+		s.AddFunction(node::Complex::Make(complex_mp("0.735966", "0")) * x
+		            + node::Complex::Make(complex_mp("0.593277", "0")) * y
+		            - node::Complex::Make(complex_mp(c, "0")));
+		return s;
+	};
+
+	// large scale: 1e-3 apart on a constant of ~2409 (4e-7 relative)
+	BOOST_CHECK_NO_THROW(MakeMovingHomotopy(fixed, row("2408.97"), row("2408.971"), "t", Gamma()));
+	// order one: 1e-7 apart on a constant of ~0.163 (6e-7 relative)
+	BOOST_CHECK_NO_THROW(MakeMovingHomotopy(fixed, row("0.162749"), row("0.1627491"), "t", Gamma()));
+
+	// ...and the guard is NOT weakened: a row that really is identical still throws.
+	BOOST_CHECK_THROW(MakeMovingHomotopy(fixed, row("2408.97"), row("2408.97"), "t", Gamma()),
+	                  std::runtime_error);
+}
+
 // Regression: Clone(System) is now a Memory-isolating shallow copy --- it shares the
 // immutable node DAG and the compiled SLP Program, but copies the per-thread evaluation Memory at
 // every level, INCLUDING a BlendBlock's nested operand Systems (which are deep-copied via the


### PR DESCRIPTION
Fixes #391.

Both of `MakeMovingHomotopy`'s identity guards compared functions via `operator<<`.
That is a **presentation** rendering — the default ostream precision is 6 significant
digits — so two genuinely different moving rows that happened to agree to 6 digits
compared *equal*, and a valid deformation was refused with a message asserting its two
endpoints were the same row.

The collision is ~1e-6 **relative**, so it bites at every coordinate scale rather than
only large ones. Measured refusals at rows 1e-3 apart on a constant of 2409, and
1.6e-7 apart on a constant of 0.163.

Found by a surface cell decomposition whose two adjacent slice values were 1.93e-05
apart at magnitude 2409 — distinct by ~7 orders of magnitude relative to their own
1.8e-12 accuracy. The caller was right; the guard was wrong.

## Fix

Identity now uses `node::CanonicalEncoding`, the exact-value encoding the content
digests are built on. This is the preimage-not-presentation distinction that ADR-0042
exists to enforce, applied to an identity decision that had quietly been coupled to a
formatting default. `operator<<` is retained for the human-readable message text.

Fixed in **both** guards, not only the one that bit — the
fixed-function-duplicated-in-moving-rows check shared the same comparison.

## Tests

Regression test in `core/test/classes/moving_homotopy_test.cpp` covering rows that
agree to 6 digits but differ exactly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6T44NHtv1m8p62qQp8Zeo
