### PR TITLE
feat(bindings): runtime get/set for PowerSeriesConfig and CauchyConfig on endgame objects

### DIFF
--- a/python/test/tracking/cauchy_endgame_test.py
+++ b/python/test/tracking/cauchy_endgame_test.py
@@ -270,3 +270,47 @@ def test_amp_cauchy_cycle_num_2(quadratic_homotopy, precision):
     assert code == SuccessCode.Success
     assert mp.abs(fa[0] - mpfr_complex(1)) < 1e-5
     assert eg.cycle_number() == 2
+
+
+# ---------------------------------------------------------------------------
+# flavor-config runtime accessors (get/set_cauchy_settings)
+# ---------------------------------------------------------------------------
+
+def test_amp_cauchy_flavor_config_setters(quadratic_homotopy):
+    """get/set_cauchy_settings round-trips, returns a DETACHED copy, and a mutated
+    endgame still runs.  Regression for the constructor-only flavor-config gap:
+    the CauchyConfig (maximum_cauchy_ratio, ...) was unreachable once the endgame
+    was built (e.g. the one a HomotopySolver owns).  The accessors are forwarded
+    through the pure-Python endgame wrapper, so this is the path the port uses."""
+    s, x, t = quadratic_homotopy
+    ampconfig = amp_config_from(s)
+    tracker = AMPTracker(s)
+    nc = NewtonConfig()
+    nc.max_num_newton_iterations = 2
+    nc.min_num_newton_iterations = 1
+    tracker.setup(Predictor.HeunEuler, 1e-5, 1e5, SteppingConfig(), nc)
+    tracker.precision_setup(ampconfig)
+
+    eg = AMPCauchyEndgame(tracker, mpfr_complex("0.1"))
+
+    got = eg.get_cauchy_settings()
+    assert float(got.maximum_cauchy_ratio) == 0.5  # library default
+
+    got.maximum_cauchy_ratio = 0.9999999
+    got.num_consecutive_same_cycle_number = 3
+    eg.set_cauchy_settings(got)
+
+    back = eg.get_cauchy_settings()
+    assert float(back.maximum_cauchy_ratio) == pytest.approx(0.9999999)
+    assert back.num_consecutive_same_cycle_number == 3
+
+    # get returns a DETACHED copy -- mutating it must not reach into the endgame
+    back.maximum_cauchy_ratio = 0.1
+    assert float(eg.get_cauchy_settings().maximum_cauchy_ratio) == pytest.approx(0.9999999)
+
+    # a mutated endgame still runs to the cycle-2 double root
+    sample = np.array([mpfr_complex("9.000000000000001e-01", "4.358898943540673e-01")])
+    code = eg.run(sample)
+    assert code == SuccessCode.Success
+    assert mp.abs(eg.final_approximation()[0] - mpfr_complex(1)) < 1e-5
+    assert eg.cycle_number() == 2

--- a/python/test/tracking/powerseries_endgame_test.py
+++ b/python/test/tracking/powerseries_endgame_test.py
@@ -244,3 +244,46 @@ def test_amp_pseg_full_run(cubic_homotopy, precision):
     fa = eg.final_approximation()
     assert code == SuccessCode.Success
     assert mp.abs(fa[0] - mpfr_complex(1)) < 1e-11
+
+
+# ---------------------------------------------------------------------------
+# flavor-config runtime accessors (get/set_powerseries_settings)
+# ---------------------------------------------------------------------------
+
+def test_amp_pseg_flavor_config_setters(cubic_homotopy):
+    """get/set_powerseries_settings round-trips, returns a DETACHED copy, and a
+    mutated endgame still converges the cycle-3 endpoint.  Regression for the
+    constructor-only flavor-config gap: the PowerSeriesConfig (max_cycle_number,
+    ...) was unreachable once the endgame was built.  The accessors are forwarded
+    through the pure-Python endgame wrapper, so this is the path the port uses."""
+    s, x, t = cubic_homotopy
+    ampconfig = amp_config_from(s)
+    tracker = AMPTracker(s)
+    tracker.setup(Predictor.HeunEuler, 1e-6, 1e5, SteppingConfig(), NewtonConfig())
+    tracker.precision_setup(ampconfig)
+
+    start = np.array([mpfr_complex(-1)])
+    bdry = np.array(np.zeros(1, dtype=np.int64), dtype=mpfr_complex)
+    code = tracker.track_path(bdry, mpfr_complex(1), mpfr_complex("0.1"), start)
+    assert code == SuccessCode.Success
+
+    eg = AMPPowerSeriesEndgame(tracker, mpfr_complex("0.1"))
+
+    got = eg.get_powerseries_settings()
+    assert got.max_cycle_number == 6  # library default
+
+    got.max_cycle_number = 12
+    eg.set_powerseries_settings(got)
+
+    back = eg.get_powerseries_settings()
+    assert back.max_cycle_number == 12
+
+    # get returns a DETACHED copy -- mutating it must not reach into the endgame
+    back.max_cycle_number = 3
+    assert eg.get_powerseries_settings().max_cycle_number == 12
+
+    # a mutated endgame still converges the cycle-3 triple root
+    code = eg.run(bdry)
+    assert code == SuccessCode.Success
+    assert mp.abs(eg.final_approximation()[0] - mpfr_complex(1)) < 1e-11
+    assert eg.cycle_number() == 3

