### PR TITLE
fix(trackers): the step budget counts failed steps, not only successful ones

### DIFF
--- a/core/include/bertini2/trackers/amp_tracker.hpp
+++ b/core/include/bertini2/trackers/amp_tracker.hpp
@@ -616,7 +616,10 @@ namespace bertini{
 			*/
 			SuccessCode PreIterationCheck() const override
 			{
-				if (num_successful_steps_taken_ >= Get<Stepping>().max_num_steps)
+				// The budget counts EVERY step, not only the successful ones -- see the
+				// same check in FixedPrecisionTracker and issue #410.  This is the guard
+				// that bounds a path whose steps fail without ever advancing.
+				if (NumTotalStepsTaken() >= Get<Stepping>().max_num_steps)
 					return SuccessCode::MaxNumStepsTaken;
 				if (current_stepsize_ < Get<Stepping>().min_step_size)
 					return SuccessCode::MinStepSizeReached;

--- a/core/include/bertini2/trackers/config.hpp
+++ b/core/include/bertini2/trackers/config.hpp
@@ -111,7 +111,7 @@ namespace tracking{
 		unsigned consecutive_successful_steps_before_stepsize_increase = 5; ///< What it says.  If you can come up with a better name, please suggest it.  StepsForIncrease
 
 		unsigned min_num_steps = 1; ///< The minimum number of steps allowed during tracking.
-		unsigned max_num_steps = 1e5; ///< The maximum number of steps allowed during tracking.  This is per call to TrackPath.  MaxNumberSteps
+		unsigned max_num_steps = 1e5; ///< The maximum number of steps allowed during tracking, counting FAILED steps as well as successful ones.  This is per call to TrackPath.  MaxNumberSteps
 
 		unsigned frequency_of_CN_estimation = 1; ///< Estimate the condition number every so many steps.  Eh.
 	};

--- a/core/include/bertini2/trackers/fixed_precision_tracker.hpp
+++ b/core/include/bertini2/trackers/fixed_precision_tracker.hpp
@@ -111,7 +111,11 @@ namespace bertini{
 			*/
 			SuccessCode PreIterationCheck() const override
 			{
-				if (this->num_successful_steps_taken_ >= Get<Stepping>().max_num_steps)
+				// The budget counts EVERY step, not only the successful ones.  A path that
+				// fails steps has spent the effort whether or not it advanced, and counting
+				// only successes leaves a failing path un-budgeted: it can fail forever at
+				// 0% of its allowance.  See issue #410.
+				if (this->NumTotalStepsTaken() >= Get<Stepping>().max_num_steps)
 					return SuccessCode::MaxNumStepsTaken;
 				if (this->current_stepsize_ < Get<Stepping>().min_step_size)
 					return SuccessCode::MinStepSizeReached;

--- a/core/test/tracking_basics/fixed_precision_tracker_test.cpp
+++ b/core/test/tracking_basics/fixed_precision_tracker_test.cpp
@@ -238,6 +238,63 @@ BOOST_AUTO_TEST_CASE(condition_number_refresh_honors_frequency)
 
 
 
+// Regression test for the step budget (b2 #410, second half).
+//
+// max_num_steps is documented as "the maximum number of steps allowed during tracking",
+// but it was compared against num_successful_steps_taken_ only.  A path whose steps FAIL
+// therefore never approached its budget -- it could fail indefinitely while sitting at 0%
+// of its allowance.  Observed in the wild: 3.9 million failed steps against 343 successful
+// ones, thirty minutes at 100% CPU, the enclosing Solve() never returning.
+//
+// Here every step fails on purpose: a tracking tolerance of 1e-30 is unreachable in double
+// precision, so the corrector never converges and every iteration is a failed step.  With
+// max_num_steps = 10 the budget must stop it.
+//
+// The case DISCRIMINATES.  Counting only successes, this path never reaches the budget
+// (successes stay at 0) and instead halves its stepsize ~330 times down to the 1e-100
+// min_step_size floor, returning MinStepSizeReached.  Counting every step, it returns
+// MaxNumStepsTaken after 10.  So the asserted code distinguishes the fix from its absence.
+BOOST_AUTO_TEST_CASE(step_budget_counts_failed_steps_not_only_successes)
+{
+	DefaultPrecision(30);
+	using namespace bertini::tracking;
+
+	Var y = Variable::Make("y");
+	Var t = Variable::Make("t");
+
+	System sys;
+	VariableGroup v{y};
+	sys.AddFunction(y*y - t);          // sqrt path: a genuine tracking problem
+	sys.AddPathVariable(t);
+	sys.AddVariableGroup(v);
+
+	bertini::tracking::DoublePrecisionTracker tracker(sys);
+
+	SteppingConfig stepping_preferences;
+	stepping_preferences.max_num_steps = 10;      // the budget under test
+	NewtonConfig newton_preferences;
+
+	tracker.Setup(Predictor::Euler,
+	              double(1e-30),                  // UNREACHABLE at double precision
+	              double(1e5),
+	              stepping_preferences,
+	              newton_preferences);
+
+	complex_dbl t_start(1);
+	complex_dbl t_end(0);
+	Vec<complex_dbl> start_point(1);
+	start_point << complex_dbl(1);
+
+	Vec<complex_dbl> end_point;
+	auto code = tracker.TrackPath(end_point, t_start, t_end, start_point);
+
+	BOOST_CHECK(code != bertini::SuccessCode::Success);
+	BOOST_CHECK(code == bertini::SuccessCode::MaxNumStepsTaken);
+	// and the budget is what stopped it: total steps did not exceed the allowance
+	BOOST_CHECK_LE(tracker.NumTotalStepsTaken(), 11u);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
 
 


### PR DESCRIPTION
Closes the second half of #410. (The first half — a terminal step code the stepping loop
ignored — is #411.)

## The bug

`SteppingConfig::max_num_steps` is documented as *"the maximum number of steps allowed
during tracking"*, but both `PreIterationCheck` implementations compared it against
`num_successful_steps_taken_` alone:

```cpp
if (num_successful_steps_taken_ >= Get<Stepping>().max_num_steps)
    return SuccessCode::MaxNumStepsTaken;
```

So a path whose steps **fail** never approached its budget. It could fail indefinitely
while sitting at 0% of its allowance, because the only counter the guard watched was the
one that had stopped moving.

Observed on a real run: **3.9 million failed steps against 343 successful ones**, thirty
minutes at 100% CPU with no progress, and the enclosing `Solve()` never returning. Every
other exit was structurally unable to fire — the stepsize was not descending toward
`min_step_size`, precision was not escalating toward `maximum_precision` — so nothing could
stop that path at all.

## The fix

Use `NumTotalStepsTaken()`, which already existed and already returns
`num_failed_steps_taken_ + num_successful_steps_taken_`. A failing path now terminates with
`MaxNumStepsTaken`, which is what a path that has spent its whole allowance without
arriving should report.

Fixed in **both** trackers, since both carried the same comparison. The config comment now
states the contract where the setting is configured, rather than leaving "steps" to be read
as "successful steps".

**No behaviour change for any path making progress.** A path that reaches its endpoint in
far fewer than `max_num_steps` total is unaffected, and the default allowance is 1e5. All
105 cases in `test_tracking_basics` pass.

## Test

A path where every step fails on purpose — tracking tolerance 1e-30 is unreachable in
double precision, so the corrector never converges — against `max_num_steps = 10`.

The case **discriminates**, which is the point: counting only successes it never reaches
the budget and instead halves its stepsize ~330 times down to the `1e-100` `min_step_size`
floor, returning `MinStepSizeReached`; counting every step it returns `MaxNumStepsTaken`
after 10. So the asserted code distinguishes the fix from its absence, with ~320 steps of
margin.

## An honest negative result

This fix did **not** recover the case that motivated looking for it. Five decompositions in
a 40-seed block were timing out at 2400s, and I expected them to be un-budgeted failing
paths. With the fix live and verified through the Python bindings (a failing path now
returns `MaxNumStepsTaken`), **all five still time out**. So their cost is spread across
many paths rather than concentrated in one runaway path, and that is a separate problem.

The fix still closes a real hole — the 3.9-million-failed-step path above was real, and
nothing in the library could have stopped it — but it should not be advertised as a
performance fix.

## Noted, deliberately not changed here

The member `num_total_steps_taken_` is **vestigial** — declared and reset, never
incremented anywhere in the tree — while `NumTotalStepsTaken()` computes the sum instead.
It reads like usable state and is always zero. Worth removing, but it isn't this fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6T44NHtv1m8p62qQp8Zeo