--- a/python_bindings/include/endgame_export.hpp
+++ b/python_bindings/include/endgame_export.hpp
@@ -184,7 +184,18 @@ namespace bertini{
 			cl
 			.def(init<TrackerT const&, endgame::CauchyConfig const&>((arg("self"),arg("tracker"),arg("cauchyconfig"))))
 			.def(init<TrackerT const&, endgame::EndgameConfig const&>((arg("self"),arg("tracker"),arg("endgameconfig"))))
-			.def(init<TrackerT const&, endgame::SecurityConfig const&>((arg("self"),arg("tracker"),arg("securityconfig"))));
+			.def(init<TrackerT const&, endgame::SecurityConfig const&>((arg("self"),arg("tracker"),arg("securityconfig"))))
+
+			// flavor-config accessors, mirroring the generic get/set_endgame_settings on EndgameBaseVisitor.
+			// Without these the CauchyConfig (maximum_cauchy_ratio, ...) is constructor-only -- unreachable
+			// once the endgame is built (e.g. the one a HomotopySolver owns).  get returns a detached copy;
+			// mutate it and hand it back through set.
+			.def("get_cauchy_settings", &EndgameT::template Get<endgame::CauchyConfig>,
+				 return_value_policy<copy_const_reference>(), arg("self"),
+				 "Get a copy of the Cauchy-specific endgame settings (maximum_cauchy_ratio, etc.)")
+			.def("set_cauchy_settings", &EndgameT::template Set<endgame::CauchyConfig>,
+				 (arg("self"), arg("settings")),
+				 "Set the Cauchy-specific endgame settings");
 		}
 
 
@@ -197,7 +208,18 @@ namespace bertini{
 			cl
 			.def(init<TrackerT const&, endgame::PowerSeriesConfig const&>((arg("self"),arg("tracker"),arg("powerseriesconfig"))))
 			.def(init<TrackerT const&, endgame::EndgameConfig const&>((arg("self"),arg("tracker"),arg("endgameconfig"))))
-			.def(init<TrackerT const&, endgame::SecurityConfig const&>((arg("self"),arg("tracker"),arg("securityconfig"))));
+			.def(init<TrackerT const&, endgame::SecurityConfig const&>((arg("self"),arg("tracker"),arg("securityconfig"))))
+
+			// flavor-config accessors, mirroring the generic get/set_endgame_settings on EndgameBaseVisitor.
+			// Without these the PowerSeriesConfig (max_cycle_number, ...) is constructor-only -- unreachable
+			// once the endgame is built (e.g. the one a HomotopySolver owns).  get returns a detached copy;
+			// mutate it and hand it back through set.
+			.def("get_powerseries_settings", &EndgameT::template Get<endgame::PowerSeriesConfig>,
+				 return_value_policy<copy_const_reference>(), arg("self"),
+				 "Get a copy of the power-series-specific endgame settings (max cycle number, etc.)")
+			.def("set_powerseries_settings", &EndgameT::template Set<endgame::PowerSeriesConfig>,
+				 (arg("self"), arg("settings")),
+				 "Set the power-series-specific endgame settings");
 		}
 
 


### PR DESCRIPTION
The flavor-specific endgame configs were **constructor-only**. Once an endgame object
existed — for example the one a `HomotopySolver` builds internally — there was no way to
reach `PowerSeriesConfig.max_cycle_number`, `CauchyConfig.maximum_cauchy_ratio`,
`num_consecutive_same_cycle_number` and friends. That is unlike the generic
`EndgameConfig` / `SecurityConfig`, which already have `get/set_endgame_settings` and
`get/set_security_settings` on `EndgameBaseVisitor`.

## Change

* `get/set_powerseries_settings` on `PowerSeriesVisitor`
* `get/set_cauchy_settings` on `CauchyVisitor`

mirroring the existing generic accessors (`Configured::Get<T>` / `Set<T>`). `get` returns
a detached copy (`copy_const_reference`); mutate it and hand it back through `set`. The
pure-Python endgame wrapper forwards these via `__getattr__`, so they are reachable on the
`bertini.endgame.*` classes directly.

## Why

This unlocks tuning the singular-endpoint gates from Python at runtime — in particular
running a tracked connection through Cauchy with a permissive `maximum_cauchy_ratio`
instead of a track-then-guess fallback. Part of #27.

## Tests

Round-trip, detached-copy, and mutated-endgame-still-runs, in both flavor test files.
Full endgame suite (27 tests) green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6T44NHtv1m8p62qQp8Zeo
